### PR TITLE
Add 3.13t build CI job for macOS

### DIFF
--- a/.github/workflows/_build_macos.yml
+++ b/.github/workflows/_build_macos.yml
@@ -6,13 +6,17 @@ on:
       python-version:
         required: true
         type: string
+      free-threaded:
+        description: 'Whether FT Python or not. Valid value is "ft" or not.'
+        default: ''
+        type: string
       run-test:
         required: false
         default: 'false'
         type: string
 
 env:
-  ARTIFACT: wheel-macos-py${{ inputs.python-version }}
+  ARTIFACT: wheel-macos-py${{ inputs.python-version }}${{ inputs.free-threaded }}
         
 jobs:
   build:
@@ -29,7 +33,13 @@ jobs:
         run: |
           curl -LsSf https://astral.sh/uv/install.sh | sh
           set -ex
-          uv python pin "${{ inputs.python-version }}"
+
+          py_ver="${{ inputs.python-version }}"
+          if [[ "${{ inputs.free-threaded }}" == 'ft' ]]; then
+            py_ver="${py_ver}t"
+          fi
+
+          uv python pin "${py_ver}"
           uv python list --only-installed
           uv venv
           uv build --all-packages --wheel
@@ -78,11 +88,19 @@ jobs:
 
       - name: Unit test
         run: |
+          if [[ "${{ inputs.free-threaded }}" == 'ft' ]]; then
+            conda install -q -c conda-forge python-freethreading
+          fi
+
           # Install SPDL
           pip install $(find "${HOME}/package" -name '*.whl' -depth -maxdepth 1)
 
           # Install PyTorch and others
-          pip install torch numpy numba pytest
+          if [[ "${{ inputs.free-threaded }}" == 'ft' ]]; then
+            pip install torch numpy pytest
+          else
+            pip install torch numpy numba pytest
+          fi
 
           # Install FFmpeg
           conda install -q -c conda-forge "ffmpeg==${{ matrix.ffmpeg-version }}"

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -27,10 +27,15 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
+        free-threaded: [""]
+        include:
+          - python-version: "3.13"
+            free-threaded: "ft"
     uses: ./.github/workflows/_build_macos.yml
     with:
       python-version: "${{ matrix.python-version }}"
-      run-test: "${{ matrix.python-version == '3.10'}}"
+      free-threaded: "${{ matrix.free-threaded }}"
+      run-test: "${{ matrix.python-version == '3.10' }}"
 
   #############################################################################
   # Linux (CPU)


### PR DESCRIPTION
PyTorch 2.6 3.13t causes the following issue so no unit test for now.

` ImportError: Failed to load PyTorch C extensions:`