### PR TITLE
Fix OSS conda build jobs

### DIFF
--- a/.github/workflows/build_conda.yml
+++ b/.github/workflows/build_conda.yml
@@ -56,6 +56,6 @@ jobs:
         if: matrix.python-version == '3.10'
         run: |
           conda install -c file://${HOME}/package/ spdl
-          conda install -c conda-forge ffmpeg
+          conda install -c conda-forge 'ffmpeg==6'
           conda install -c pytorch numpy pytest pytorch numba
           pytest -v tests/spdl_unittest/io/

--- a/packaging/conda/meta.yaml
+++ b/packaging/conda/meta.yaml
@@ -3,7 +3,7 @@ package:
   version: "{{ environ.get('SPDL_BUILD_VERSION', '0.0.0') }}"
 
 source:
-  path: ".."
+  path: "../.."
 
 requirements:
   build:
@@ -20,6 +20,7 @@ requirements:
     - setuptools
     - cmake
     - ninja
+    - typing_extensions
     {{ environ.get('CONDA_CUDATOOLKIT_CONSTRAINT', '') }}
 
   run:
@@ -47,7 +48,5 @@ test:
     - numpy
 
 about:
-  home: https://github.com/mthrok/spdl
-  license: Apache 2
-  license_file: LICENSE
+  home: https://github.com/facebookresearch/spdl
   summary: Scalable and performant data loading for scientific computing


### PR DESCRIPTION
Fix OSS conda build.

Unittest failed on macOS and Ubuntu when using FFmpeg 7.
See https://github.com/facebookresearch/spdl/issues/8