### PR TITLE
Re-land update for FFmpeg7

### DIFF
--- a/src/libspdl/core/detail/ffmpeg/filter_graph.cpp
+++ b/src/libspdl/core/detail/ffmpeg/filter_graph.cpp
@@ -185,11 +185,17 @@ FilterGraph get_filter(
 
 #define TS(OBJ, BASE) (static_cast<double>(OBJ->pts) * BASE.num / BASE.den)
 
-void add_frame(AVFilterContext* src_ctx, AVFrame* frame) {
-  TRACE_EVENT("decoding", "av_buffersrc_add_frame_flags");
-  CHECK_AVERROR(
-      av_buffersrc_add_frame_flags(src_ctx, frame, AV_BUFFERSRC_FLAG_KEEP_REF),
-      "Failed to pass a frame to filter.");
+int add_frame(AVFilterContext* src_ctx, AVFrame* frame) {
+  int ret;
+  {
+    TRACE_EVENT("decoding", "av_buffersrc_add_frame_flags");
+    ret = av_buffersrc_add_frame_flags(
+        src_ctx, frame, AV_BUFFERSRC_FLAG_KEEP_REF);
+  }
+  if (ret < 0 && ret != AVERROR_EOF) {
+    CHECK_AVERROR_NUM(ret, "Failed to pass a frame to filter.");
+  }
+  return ret;
 }
 
 int get_frame(AVFilterContext* sink_ctx, AVFrame* frame) {
@@ -215,7 +221,10 @@ Generator<AVFramePtr> FilterGraph::filter(AVFrame* frame) {
                       frame->pts)
                 : fmt::format(" --- flush filter graph"));
 
-  add_frame(graph->filters[0], frame);
+  if (add_frame(graph->filters[0], frame) == AVERROR_EOF) {
+    co_return;
+  }
+
   int errnum;
   do {
     AVFramePtr ret = AVFramePtr{CHECK_AVALLOCATE(av_frame_alloc())};


### PR DESCRIPTION
The behavior of some filters seem to be different on FFmpeg7. `packets_test.py::test_packet_len` failed with EOF.

This commit fixes that.