### PR TITLE
Delay importing NumPy

### DIFF
--- a/src/spdl/io/_convert.py
+++ b/src/spdl/io/_convert.py
@@ -6,18 +6,12 @@
 
 # pyre-unsafe
 
-import numpy as np
-
-try:
-    from numpy.typing import NDArray
-except ImportError:
-    NDArray = np.ndarray
-
 from spdl._internal import import_utils
 from spdl.io import CPUBuffer, CUDABuffer
 
 torch = import_utils.lazy_import("torch")
 cuda = import_utils.lazy_import("numba.cuda")
+np = import_utils.lazy_import("numpy")
 
 __all__ = [
     "to_numba",
@@ -26,7 +20,7 @@ __all__ = [
 ]
 
 
-def to_numpy(buffer: CPUBuffer) -> NDArray:
+def to_numpy(buffer: CPUBuffer):
     """Convert to NumPy NDArray.
 
     Args:

--- a/src/spdl/io/_core.py
+++ b/src/spdl/io/_core.py
@@ -13,16 +13,24 @@ import logging
 import warnings
 from collections.abc import AsyncIterator, Callable, Iterator
 from concurrent.futures import ThreadPoolExecutor
-from typing import overload, TypeVar
+from typing import overload, TYPE_CHECKING, TypeVar
 
-import numpy as np
+# We import NumPy only when type-checkng.
+# The functions of this module do not need NumPy itself to run.
+# This is for experimenting with FT (no-GIL) Python.
+# Once NumPy supports FT Python, we can import normally.
+if TYPE_CHECKING:
+    import numpy as np
 
-try:
-    from numpy.typing import NDArray
+    try:
+        from numpy.typing import NDArray
 
-    UintArray = NDArray[np.uint8]
-except ImportError:
-    UintArray = np.ndarray
+        UintArray = NDArray[np.uint8]
+    except ImportError:
+        UintArray = np.ndarray
+else:
+    UintArray = object
+
 
 from spdl.io import (
     AudioFrames,


### PR DESCRIPTION
Until I figure out how to build NumPy with FT Python, delaying the import of NumPy so that the rest of SPDL works with FT Python.