### PR TITLE
Fix repr

### DIFF
--- a/src/spdl/dataloader/_builder.py
+++ b/src/spdl/dataloader/_builder.py
@@ -831,7 +831,12 @@ class PipelineBuilder:
 
     def _get_desc(self) -> list[str]:
         parts = []
-        parts.append(f"  - src: {self._source}")
+        src_repr = (
+            self._source.__name__
+            if hasattr(self._source, "__name__")
+            else type(self._source).__name__
+        )
+        parts.append(f"  - src: {src_repr}")
         if self._source_buffer_size != 1:
             parts.append(f"    Buffer: buffer_size={self._source_buffer_size}")
 


### PR DESCRIPTION
When source is a long list of data samples that contain byte strings, calling `repr` consumes considerable amount of time and memory.

This fix avoids it by fetching the name of type.

fixes #264 