### PR TITLE
Fix OSS compilation

### DIFF
--- a/src/libspdl/core/packets.cpp
+++ b/src/libspdl/core/packets.cpp
@@ -6,6 +6,8 @@
 
 #include <glog/logging.h>
 
+#include <cassert>
+
 extern "C" {
 #include <libavcodec/avcodec.h>
 }


### PR DESCRIPTION
```
$SRC_DIR/src/libspdl/core/packets.cpp:88:5: error: there are no arguments to 'assert' that depend on a template parameter, so a declaration of 'assert' must be available [-fpermissive]
$SRC_DIR/src/libspdl/core/packets.cpp:88:5: note: (if you use '-fpermissive', G++ will accept your code, but allowing the use of an undeclared name is deprecated)
$SRC_DIR/src/libspdl/core/packets.cpp:88:11: error: 'assert' was not declared in this scope
   88 |     assert(packets.size() == 1);
      |     ~~~~~~^~~~~~~~~~~~~~~~~~~~~
$SRC_DIR/src/libspdl/core/packets.cpp:8:1: note: 'assert' is defined in header '<cassert>'; did you forget to '#include <cassert>'?
```

Extracted from https://github.com/facebookresearch/spdl/pull/4