### PR TITLE
Extract builder

### DIFF
--- a/tests/spdl_unittest/dataloader/pipeline_test.py
+++ b/tests/spdl_unittest/dataloader/pipeline_test.py
@@ -997,7 +997,7 @@ def test_async_pipeline_infinite_loop():
         i = 0
         for _ in range(10):
 
-            num_items = random.randint(0, 128)
+            num_items = random.randint(1, 128)
             await apl.run(num_items=num_items)
             results = _flush_aqueue(apl.output_queue)
             assert results == list(range(i, i + num_items))


### PR DESCRIPTION
The treatment of iterator state got somewhat complicated.
So. we extract the builder logic.

Later we refactor the code so that builder only handles iterable,
while pipeline handles iterator, and let pipeline manage all the
resources including thread and event loop.