### PR TITLE
Fix get_item draining the output queue

### DIFF
--- a/tests/spdl_unittest/dataloader/pipeline_test.py
+++ b/tests/spdl_unittest/dataloader/pipeline_test.py
@@ -1248,3 +1248,20 @@ def test_async_pipeline2_iter_and_next():
         iterator = iter(apl)
         with pytest.raises(StopIteration):
             next(iterator)
+
+
+def test_async_pipeline2_stuck():
+    """`get_item` waits for slow pipeline."""
+
+    async def delay(i):
+        print(f"Sleeping: {i}")
+        await asyncio.sleep(0.5)
+        print(f"Sleeping: {i} - done")
+        return i
+
+    apl = PipelineBuilder().add_source(range(3)).pipe(delay).add_sink(1).build()
+
+    with apl.auto_stop():
+        for i, item in enumerate(apl.get_iterator(timeout=3)):
+            print(i, item)
+            assert i == item


### PR DESCRIPTION
When `get_item` attempts to fetch item from the output_queue while the task is running, it creates a coroutine for fetching the item and schedule it with `run_coroutine_threadsafe` method.

This coroutine is not executed right away. There is a delay. So `get_item` method waits for the coroutine to complete. At this point, if the item is not available, the foreground cannot tell if it's because the pipeline is slow or the pipeline is completed without producing a new item.

https://github.com/facebookresearch/spdl/pull/86 introduced a mechanism to split the timeout to smaller timeouts and periodically checks if the task is completed while waiting for the coroutine to be exeucted.

There was a bug in this mechanism. The method was creating the fetch coroutine over and over in the wait loop, these coroutine eventually empty the queue.

This commit fixes the issue by moving the coroutine scheduling out of the loop.