### PR TITLE
Test 3.13 build

### DIFF
--- a/.github/workflows/build_conda.yml
+++ b/.github/workflows/build_conda.yml
@@ -21,6 +21,14 @@ jobs:
   #############################################################################
   # macOS
   #############################################################################
+  mac-313:
+    name: "Conda Package (mac-3.13)"
+    uses: ./.github/workflows/conda_build.yml
+    with:
+      os: macos-latest
+      python-version: "3.13"
+      run-test: true
+
   mac-312:
     name: "Conda Package (mac-3.12)"
     uses: ./.github/workflows/conda_build.yml
@@ -46,6 +54,14 @@ jobs:
   #############################################################################
   # ubuntu (CPU)
   #############################################################################
+  ubuntu-313:
+    name: "Conda Package (ubuntu-3.13)"
+    uses: ./.github/workflows/conda_build.yml
+    with:
+      os: ubuntu-latest
+      python-version: "3.13"
+      run-test: true
+
   ubuntu-312:
     name: "Conda Package (ubuntu-3.12)"
     uses: ./.github/workflows/conda_build.yml

--- a/.github/workflows/build_conda_cuda.yml
+++ b/.github/workflows/build_conda_cuda.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest ]
-        python-version: [ "3.10", "3.11", "3.12" ]
+        python-version: [ "3.10", "3.11", "3.12", "3.13" ]
         cu_version: [ "11.8.0", "12.1.0" ]
     runs-on: ${{ matrix.os }}
     defaults:

--- a/.github/workflows/build_wheel_cuda.yml
+++ b/.github/workflows/build_wheel_cuda.yml
@@ -25,7 +25,7 @@ jobs:
       fail-fast: false
       matrix:
         cu-version: ["12.1"]
-        python-version: ["cp310-cp310", "cp311-cp311", "cp312-cp312"]
+        python-version: ["cp310-cp310", "cp311-cp311", "cp312-cp312", "cp313-cp313"]
     container:
       image: pytorch/manylinux2_28-builder:cuda${{ matrix.cu-version }}
     steps:


### PR DESCRIPTION
Findings:
- Conda does not support 3.13 yet.
- Wheel fails with an error: `ERROR Backend 'setuptools.build_meta:__legacy__' is not available.`.
    - Adding `pyproject.toml` might solve it. https://github.com/pypa/setuptools/issues/1694