### PR TITLE
Add simple str function

### DIFF
--- a/src/spdl/dataloader/_pipeline.py
+++ b/src/spdl/dataloader/_pipeline.py
@@ -339,7 +339,7 @@ class AsyncPipeline:
 
         self._process_funcs.append(
             (
-                name,
+                f"AsyncPipeline::{len(self._process_funcs) + 1}_{name}",
                 lambda: _pipe(
                     in_queue,
                     afunc,
@@ -441,6 +441,14 @@ class AsyncPipeline:
         )
         return self
 
+    def __str__(self) -> str:
+        parts = [repr(self)]
+        parts.append(f"  - AsyncPipeline::0_src: {self._source}")
+
+        for i, (name, _) in enumerate(self._process_funcs, start=1):
+            parts.append(f"  - {name}")
+        return "\n".join(parts)
+
     # TODO [Python 3.11]: Try TaskGroup
     async def run(self, *, num_items: int | None = None) -> None:
         """Run the pipeline until its completion. All stages are executed concurrently.
@@ -483,7 +491,7 @@ class AsyncPipeline:
         )
         # Rest
         for i, (name, process_fn) in enumerate(self._process_funcs, start=1):
-            tasks.add(create_task(process_fn(), name=f"AsyncPipeline::{i}_{name}"))
+            tasks.add(create_task(process_fn(), name=name))
 
         while tasks:
             # Note:

--- a/tests/spdl_unittest/dataloader/pipeline_test.py
+++ b/tests/spdl_unittest/dataloader/pipeline_test.py
@@ -935,6 +935,36 @@ def test_task_stats_log_interval_stats():
 
 
 ################################################################################
+# __str__
+################################################################################
+
+
+def test_async_pipeline_str_smoke():
+    apl = AsyncPipeline()
+
+    print(apl)
+
+    apl = AsyncPipeline().add_source(range(10))
+
+    print(apl)
+
+    async def foo(i):
+        return i
+
+    apl = AsyncPipeline().add_source(range(10)).pipe(foo)
+
+    print(apl)
+
+    apl = AsyncPipeline().add_source(range(10)).pipe(foo).aggregate(1)
+
+    print(apl)
+
+    apl = AsyncPipeline().add_source(range(10)).pipe(foo).aggregate(1).add_sink(None)
+
+    print(apl)
+
+
+################################################################################
 # AsyncPipeline - resume
 ################################################################################
 


### PR DESCRIPTION
TODO:
- do not call `iter` on source
- Retain parameters of instead of lambda

```
<spdl.dataloader._pipeline.AsyncPipeline object at 0x101619c90>
  - AsyncPipeline::0_src: None
<spdl.dataloader._pipeline.AsyncPipeline object at 0x101c8a310>
  - AsyncPipeline::0_src: <range_iterator object at 0x1032dbc30>
<spdl.dataloader._pipeline.AsyncPipeline object at 0x101619c90>
  - AsyncPipeline::0_src: <range_iterator object at 0x1032db960>
  - AsyncPipeline::1_foo
<spdl.dataloader._pipeline.AsyncPipeline object at 0x101c8a310>
  - AsyncPipeline::0_src: <range_iterator object at 0x1032db810>
  - AsyncPipeline::1_foo
  - AsyncPipeline::2_aggregate(1)
<spdl.dataloader._pipeline.AsyncPipeline object at 0x101619c90>
  - AsyncPipeline::0_src: <range_iterator object at 0x1032db8a0>
  - AsyncPipeline::1_foo
  - AsyncPipeline::2_aggregate(1)
  - AsyncPipeline::3_sink
 ```