### PR TITLE
Update 16-bit gray PNG handling

### DIFF
--- a/src/libspdl/core/detail/ffmpeg/conversion.cpp
+++ b/src/libspdl/core/detail/ffmpeg/conversion.cpp
@@ -487,7 +487,7 @@ CPUBufferPtr convert_frames(
       case AV_PIX_FMT_GRAY8:
         // Technically, not a planer format, but it's the same.
         return convert_planer(batch, 1, sizeof(uint8_t), std::move(storage));
-      case AV_PIX_FMT_GRAY16BE:
+      case AV_PIX_FMT_GRAY16:
         return convert_planer(batch, 1, sizeof(uint16_t), std::move(storage));
       case AV_PIX_FMT_RGBA:
         return convert_interleaved(batch, 4, std::move(storage));
@@ -575,7 +575,7 @@ AVFrameViewPtr reference_image_buffer(
     case AV_PIX_FMT_GRAY8:
       ref_interweaved(frame.get(), data, 1);
       break;
-    case AV_PIX_FMT_GRAY16BE:
+    case AV_PIX_FMT_GRAY16:
       ref_interweaved(frame.get(), data, 1, 2);
       break;
     case AV_PIX_FMT_YUV444P:

--- a/src/libspdl/core/encoding.cpp
+++ b/src/libspdl/core/encoding.cpp
@@ -42,15 +42,15 @@ std::tuple<size_t, size_t> get_image_size(
       }
       return {shape[1], shape[0]};
     }
-    case AV_PIX_FMT_GRAY16BE: {
+    case AV_PIX_FMT_GRAY16: {
       if (shape.size() != 2) {
         SPDL_FAIL(fmt::format(
-            "Array must be 2D when pixel format is \"gray16be\", but found {}D",
+            "Array must be 2D when pixel format is \"gray16\", but found {}D",
             shape.size()));
       }
       if (depth != 2) {
         SPDL_FAIL(fmt::format(
-            "Pixel must be 2 byte when pixel format is \"gray16be\", but found {}",
+            "Pixel must be 2 byte when pixel format is \"gray16\", but found {}",
             depth));
       }
       return {shape[1], shape[0]};

--- a/tests/spdl_unittest/io/encoding_test.py
+++ b/tests/spdl_unittest/io/encoding_test.py
@@ -51,7 +51,7 @@ def test_encode_png_gray16be():
             await spdl.io.async_encode_image(
                 f.name,
                 arr,
-                pix_fmt="gray16be",
+                pix_fmt="gray16",
                 encode_config=enc_cfg,
             )
 


### PR DESCRIPTION
1. Change the supported pixel format to PIX_FMT_GRAY16, so that only platform-native endian is accepted. (One needs to convert the pixel format to `"gray16"` manually.)
2. Decoding as non-native endian is rejected because `memcpy` would produce a wrong values.
3. Similarly, when encoding, the accepted source pixel format is `"gray16"`, instead of `"gray16be"`.
   To encode 16-bit grayscale PNG, the target `pix_fmt="gray16be"` must be specified.
