### PR TITLE
Make SKIP internal to pipe implementation

### DIFF
--- a/src/spdl/pipeline/_components/_common.py
+++ b/src/spdl/pipeline/_components/_common.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-__all__ = ["_queue_stage_hook", "_EOF", "_SKIP"]
+__all__ = ["_queue_stage_hook", "_EOF"]
 
 from contextlib import asynccontextmanager
 from typing import AsyncGenerator, TypeVar
@@ -28,7 +28,6 @@ class _Sentinel:
 
 
 _EOF = _Sentinel("EOF")  # Indicate the end of stream.
-_SKIP = _Sentinel("SKIP")  # Indicate that there is no data to process.
 
 
 @asynccontextmanager

--- a/src/spdl/pipeline/_components/_sink.py
+++ b/src/spdl/pipeline/_components/_sink.py
@@ -9,7 +9,7 @@ __all__ = ["_sink"]
 from typing import TypeVar
 
 from .._queue import AsyncQueue
-from ._common import _EOF, _SKIP
+from ._common import _EOF
 
 # pyre-strict
 
@@ -25,8 +25,4 @@ async def _sink(input_queue: AsyncQueue[T], output_queue: AsyncQueue[T]) -> None
 
             if item is _EOF:
                 break
-
-            if item is _SKIP:
-                continue
-
             await output_queue.put(item)

--- a/src/spdl/pipeline/_components/_source.py
+++ b/src/spdl/pipeline/_components/_source.py
@@ -11,7 +11,7 @@ from typing import TypeVar
 
 from .._convert import _to_async_gen
 from .._queue import AsyncQueue
-from ._common import _queue_stage_hook, _SKIP
+from ._common import _queue_stage_hook
 
 # pyre-strict
 
@@ -31,8 +31,7 @@ async def _source(
     async with _queue_stage_hook(queue):
         num_items = 0
         async for item in src_:
-            if item is not _SKIP:
-                await queue.put(item)
-                num_items += 1
-                if max_items is not None and num_items >= max_items:
-                    return
+            await queue.put(item)
+            num_items += 1
+            if max_items is not None and num_items >= max_items:
+                return


### PR DESCRIPTION
Rather than pass the SKIP sentinel to the next pipe, it is better to not to pass it at all.

SKIP logic is currently used only by Aggregate, so for the sake of simplifying the implementation, make the SKIP internal to pipe, and make source and sink unaware of it.