### PR TITLE
Disable macOS CI unit tests

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -35,7 +35,7 @@ jobs:
     with:
       python-version: "${{ matrix.python-version }}"
       free-threaded: "${{ matrix.free-threaded }}"
-      run-test: "${{ matrix.python-version == '3.10' }}"
+      run-test: "false"
 
   #############################################################################
   # Linux (CPU)


### PR DESCRIPTION
The cost multiplier for macos is HUGE.