### PR TITLE
Fix aggregate/disaggregate

### DIFF
--- a/src/spdl/pipeline/_builder.py
+++ b/src/spdl/pipeline/_builder.py
@@ -499,7 +499,7 @@ async def _run_pipeline_coroutines(
 ################################################################################
 
 
-async def disaggregate(items):
+def disaggregate(items):
     for item in items:
         yield item
 
@@ -708,7 +708,7 @@ class PipelineBuilder:
         """
         vals = [[]]
 
-        async def aggregate(i):
+        def aggregate(i):
             if i is not _EOF:
                 vals[0].append(i)
 


### PR DESCRIPTION
Make aggregate and disaggregate sync so that they run in thread executor, instead of the event loop thread.

I originally thought aggregate and disaggregate are fast enough, but there is a case where aggreaget takes more than 10ms, which is significant enough.