### PR TITLE
Fix race condition in Pipeline

### DIFF
--- a/tests/spdl_unittest/dataloader/pipeline_test.py
+++ b/tests/spdl_unittest/dataloader/pipeline_test.py
@@ -1179,7 +1179,7 @@ def test_async_pipeline2_fail_middle():
 
 
 def test_async_pipeline2_eof_stop():
-    """APL2 can be closed after eaching EOF."""
+    """APL2 can be closed after reaching EOF."""
     apl = (
         PipelineBuilder().add_source(range(2)).pipe(passthrough).add_sink(1000).build()
     )


### PR DESCRIPTION
* Use `threading.Event` for inter-thread communication instead of `asyncio.Event`.
* Use `Event` for notifying the pipeline execution stage progression happening in background thread.
* Use `asyncio.run(coro)` in thread so that loop is cleaned-up automatically.
* Keep the loop running after the pipeline task is completed, until it's explicitly stopped.
