### PR TITLE
Fix shadowed variable in spdl/src/libspdl/core/detail/nvjpeg/decoding.cpp

### DIFF
--- a/src/libspdl/core/detail/nvjpeg/decoding.cpp
+++ b/src/libspdl/core/detail/nvjpeg/decoding.cpp
@@ -58,13 +58,13 @@ std::tuple<CUDABufferPtr, SizeMeta> get_output(
     std::optional<size_t> batch_size = std::nullopt) {
   auto [num_channels, interleaved] = get_shape(out_fmt);
 
-  auto buffer = [&](const size_t ch, bool interleaved) {
+  auto buffer = [&](const size_t ch, bool interleaved_2) {
     return batch_size
-        ? (interleaved
+        ? (interleaved_2
                ? cuda_buffer({*batch_size, height, width, ch}, cuda_config)
                : cuda_buffer({*batch_size, ch, height, width}, cuda_config))
-        : (interleaved ? cuda_buffer({height, width, ch}, cuda_config)
-                       : cuda_buffer({ch, height, width}, cuda_config));
+        : (interleaved_2 ? cuda_buffer({height, width, ch}, cuda_config)
+                         : cuda_buffer({ch, height, width}, cuda_config));
   }(num_channels, interleaved);
 
   return {


### PR DESCRIPTION
Summary:
Our upcoming compiler upgrade will require us not to have shadowed variables. Such variables have a _high_ bug rate and reduce readability, so we would like to avoid them even if the compiler was not forcing us to do so.

This codemod attempts to fix an instance of a shadowed variable. Please review with care: if it's failed the result will be a silent bug.

**What's a shadowed variable?**

Shadowed variables are variables in an inner scope with the same name as another variable in an outer scope. Having the same name for both variables might be semantically correct, but it can make the code confusing to read! It can also hide subtle bugs.

This diff fixes such an issue by renaming the variable.

 - If you approve of this diff, please use the "Accept & Ship" button :-)

Differential Revision: D64398711


