### PR TITLE
Add StatsQueue

### DIFF
--- a/src/spdl/pipeline/__init__.py
+++ b/src/spdl/pipeline/__init__.py
@@ -11,17 +11,18 @@
 from ._builder import PipelineBuilder, PipelineFailure, run_pipeline_in_subprocess
 from ._hook import PipelineHook, TaskStatsHook
 from ._pipeline import Pipeline
-from ._queue import AsyncQueue
+from ._queue import AsyncQueue, StatsQueue
 from ._utils import create_task, iterate_in_subprocess
 
 __all__ = [
-    "AsyncQueue",
     "Pipeline",
     "PipelineBuilder",
     "PipelineFailure",
     "create_task",
     "PipelineHook",
     "TaskStatsHook",
+    "AsyncQueue",
+    "StatsQueue",
     "iterate_in_subprocess",
     "run_pipeline_in_subprocess",
 ]

--- a/src/spdl/pipeline/_builder.py
+++ b/src/spdl/pipeline/_builder.py
@@ -38,7 +38,7 @@ from ._hook import (
     TaskStatsHook,
 )
 from ._pipeline import Pipeline
-from ._queue import AsyncQueue
+from ._queue import AsyncQueue, StatsQueue
 from ._utils import create_task, iterate_in_subprocess
 
 __all__ = [
@@ -560,7 +560,7 @@ class PipelineBuilder(Generic[T, U]):
         self,
         source: Iterable[T] | AsyncIterable[T],
         *,
-        queue_class: type[AsyncQueue[T]] = AsyncQueue,
+        queue_class: type[AsyncQueue[T]] = StatsQueue,
         **_kwargs,  # pyre-ignore: [2]
     ) -> "PipelineBuilder[T, U]":
         """Attach an iterator to the source buffer.
@@ -612,7 +612,7 @@ class PipelineBuilder(Generic[T, U]):
         hooks: list[PipelineHook] | None = None,
         report_stats_interval: float | None = None,
         output_order: str = "completion",
-        queue_class: type[AsyncQueue[U_]] = AsyncQueue,
+        queue_class: type[AsyncQueue[U_]] = StatsQueue,
         **_kwargs,  # pyre-ignore: [2]
     ) -> "PipelineBuilder[T, U]":
         """Apply an operation to items in the pipeline.
@@ -750,7 +750,7 @@ class PipelineBuilder(Generic[T, U]):
         drop_last: bool = False,
         hooks: list[PipelineHook] | None = None,
         report_stats_interval: float | None = None,
-        queue_class: type[AsyncQueue[T]] = AsyncQueue,
+        queue_class: type[AsyncQueue[T]] = StatsQueue,
     ) -> "PipelineBuilder[T, U]":
         """Buffer the items in the pipeline.
 
@@ -787,7 +787,7 @@ class PipelineBuilder(Generic[T, U]):
         *,
         hooks: list[PipelineHook] | None = None,
         report_stats_interval: float | None = None,
-        queue_class: type[AsyncQueue[T_]] = AsyncQueue,
+        queue_class: type[AsyncQueue[T_]] = StatsQueue,
     ) -> "PipelineBuilder[T, U]":
         """Disaggregate the items in the pipeline.
 
@@ -818,7 +818,7 @@ class PipelineBuilder(Generic[T, U]):
     def add_sink(
         self,
         buffer_size: int,
-        queue_class: type[AsyncQueue[U]] = AsyncQueue,
+        queue_class: type[AsyncQueue[U]] = StatsQueue,
     ) -> "PipelineBuilder[T, U]":
         """Attach a buffer to the end of the pipeline.
 


### PR DESCRIPTION
`StatsQueue` tracks the time it takes to put items in queue and get items from queue.

It helps analyze the bottleneck in the pipeline.

Let's say we have the following pipeline.
The source is in-memory dataset catalogue.
The `download` function downloads images from the remote server. It fetches multiple images par sample, and it works on batched samples. The `preprocess` function does some heavy image processing. It is applied par sample images. (not batch)

```
pipeline = (
    PipelineBuilder()
    .add_source(source)
    .aggregate(8)
    .pipe(download, concurrency=8)
    .disaggregate()
    .pipe(preprocess, concurrency=8)
    .add_sink()
    .build(num_workers=8)
)
```

The average time it takes for each stage looks like the following. The aggregate/disaggregate stages are relatively negligible. On average, download process for one sample takes 1.5/8 ~= 0.2 sec. The preprocessing stage takes 0.7 sec par sample.

QPS looks the same for all the stages.
This is because the pipeline is elastic.
When one stage of the pipeline is slow, other stages react quickly to the stage, but cannot be faster.
Averaging QPS over for certain preriod make QPS of all stages look similar.

```
INFO:[aggregate_0(8, drop_last=False)]        Completed  1090 tasks (  0 failed) in 99.6576 [sec]. QPS: 10.94 (Concurrency:   1). Average task time:   5.8140 [ ms].
INFO:[download]                               Completed   134 tasks (  0 failed) in 99.6579 [sec]. QPS:  1.34 (Concurrency:   8). Average task time:   1.4997 [sec].
INFO:[disaggregate_0()]                       Completed  1010 tasks (  0 failed) in 99.6579 [sec]. QPS: 10.13 (Concurrency:   1). Average task time:   0.6098 [ ms].
INFO:[preprocess]                             Completed  1000 tasks (  0 failed) in 99.6577 [sec]. QPS: 10.03 (Concurrency:   8). Average task time: 731.9253 [ ms].
```

Let's look at the queue stats.

```
INFO:[src_output]                             Processed  1090 items in 99.6583 [sec]. QPS: 10.94. Ave wait time: 85.2559 [ ms] (upstream),  0.1894 [ ms] (downstream).
INFO:[aggregate_0(8, drop_last=False)_output] Processed  1088 items in 99.6577 [sec]. QPS: 10.92. Ave wait time: 85.3507 [ ms] (upstream),  6.0617 [ ms] (downstream).
INFO:[download_output]                        Processed   127 items in 99.6579 [sec]. QPS:  1.27. Ave wait time:  4.1913 [sec] (upstream), 71.9291 [ ms] (downstream).
                                                                                                                 ^^^^^^^^^^^^^
INFO:[disaggregate_0()_output]                Processed  1008 items in 99.6580 [sec]. QPS: 10.11. Ave wait time: 88.9635 [ ms] (upstream),  7.9042 [ ms] (downstream).
INFO:[preprocess_output]                      Processed  1000 items in 99.6577 [sec]. QPS: 10.03. Ave wait time:  0.0159 [ ms] (upstream), 99.6241 [ ms] (downstream).
                                                                                                                 ^^^^^^^^^^^^^
INFO:[sink]                                   Processed  1000 items in 99.6579 [sec]. QPS: 10.03. Average wait time: Upstream: 99.6297 [ ms], Downstream: 0.0093 [ ms].
```

There are two things stand out.
1. The time to put results of the download stage is much longer than the rest.
2. Upstream time (time for `put`) is longer than downstream (time for `get`) except the preprocess stage.

This suggests that there is a congestion **after** the download stage, and it is the preprocess stage. The stages other than preprocess are waiting on its downstream stages to complete, while the stage after the preprocess (sink) waits on the upstream (preprocess).

This tells that the bottleneck is in `preprocess`.