### PR TITLE
Change default buffer_size to 1

### DIFF
--- a/src/spdl/dataloader/_pipeline.py
+++ b/src/spdl/dataloader/_pipeline.py
@@ -273,8 +273,7 @@ class PipelineBuilder:
                     "hooks": hooks,
                     "report_stats_interval": report_stats_interval,
                 },
-                # TODO: change this to 1
-                kwargs.get("buffer_size", 10),
+                kwargs.get("buffer_size", 1),
             )
         )
         return self


### PR DESCRIPTION
Concurrency itself serves as buffer when downstream gets stuck, so buffer_size does not really help performance.