### PR TITLE
Remove async IO from test

### DIFF
--- a/src/spdl/io/__init__.py
+++ b/src/spdl/io/__init__.py
@@ -33,6 +33,7 @@ from ._type_stub import (  # isort: skip
 from ._composite import (
     load_audio,
     load_image,
+    load_image_batch,
     load_image_batch_nvjpeg,
     load_video,
     sample_decode_video,
@@ -80,6 +81,7 @@ __all__ = [
     "load_audio",
     "load_video",
     "load_image",
+    "load_image_batch",
     "load_image_batch_nvjpeg",
     "sample_decode_video",
     # DEMUXING

--- a/tests/spdl_unittest/io/async_test.py
+++ b/tests/spdl_unittest/io/async_test.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-import asyncio
+import time
 
 import numpy as np
 import pytest
@@ -21,29 +21,30 @@ def test_failure():
         spdl.io.Demuxer("dvkgviuerehidguburuekkhgjijfjbkj")
 
 
-async def _decode_packet(packets):
-    frames = await spdl.io.async_decode_packets(packets)
+def _decode_packet(packets):
+    frames = spdl.io.decode_packets(packets)
     print(frames)
-    buffer = await spdl.io.async_convert_frames(frames)
+    buffer = spdl.io.convert_frames(frames)
     print(buffer)
     array = spdl.io.to_numpy(buffer)
     print(array.shape, array.dtype)
     return array
 
 
-async def _test_async_decode(demux_fn, timestamps):
+def _test_decode(demux_fn, timestamps):
     # There was a case where the underlying file device was delayed, and the
     # generated sample file is not ready when the test is started, so
     # sleeping here for 1 second to make sure the file is ready.
-    await asyncio.sleep(1)
+    time.sleep(1)
 
-    tasks = []
+    frames = []
     for timestamp in timestamps:
         packets = demux_fn(timestamp)
         print(packets)
-        tasks.append(asyncio.create_task(_decode_packet(packets)))
+        frames_ = _decode_packet(packets)
+        frames.append(frames_)
 
-    return await asyncio.gather(*tasks)
+    return frames
 
 
 def test_decode_audio_clips(get_sample):
@@ -51,10 +52,10 @@ def test_decode_audio_clips(get_sample):
     cmd = "ffmpeg -hide_banner -y -f lavfi -i 'sine=frequency=1000:sample_rate=48000:duration=3' -c:a pcm_s16le sample.wav"
     sample = get_sample(cmd)
 
-    async def _test():
+    def _test():
         timestamps = [(i, i + 1) for i in range(2)]
         demuxer = spdl.io.Demuxer(sample.path)
-        arrays = await _test_async_decode(demuxer.demux_audio, timestamps)
+        arrays = _test_decode(demuxer.demux_audio, timestamps)
 
         assert len(arrays) == 2
         for i, arr in enumerate(arrays):
@@ -62,7 +63,7 @@ def test_decode_audio_clips(get_sample):
             assert arr.shape == (1, 48000)
             assert arr.dtype == np.float32
 
-    asyncio.run(_test())
+    _test()
 
 
 def test_decode_audio_clips_num_frames(get_sample):
@@ -70,37 +71,35 @@ def test_decode_audio_clips_num_frames(get_sample):
     cmd = "ffmpeg -hide_banner -y -f lavfi -i 'sine=frequency=1000:sample_rate=16000:duration=1' -c:a pcm_s16le sample.wav"
     sample = get_sample(cmd)
 
-    async def _decode(src, num_frames=None):
+    def _decode(src, num_frames=None):
         with spdl.io.Demuxer(src) as demuxer:
             packets = demuxer.demux_audio(window=(0, 1))
             filter_desc = get_audio_filter_desc(
                 timestamp=(0, 1), num_frames=num_frames, sample_fmt="s16"
             )
-            frames = await spdl.io.async_decode_packets(
-                packets, filter_desc=filter_desc
-            )
-            buffer = await spdl.io.async_convert_frames(frames)
+            frames = spdl.io.decode_packets(packets, filter_desc=filter_desc)
+            buffer = spdl.io.convert_frames(frames)
             return spdl.io.to_numpy(buffer)
 
-    async def _test(src):
-        arr0 = await _decode(src)
+    def _test(src):
+        arr0 = _decode(src)
         assert arr0.dtype == np.int16
         assert arr0.shape == (16000, 1)
 
         num_frames = 8000
-        arr1 = await _decode(src, num_frames=num_frames)
+        arr1 = _decode(src, num_frames=num_frames)
         assert arr1.dtype == np.int16
         assert arr1.shape == (num_frames, 1)
         assert np.all(arr1 == arr0[:num_frames])
 
         num_frames = 32000
-        arr2 = await _decode(src, num_frames=num_frames)
+        arr2 = _decode(src, num_frames=num_frames)
         assert arr2.dtype == np.int16
         assert arr2.shape == (num_frames, 1)
         assert np.all(arr2[:16000] == arr0)
         assert np.all(arr2[16000:] == 0)
 
-    asyncio.run(_test(sample.path))
+    _test(sample.path)
 
 
 def test_decode_video_clips(get_sample):
@@ -109,17 +108,17 @@ def test_decode_video_clips(get_sample):
     sample = get_sample(cmd, width=320, height=240)
     N = 10
 
-    async def _test():
+    def _test():
         timestamps = [(i, i + 1) for i in range(N)]
         demuxer = spdl.io.Demuxer(sample.path)
-        arrays = await _test_async_decode(demuxer.demux_video, timestamps)
+        arrays = _test_decode(demuxer.demux_video, timestamps)
         assert len(arrays) == N
         for i, arr in enumerate(arrays):
             print(i, arr.shape, arr.dtype)
             assert arr.shape == (25, 240, 320, 3)
             assert arr.dtype == np.uint8
 
-    asyncio.run(_test())
+    _test()
 
 
 def test_decode_video_clips_num_frames(get_sample):
@@ -130,51 +129,49 @@ def test_decode_video_clips_num_frames(get_sample):
     cmd = "ffmpeg -hide_banner -y -f lavfi -i testsrc -frames:v 50 sample.mp4"
     sample = get_sample(cmd)
 
-    async def _decode(src, pix_fmt="rgb24", **kwargs):
+    def _decode(src, pix_fmt="rgb24", **kwargs):
         with spdl.io.Demuxer(src) as demuxer:
             packets = demuxer.demux_video(window=(0, 2))
             filter_desc = get_video_filter_desc(
                 timestamp=(0, 2), pix_fmt=pix_fmt, **kwargs
             )
-            frames = await spdl.io.async_decode_packets(
-                packets, filter_desc=filter_desc
-            )
-            buffer = await spdl.io.async_convert_frames(frames)
+            frames = spdl.io.decode_packets(packets, filter_desc=filter_desc)
+            buffer = spdl.io.convert_frames(frames)
             return spdl.io.to_numpy(buffer)
 
-    async def _test(src):
-        arr0 = await _decode(src)
+    def _test(src):
+        arr0 = _decode(src)
         assert arr0.dtype == np.uint8
         assert arr0.shape == (50, 240, 320, 3)
 
         num_frames = 25
-        arr1 = await _decode(src, num_frames=num_frames)
+        arr1 = _decode(src, num_frames=num_frames)
         assert arr1.dtype == np.uint8
         assert arr1.shape == (num_frames, 240, 320, 3)
         assert np.all(arr1 == arr0[:num_frames])
 
         num_frames = 100
-        arr2 = await _decode(src, num_frames=num_frames)
+        arr2 = _decode(src, num_frames=num_frames)
         assert arr2.dtype == np.uint8
         assert arr2.shape == (num_frames, 240, 320, 3)
         assert np.all(arr2[:50] == arr0)
         assert np.all(arr2[50:] == arr2[50])
 
         num_frames = 100
-        arr2 = await _decode(src, num_frames=num_frames, pad_mode="black")
+        arr2 = _decode(src, num_frames=num_frames, pad_mode="black")
         assert arr2.dtype == np.uint8
         assert arr2.shape == (num_frames, 240, 320, 3)
         assert np.all(arr2[:50] == arr0)
         assert np.all(arr2[50:] == 0)
 
         num_frames = 100
-        arr2 = await _decode(src, num_frames=num_frames, pad_mode="white")
+        arr2 = _decode(src, num_frames=num_frames, pad_mode="white")
         assert arr2.dtype == np.uint8
         assert arr2.shape == (num_frames, 240, 320, 3)
         assert np.all(arr2[:50] == arr0)
         assert np.all(arr2[50:] == 255)
 
-    asyncio.run(_test(sample.path))
+    _test(sample.path)
 
 
 def test_decode_video_frame_rate_pts(get_sample):
@@ -182,10 +179,10 @@ def test_decode_video_frame_rate_pts(get_sample):
     cmd = "ffmpeg -hide_banner -y -f lavfi -i testsrc -r 10 -frames:v 20 sample.mp4"
     sample = get_sample(cmd)
 
-    async def _test(src):
-        packets = await spdl.io.async_demux_video(src)
-        frames_ref = await spdl.io.async_decode_packets(packets.clone())
-        frames = await spdl.io.async_decode_packets(
+    def _test(src):
+        packets = spdl.io.demux_video(src)
+        frames_ref = spdl.io.decode_packets(packets.clone())
+        frames = spdl.io.decode_packets(
             packets, filter_desc=get_video_filter_desc(frame_rate=(5, 1))
         )
 
@@ -195,20 +192,20 @@ def test_decode_video_frame_rate_pts(get_sample):
 
         assert np.all(pts_ref[::2] == pts)
 
-    asyncio.run(_test(sample.path))
+    _test(sample.path)
 
 
-async def _decode_image(path):
-    packets = await spdl.io.async_demux_image(path)
+def _decode_image(path):
+    packets = spdl.io.demux_image(path)
     print(packets)
-    frames = await spdl.io.async_decode_packets(packets)
+    frames = spdl.io.decode_packets(packets)
     print(frames)
     assert type(frames) is _libspdl.FFmpegImageFrames
     return frames
 
 
-async def _batch_decode_image(paths):
-    return await asyncio.gather(*[_decode_image(path) for path in paths])
+def _batch_decode_image(paths):
+    return [_decode_image(path) for path in paths]
 
 
 def test_decode_image(get_sample):
@@ -216,14 +213,14 @@ def test_decode_image(get_sample):
     cmd = "ffmpeg -hide_banner -y -f lavfi -i testsrc -frames:v 1 sample.jpg"
     sample = get_sample(cmd, width=320, height=240)
 
-    async def _test(src):
-        buffer = await spdl.io.async_load_image(src)
+    def _test(src):
+        buffer = spdl.io.load_image(src)
         array = spdl.io.to_numpy(buffer)
         print(array.shape, array.dtype)
         assert array.dtype == np.uint8
         assert array.shape == (240, 320, 3)
 
-    asyncio.run(_test(sample.path))
+    _test(sample.path)
 
 
 def test_batch_decode_image(get_samples):
@@ -233,74 +230,74 @@ def test_batch_decode_image(get_samples):
 
     flist = ["NON_EXISTING_FILE.JPG", *samples]
 
-    async def _test():
-        buffer = await spdl.io.async_load_image_batch(
+    def _test():
+        buffer = spdl.io.load_image_batch(
             flist, width=None, height=None, pix_fmt=None, strict=False
         )
         assert buffer.__array_interface__["shape"] == (250, 3, 240, 320)
 
-    asyncio.run(_test())
+    _test()
 
 
-def test_async_convert_audio(get_sample):
-    """async_convert_frames can convert FFmpegAudioFrames to Buffer"""
+def test_convert_audio(get_sample):
+    """convert_frames can convert FFmpegAudioFrames to Buffer"""
     cmd = "ffmpeg -hide_banner -y -f lavfi -i 'sine=frequency=1000:sample_rate=48000:duration=3' -c:a pcm_s16le sample.wav"
     sample = get_sample(cmd)
 
-    async def _test(src):
+    def _test(src):
         ts = [(1, 2)]
         demuxer = spdl.io.Demuxer(src)
-        arrays = await _test_async_decode(demuxer.demux_audio, ts)
+        arrays = _test_decode(demuxer.demux_audio, ts)
         array = arrays[0]
         print(array.dtype, array.shape)
         assert array.shape == (1, 48000)
 
-    asyncio.run(_test(sample.path))
+    _test(sample.path)
 
 
-def test_async_convert_video(get_sample):
-    """async_convert_frames can convert FFmpegVideoFrames to Buffer"""
+def test_convert_video(get_sample):
+    """convert_frames can convert FFmpegVideoFrames to Buffer"""
     cmd = "ffmpeg -hide_banner -y -f lavfi -i testsrc -frames:v 1000 sample.mp4"
     sample = get_sample(cmd, width=320, height=240)
 
-    async def _test(src):
-        packets = await spdl.io.async_demux_video(src)
-        frames = await spdl.io.async_decode_packets(packets)
-        buffer = await spdl.io.async_convert_frames(frames)
+    def _test(src):
+        packets = spdl.io.demux_video(src)
+        frames = spdl.io.decode_packets(packets)
+        buffer = spdl.io.convert_frames(frames)
         array = spdl.io.to_numpy(buffer)
         print(array.dtype, array.shape)
         assert array.shape == (1000, 240, 320, 3)
 
-    asyncio.run(_test(sample.path))
+    _test(sample.path)
 
 
-def test_async_convert_image(get_sample):
-    """async_convert_frames can convert FFmpegImageFrames to Buffer"""
+def test_convert_image(get_sample):
+    """convert_frames can convert FFmpegImageFrames to Buffer"""
     cmd = "ffmpeg -hide_banner -y -f lavfi -i testsrc -frames:v 1 sample.jpg"
     sample = get_sample(cmd, width=320, height=240)
 
-    async def _test(src):
-        frames = await _decode_image(src)
-        buffer = await spdl.io.async_convert_frames(frames)
+    def _test(src):
+        frames = _decode_image(src)
+        buffer = spdl.io.convert_frames(frames)
         print(buffer)
         arr = spdl.io.to_numpy(buffer)
         print(arr.dtype, arr.shape)
         assert arr.shape == (240, 320, 3)
 
-    asyncio.run(_test(sample.path))
+    _test(sample.path)
 
 
-def test_async_convert_batch_image(get_samples):
-    """async_convert_frames can convert list[FFmpegImageFrames] to Buffer"""
+def test_convert_batch_image(get_samples):
+    """convert_frames can convert list[FFmpegImageFrames] to Buffer"""
     cmd = "ffmpeg -hide_banner -y -f lavfi -i testsrc -frames:v 4 sample_%03d.jpg"
     flist = get_samples(cmd)
 
-    async def _test(flist):
-        frames = await _batch_decode_image(flist)
-        buffer = await spdl.io.async_convert_frames(frames)
+    def _test(flist):
+        frames = _batch_decode_image(flist)
+        buffer = spdl.io.convert_frames(frames)
         print(buffer)
         arr = spdl.io.to_numpy(buffer)
         print(arr.dtype, arr.shape)
         assert arr.shape == (4, 240, 320, 3)
 
-    asyncio.run(_test(flist))
+    _test(flist)

--- a/tests/spdl_unittest/io/buffer_conversion_refcount_test.py
+++ b/tests/spdl_unittest/io/buffer_conversion_refcount_test.py
@@ -4,7 +4,6 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-import asyncio
 import gc
 import sys
 
@@ -14,15 +13,6 @@ import spdl.utils
 from spdl.io import get_video_filter_desc
 
 
-def _decode_video(src, pix_fmt=None):
-    return asyncio.run(
-        spdl.io.async_load_video(
-            src,
-            filter_desc=get_video_filter_desc(pix_fmt=pix_fmt),
-        )
-    )
-
-
 def test_buffer_conversion_refcount(get_sample):
     """NumPy array created from Buffer should increment a reference to the buffer
     so that array keeps working after the original Buffer variable is deleted.
@@ -30,7 +20,10 @@ def test_buffer_conversion_refcount(get_sample):
     cmd = "ffmpeg -hide_banner -y -f lavfi -i testsrc,format=yuv420p -frames:v 100 sample.mp4"
     sample = get_sample(cmd, width=320, height=240)
 
-    buf = _decode_video(sample.path, pix_fmt="rgb24")
+    buf = spdl.io.load_video(
+        sample.path,
+        filter_desc=get_video_filter_desc(pix_fmt="rgb24"),
+    )
 
     assert hasattr(buf, "__array_interface__")
     print(f"{buf.__array_interface__=}")

--- a/tests/spdl_unittest/io/configs_test.py
+++ b/tests/spdl_unittest/io/configs_test.py
@@ -4,8 +4,6 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-import asyncio
-
 import pytest
 import spdl.io
 
@@ -15,20 +13,17 @@ def test_demux_config_smoketest(get_sample):
     cmd = "ffmpeg -hide_banner -y -f lavfi -i 'sine=frequency=1000:sample_rate=48000:duration=3' -c:a pcm_s16le sample.wav"
     sample = get_sample(cmd)
 
-    async def _test(src):
-        demux_config = spdl.io.demux_config()
-        _ = await spdl.io.async_demux_audio(src, demux_config=demux_config)
+    demux_config = spdl.io.demux_config()
+    _ = spdl.io.demux_audio(sample.path, demux_config=demux_config)
 
-        demux_config = spdl.io.demux_config(format="wav")
-        _ = await spdl.io.async_demux_audio(src, demux_config=demux_config)
+    demux_config = spdl.io.demux_config(format="wav")
+    _ = spdl.io.demux_audio(sample.path, demux_config=demux_config)
 
-        demux_config = spdl.io.demux_config(format_options={"ignore_length": "true"})
-        _ = await spdl.io.async_demux_audio(src, demux_config=demux_config)
+    demux_config = spdl.io.demux_config(format_options={"ignore_length": "true"})
+    _ = spdl.io.demux_audio(sample.path, demux_config=demux_config)
 
-        demux_config = spdl.io.demux_config(buffer_size=1024)
-        _ = await spdl.io.async_demux_audio(src, demux_config=demux_config)
-
-    asyncio.run(_test(sample.path))
+    demux_config = spdl.io.demux_config(buffer_size=1024)
+    _ = spdl.io.demux_audio(sample.path, demux_config=demux_config)
 
 
 def test_demux_config_headless(get_sample):
@@ -36,14 +31,11 @@ def test_demux_config_headless(get_sample):
     cmd = "ffmpeg -hide_banner -y -f lavfi -i 'sine=frequency=1000:sample_rate=48000:duration=3' -f s16le -c:a pcm_s16le sample.raw"
     sample = get_sample(cmd)
 
-    async def _test(src):
-        with pytest.raises(RuntimeError):
-            await spdl.io.async_demux_audio(src)
+    with pytest.raises(RuntimeError):
+        spdl.io.demux_audio(sample.path)
 
-        demux_config = spdl.io.demux_config(format="s16le")
-        _ = await spdl.io.async_demux_audio(src, demux_config=demux_config)
-
-    asyncio.run(_test(sample.path))
+    demux_config = spdl.io.demux_config(format="s16le")
+    _ = spdl.io.demux_audio(sample.path, demux_config=demux_config)
 
 
 def test_decode_config_smoketest(get_sample):
@@ -51,18 +43,15 @@ def test_decode_config_smoketest(get_sample):
     cmd = "ffmpeg -hide_banner -y -f lavfi -i testsrc -frames:v 1000 sample.mp4"
     sample = get_sample(cmd)
 
-    async def _test(src):
-        packets = await spdl.io.async_demux_video(src)
+    packets = spdl.io.demux_video(sample.path)
 
-        cfg = spdl.io.decode_config()
-        _ = await spdl.io.async_decode_packets(packets.clone(), decode_config=cfg)
+    cfg = spdl.io.decode_config()
+    _ = spdl.io.decode_packets(packets.clone(), decode_config=cfg)
 
-        cfg = spdl.io.decode_config(decoder="h264")
-        _ = await spdl.io.async_decode_packets(packets.clone(), decode_config=cfg)
+    cfg = spdl.io.decode_config(decoder="h264")
+    _ = spdl.io.decode_packets(packets.clone(), decode_config=cfg)
 
-        cfg = spdl.io.decode_config(
-            decoder="h264", decoder_options={"nal_length_size": "4"}
-        )
-        _ = await spdl.io.async_decode_packets(packets.clone(), decode_config=cfg)
-
-    asyncio.run(_test(sample.path))
+    cfg = spdl.io.decode_config(
+        decoder="h264", decoder_options={"nal_length_size": "4"}
+    )
+    _ = spdl.io.decode_packets(packets.clone(), decode_config=cfg)

--- a/tests/spdl_unittest/io/encoding_test.py
+++ b/tests/spdl_unittest/io/encoding_test.py
@@ -4,7 +4,6 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-import asyncio
 from itertools import product
 from tempfile import NamedTemporaryFile
 
@@ -29,47 +28,44 @@ def test_encode_smoketest(fmt, enc_cfg):
     shape, pix_fmt = fmt
     data = np.random.randint(255, size=shape, dtype=np.uint8)
 
-    async def _test(arr):
+    def _test(arr):
         with NamedTemporaryFile(suffix=".png") as f:
-            await spdl.io.async_encode_image(
+            spdl.io.encode_image(
                 f.name,
                 arr,
                 pix_fmt=pix_fmt,
                 encode_config=enc_cfg,
             )
 
-    asyncio.run(_test(data))
-    asyncio.run(_test(torch.from_numpy(data)))
+    _test(data)
+    _test(torch.from_numpy(data))
 
 
 def test_encode_png_gray16be():
     data = np.random.randint(256, size=(32, 64), dtype=np.uint16)
     enc_cfg = spdl.io.encode_config(format="gray16be")
 
-    async def _test(arr):
+    def _test(arr):
         with NamedTemporaryFile(suffix=".png") as f:
-            await spdl.io.async_encode_image(
+            spdl.io.encode_image(
                 f.name,
                 arr,
                 pix_fmt="gray16",
                 encode_config=enc_cfg,
             )
 
-    asyncio.run(_test(data))
+    _test(data)
 
 
 def _test_rejects(pix_fmt, dtype):
-    async def _test(arr):
-        with NamedTemporaryFile(suffix=".png") as f:
-            with pytest.raises(RuntimeError):
-                await spdl.io.async_encode_image(
-                    f.name,
-                    arr,
-                    pix_fmt=pix_fmt,
-                )
-
     data = np.ones((32, 64), dtype=dtype)
-    asyncio.run(_test(data))
+    with NamedTemporaryFile(suffix=".png") as f:
+        with pytest.raises(RuntimeError):
+            spdl.io.encode_image(
+                f.name,
+                data,
+                pix_fmt=pix_fmt,
+            )
 
 
 @pytest.mark.parametrize(

--- a/tests/spdl_unittest/io/frames_test.py
+++ b/tests/spdl_unittest/io/frames_test.py
@@ -4,8 +4,6 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-import asyncio
-
 import spdl.io
 
 
@@ -18,10 +16,7 @@ def test_image_frame_metadata(get_sample):
     cmd = "ffmpeg -hide_banner -y -f lavfi -i testsrc -frames:v 1 sample.jpg"
     sample = get_sample(cmd)
 
-    async def test(src):
-        packets = await spdl.io.async_demux_image(src)
-        frames = await spdl.io.async_decode_packets(packets)
+    packets = spdl.io.demux_image(sample.path)
+    frames = spdl.io.decode_packets(packets)
 
-        assert frames.metadata == {}
-
-    asyncio.run(test(sample.path))
+    assert frames.metadata == {}

--- a/tests/spdl_unittest/io/streaming_video_decoding_test.py
+++ b/tests/spdl_unittest/io/streaming_video_decoding_test.py
@@ -4,8 +4,6 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-import asyncio
-
 import numpy as np
 import pytest
 import spdl.io
@@ -16,22 +14,19 @@ def test_streaming_decode(get_sample):
     cmd = "ffmpeg -hide_banner -y -f lavfi -i testsrc -frames:v 50 sample.mp4"
     sample = get_sample(cmd)
 
-    async def test(src):
-        packets = await spdl.io.async_demux_video(src)
-        frames = await spdl.io.async_decode_packets(packets.clone())
-        buffer = await spdl.io.async_convert_frames(frames)
-        ref_array = spdl.io.to_numpy(buffer)
+    packets = spdl.io.demux_video(sample.path)
+    frames = spdl.io.decode_packets(packets.clone())
+    buffer = spdl.io.convert_frames(frames)
+    ref_array = spdl.io.to_numpy(buffer)
 
-        agen = spdl.io.async_streaming_decode_packets(packets, 1)
-        for i in range(50):
-            print(i)
-            frame = await anext(agen)
-            buffer = await spdl.io.async_convert_frames(frame)
-            array = spdl.io.to_numpy(buffer)
-            print(f"{ref_array.shape=}, {array.shape=}")
-            assert np.array_equal(ref_array[i : i + 1], array)
-
-    asyncio.run(test(sample.path))
+    gen = spdl.io.streaming_decode_packets(packets, 1)
+    for i in range(50):
+        print(i)
+        frame = next(gen)
+        buffer = spdl.io.convert_frames(frame)
+        array = spdl.io.to_numpy(buffer)
+        print(f"{ref_array.shape=}, {array.shape=}")
+        assert np.array_equal(ref_array[i : i + 1], array)
 
 
 def test_streaming_decode_indivisible(get_sample):
@@ -39,21 +34,18 @@ def test_streaming_decode_indivisible(get_sample):
     cmd = "ffmpeg -hide_banner -y -f lavfi -i testsrc -frames:v 8 sample.mp4"
     sample = get_sample(cmd)
 
-    async def test(src):
-        packets = await spdl.io.async_demux_video(src)
-        agen = spdl.io.async_streaming_decode_packets(packets, 5)
+    packets = spdl.io.demux_video(sample.path)
+    gen = spdl.io.streaming_decode_packets(packets, 5)
 
-        frame = await anext(agen)
-        buffer = await spdl.io.async_convert_frames(frame)
-        array = spdl.io.to_numpy(buffer)
-        assert array.shape == (5, 240, 320, 3)
+    frame = next(gen)
+    buffer = spdl.io.convert_frames(frame)
+    array = spdl.io.to_numpy(buffer)
+    assert array.shape == (5, 240, 320, 3)
 
-        frame = await anext(agen)
-        buffer = await spdl.io.async_convert_frames(frame)
-        array = spdl.io.to_numpy(buffer)
-        assert array.shape == (3, 240, 320, 3)
-
-    asyncio.run(test(sample.path))
+    frame = next(gen)
+    buffer = spdl.io.convert_frames(frame)
+    array = spdl.io.to_numpy(buffer)
+    assert array.shape == (3, 240, 320, 3)
 
 
 def test_streaming_decode_stop_iteration(get_sample):
@@ -61,20 +53,17 @@ def test_streaming_decode_stop_iteration(get_sample):
     cmd = "ffmpeg -hide_banner -y -f lavfi -i testsrc -frames:v 1 sample.mp4"
     sample = get_sample(cmd)
 
-    async def test(src):
-        packets = await spdl.io.async_demux_video(src)
-        agen = spdl.io.async_streaming_decode_packets(packets, 5)
+    packets = spdl.io.demux_video(sample.path)
+    gen = spdl.io.streaming_decode_packets(packets, 5)
 
-        frame = await anext(agen)
-        buffer = await spdl.io.async_convert_frames(frame)
-        array = spdl.io.to_numpy(buffer)
-        assert array.shape == (1, 240, 320, 3)
+    frame = next(gen)
+    buffer = spdl.io.convert_frames(frame)
+    array = spdl.io.to_numpy(buffer)
+    assert array.shape == (1, 240, 320, 3)
 
-        for _ in range(20):
-            with pytest.raises(StopAsyncIteration):
-                await anext(agen)
-
-    asyncio.run(test(sample.path))
+    for _ in range(20):
+        with pytest.raises(StopIteration):
+            next(gen)
 
 
 def test_streaming_decode_carryover(get_sample):
@@ -86,24 +75,17 @@ def test_streaming_decode_carryover(get_sample):
     # this will internally cause the filtergraph to duplicate the frames.
     filter_desc = "fps=1000"
 
-    async def test(src):
-        packets = await spdl.io.async_demux_video(src)
-        frames = await spdl.io.async_decode_packets(
-            packets.clone(), filter_desc=filter_desc
-        )
-        buffer = await spdl.io.async_convert_frames(frames)
-        ref_array = spdl.io.to_numpy(buffer)
-        print(ref_array.shape)
+    packets = spdl.io.demux_video(sample.path)
+    frames = spdl.io.decode_packets(packets.clone(), filter_desc=filter_desc)
+    buffer = spdl.io.convert_frames(frames)
+    ref_array = spdl.io.to_numpy(buffer)
+    print(ref_array.shape)
 
-        agen = spdl.io.async_streaming_decode_packets(
-            packets, 5, filter_desc=filter_desc
-        )
+    gen = spdl.io.streaming_decode_packets(packets, 5, filter_desc=filter_desc)
 
-        for i in range(200):
-            print(i)
-            frame = await anext(agen)
-            buffer = await spdl.io.async_convert_frames(frame)
-            array = spdl.io.to_numpy(buffer)
-            assert array.shape == (5, 3, 240, 320)
-
-    asyncio.run(test(sample.path))
+    for i in range(200):
+        print(i)
+        frame = next(gen)
+        buffer = spdl.io.convert_frames(frame)
+        array = spdl.io.to_numpy(buffer)
+        assert array.shape == (5, 3, 240, 320)

--- a/tests/spdl_unittest/io/video_frame_slice_test.py
+++ b/tests/spdl_unittest/io/video_frame_slice_test.py
@@ -4,8 +4,6 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-import asyncio
-
 import numpy as np
 import pytest
 import spdl.io
@@ -14,18 +12,15 @@ from spdl.io import get_video_filter_desc
 
 
 def _to_numpy(frames):
-    buffer = asyncio.run(spdl.io.async_convert_frames(frames))
+    buffer = spdl.io.convert_frames(frames)
     return spdl.io.to_numpy(buffer)
 
 
 def _decode_video(src, pix_fmt=None):
-    async def _decode():
-        return await spdl.io.async_decode_packets(
-            await spdl.io.async_demux_video(src),
-            filter_desc=get_video_filter_desc(pix_fmt=pix_fmt),
-        )
-
-    return asyncio.run(_decode())
+    return spdl.io.decode_packets(
+        spdl.io.demux_video(src),
+        filter_desc=get_video_filter_desc(pix_fmt=pix_fmt),
+    )
 
 
 def test_video_frames_getitem_slice(get_sample):

--- a/tests/spdl_unittest/io/zero_copy_bytes_passing_test.py
+++ b/tests/spdl_unittest/io/zero_copy_bytes_passing_test.py
@@ -4,8 +4,6 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-import asyncio
-
 import numpy as np
 import pytest
 import spdl.io
@@ -28,65 +26,59 @@ def test_demux_bytes_without_copy(media_type, get_sample):
     sample = get_sample(cmd)
 
     demux_func = {
-        "audio": spdl.io.async_demux_audio,
-        "video": spdl.io.async_demux_video,
-        "image": spdl.io.async_demux_image,
+        "audio": spdl.io.demux_audio,
+        "video": spdl.io.demux_video,
+        "image": spdl.io.demux_image,
     }[media_type]
 
-    async def _test(src):
+    def _test(src):
         assert not _is_all_zero(src)
-        _ = await demux_func(src, _zero_clear=True)
+        _ = demux_func(src, _zero_clear=True)
         assert _is_all_zero(src)
 
     with open(sample.path, "rb") as f:
         data = f.read()
 
-    asyncio.run(_test(data))
+    _test(data)
 
 
-async def _decode(media_type, src):
+def _decode(media_type, src):
     demux_func = {
-        "audio": spdl.io.async_demux_audio,
-        "video": spdl.io.async_demux_video,
-        "image": spdl.io.async_demux_image,
+        "audio": spdl.io.demux_audio,
+        "video": spdl.io.demux_video,
+        "image": spdl.io.demux_image,
     }[media_type]
 
-    packets = await demux_func(src)
-    frames = await spdl.io.async_decode_packets(packets)
-    buffer = await spdl.io.async_convert_frames(frames)
+    packets = demux_func(src)
+    frames = spdl.io.decode_packets(packets)
+    buffer = spdl.io.convert_frames(frames)
     return spdl.io.to_numpy(buffer)
 
 
-def test_async_decode_audio_bytes(get_sample):
+def test_decode_audio_bytes(get_sample):
     """audio can be decoded from bytes."""
     cmd = "ffmpeg -hide_banner -y -f lavfi -i 'sine=frequency=1000:sample_rate=16000:duration=3' -c:a pcm_s16le sample.wav"
     sample = get_sample(cmd)
 
-    async def _test(path):
-        ref = await _decode("audio", path)
-        with open(path, "rb") as f:
-            hyp = await _decode("audio", f.read())
+    ref = _decode("audio", sample.path)
+    with open(sample.path, "rb") as f:
+        hyp = _decode("audio", f.read())
 
-        assert hyp.shape == (1, 48000)
-        assert np.all(ref == hyp)
-
-    asyncio.run(_test(sample.path))
+    assert hyp.shape == (1, 48000)
+    assert np.all(ref == hyp)
 
 
-def test_async_decode_video_bytes(get_sample):
+def test_decode_video_bytes(get_sample):
     """video can be decoded from bytes."""
     cmd = "ffmpeg -hide_banner -y -f lavfi -i testsrc -frames:v 1000 sample.mp4"
     sample = get_sample(cmd, width=320, height=240)
 
-    async def _test(path):
-        ref = await _decode("video", path)
-        with open(path, "rb") as f:
-            hyp = await _decode("video", f.read())
+    ref = _decode("video", sample.path)
+    with open(sample.path, "rb") as f:
+        hyp = _decode("video", f.read())
 
-        assert hyp.shape == (1000, 240, 320, 3)
-        assert np.all(ref == hyp)
-
-    asyncio.run(_test(sample.path))
+    assert hyp.shape == (1000, 240, 320, 3)
+    assert np.all(ref == hyp)
 
 
 def test_demux_image_bytes(get_sample):
@@ -94,12 +86,9 @@ def test_demux_image_bytes(get_sample):
     cmd = "ffmpeg -hide_banner -y -f lavfi -i color=0x000000,format=gray -frames:v 1 sample.png"
     sample = get_sample(cmd, width=320, height=240)
 
-    async def _test(path):
-        ref = await _decode("image", path)
-        with open(sample.path, "rb") as f:
-            hyp = await _decode("image", f.read())
+    ref = _decode("image", sample.path)
+    with open(sample.path, "rb") as f:
+        hyp = _decode("image", f.read())
 
-        assert hyp.shape == (240, 320, 3)
-        assert np.all(ref == hyp)
-
-    asyncio.run(_test(sample.path))
+    assert hyp.shape == (240, 320, 3)
+    assert np.all(ref == hyp)


### PR DESCRIPTION
Preparation for upcoming removal of async API from IO module.
This commit removes AsyncIO from test.
Also it modifies `async_load_image_batch` into synchronous one.