### PR TITLE
Fix top-level typing

### DIFF
--- a/src/spdl/dataloader/__init__.py
+++ b/src/spdl/dataloader/__init__.py
@@ -8,6 +8,8 @@
 
 # pyre-unsafe
 
+from typing import Any
+
 from . import _builder, _flist, _hook, _pipeline, _utils  # noqa: E402
 
 _mods = [
@@ -24,7 +26,7 @@ def __dir__():
     return __all__
 
 
-def __getattr__(name: str):
+def __getattr__(name: str) -> Any:
     for mod in _mods + [_flist]:
         if name in mod.__all__:
             return getattr(mod, name)

--- a/src/spdl/io/__init__.py
+++ b/src/spdl/io/__init__.py
@@ -8,6 +8,8 @@
 
 # pyre-unsafe
 
+from typing import Any
+
 # This has to happen before other sub modules are imporeted.
 # Otherwise circular import would occur.
 #
@@ -58,7 +60,7 @@ _deprecated = {
 }
 
 
-def __getattr__(name: str):
+def __getattr__(name: str) -> Any:
     if name in _deprecated:
         import warnings
 


### PR DESCRIPTION
To use Pyre with module-level dynamic attribute, the `__getattr__` function must be annotated to return `Any`.