### PR TITLE
Prefix the queue/stage order

### DIFF
--- a/src/spdl/pipeline/_components/_build.py
+++ b/src/spdl/pipeline/_components/_build.py
@@ -129,13 +129,13 @@ def _build_pipeline(
 
     # source
     queue_class = _get_queue(src.queue_class, report_stats_interval)
-    queues.append(queue_class("0_src_queue", 1))
-    coros.append(("AsyncPipeline::0_source", _source(src.source, queues[0])))
+    queues.append(queue_class("0:src_queue", 1))
+    coros.append(("Pipeline::0:src", _source(src.source, queues[0])))
 
     # pipes
     for i, cfg in enumerate(process_args, start=1):
         queue_class = _get_queue(cfg.queue_class, report_stats_interval)
-        queue_name = f"{i}_{cfg.args.name.split('(')[0]}_queue"
+        queue_name = f"{cfg.args.name}_queue"
         queues.append(queue_class(queue_name, 1))
         in_queue, out_queue = queues[i - 1 : i + 1]
 
@@ -149,15 +149,15 @@ def _build_pipeline(
             case _:  # pragma: no cover
                 raise ValueError(f"Unexpected process type: {cfg.type_}")
 
-        coros.append((f"AsyncPipeline::{i}_{cfg.args.name}", coro))
+        coros.append((f"Pipeline::{cfg.args.name}", coro))
 
     # sink
     n = len(process_args) + 1
     queue_class = _get_queue(sink.queue_class, report_stats_interval)
-    output_queue = queue_class(f"{n}_sink_queue", sink.buffer_size)
+    output_queue = queue_class(f"{n}:sink_queue", sink.buffer_size)
     coros.append(
         (
-            f"AsyncPipeline::{n}_sink",
+            f"Pipeline::{n}:sink",
             _sink(queues[-1], output_queue),
         )
     )

--- a/src/spdl/pipeline/_queue.py
+++ b/src/spdl/pipeline/_queue.py
@@ -141,7 +141,7 @@ class StatsQueue(AsyncQueue[T]):
     ) -> None:
         _LG.info(
             "[%s]\tProcessed %5d items in %s (QPS: %6.1f) "
-            "Ave wait time: Upstream (put): %s, Downstream (get): %s.",
+            "Ave wait time: put: %s, get (by next stage): %s.",
             self.name,
             num_items,
             _time_str(elapsed),


### PR DESCRIPTION
So that it's easier to check the stats in the log.

```

INFO:spdl.pipeline._queue:[0:src_queue]			Processed    10 items in    2.6 [ ms] (QPS: 3809.5) Ave wait time: put:    0.1 [ ms], get (by next stage):    0.0 [ ms].
INFO:spdl.pipeline._queue:[1:add1_queue]		Processed    10 items in    2.9 [ ms] (QPS: 3432.4) Ave wait time: put:    0.0 [ ms], get (by next stage):    0.0 [ ms].
INFO:spdl.pipeline._queue:[2:x2_queue]			Processed    10 items in    3.3 [ ms] (QPS: 3018.1) Ave wait time: put:    0.0 [ ms], get (by next stage):    0.1 [ ms].
INFO:spdl.pipeline._queue:[3:aggregate(3)_queue]	Processed    11 items in    3.8 [ ms] (QPS: 2889.0) Ave wait time: put:    0.0 [ ms], get (by next stage):    0.2 [ ms].
INFO:spdl.pipeline._queue:[4:sum_queue]			Processed     4 items in    4.0 [ ms] (QPS:  998.1) Ave wait time: put:    0.0 [ ms], get (by next stage):    0.7 [ ms].
INFO:spdl.pipeline._queue:[5:aggregate(2)_queue]	Processed     5 items in    4.5 [ ms] (QPS: 1102.1) Ave wait time: put:    0.0 [ ms], get (by next stage):    0.6 [ ms].
INFO:spdl.pipeline._queue:[6:disaggregate_queue]	Processed     4 items in    4.6 [ ms] (QPS:  871.2) Ave wait time: put:    0.0 [ ms], get (by next stage):    1.1 [ ms].
INFO:spdl.pipeline._queue:[7:sink_queue]		Processed     4 items in    4.6 [ ms] (QPS:  863.2) Ave wait time: put:    0.0 [ ms], get (by next stage):    0.9 [ ms].

INFO:spdl.pipeline._hook:[1:add1]		Completed    10 tasks (  0 failed). (Concurrency:   1). Ave task time:    0.1 [ ms].
INFO:spdl.pipeline._hook:[2:x2]			Completed    10 tasks (  0 failed). (Concurrency:   1). Ave task time:    0.1 [ ms].
INFO:spdl.pipeline._hook:[3:aggregate(3)]	Completed    11 tasks (  0 failed). (Concurrency:   1). Ave task time:    0.1 [ ms].
INFO:spdl.pipeline._hook:[4:sum]		Completed     4 tasks (  0 failed). (Concurrency:   1). Ave task time:    0.2 [ ms].
INFO:spdl.pipeline._hook:[5:aggregate(2)]	Completed     5 tasks (  0 failed). (Concurrency:   1). Ave task time:    0.1 [ ms].
INFO:spdl.pipeline._hook:[6:disaggregate]	Completed     4 tasks (  0 failed). (Concurrency:   1). Ave task time:    0.2 [ ms].
```