### PR TITLE
Check whether the buffer is empty

### DIFF
--- a/src/spdl/io/_convert.py
+++ b/src/spdl/io/_convert.py
@@ -51,12 +51,15 @@ def to_torch(buffer: CPUBuffer | CUDABuffer):
     Returns:
         (torch.Tensor): A PyTorch Tensor.
     """
-    if hasattr(buffer, "__cuda_array_interface__"):
+    if (interface := getattr(buffer, "__cuda_array_interface__", None)) is not None:
         # Note: this is to silence pyre errors.
         # Usually, it should be asserting that `buffer` is a CUDABuffer,
         # but CUDABuffer class is a stub, so it would fail.
         assert not isinstance(buffer, CPUBuffer)
-        data_ptr = buffer.__cuda_array_interface__["data"][0]
+        if any(s == 0 for s in interface.get("shape", [])):
+            raise ValueError("0-element array is not supported.")
+
+        data_ptr = interface["data"][0]
         tensor = torch.as_tensor(buffer, device=f"cuda:{buffer.device_index}")
         if tensor.data_ptr() == 0:
             raise RuntimeError(


### PR DESCRIPTION
Apparently, PyTorch does not handle CUDA array interface well if the tensor is empty.

Instead of saying 'failed to convert', it is better to warn users that the buffer is empty, because it is likely not what users intend.