### PR TITLE
[BC-breaking] Remove alpha channel from NVDEC decoding

### DIFF
--- a/examples/video_dataloading.py
+++ b/examples/video_dataloading.py
@@ -206,7 +206,7 @@ def decode_video_nvdec(
         ),
         width=width,
         height=height,
-        pix_fmt="rgba",
+        pix_fmt="rgb",
     )
     return spdl.io.to_torch(buffer)[..., :3].permute(0, 2, 3, 1)
 

--- a/src/libspdl/cuda/color_conversion.cpp
+++ b/src/libspdl/cuda/color_conversion.cpp
@@ -71,7 +71,7 @@ CUDABufferPtr nv12_to_rgb(
   }
   auto h0 = height / 3 * 2;
 
-  auto ret = cuda_buffer({frames.size(), 4, h0, width}, cfg);
+  auto ret = cuda_buffer({frames.size(), 3, h0, width}, cfg);
 
   auto* dst = (uint8_t*)ret->data();
   for (auto& frame : frames) {
@@ -83,26 +83,26 @@ CUDABufferPtr nv12_to_rgb(
        width,
        h0,
        matrix_coefficients);
-    dst += 4 * h0 * width;
+    dst += 3 * h0 * width;
   }
   return ret;
 }
 
 } // namespace
 
-CUDABufferPtr nv12_to_planar_rgba(
+CUDABufferPtr nv12_to_planar_rgb(
     const std::vector<CUDABuffer>& frames,
     const CUDAConfig& cfg,
     int matrix_coefficients) {
-  return nv12_to_rgb<detail::nv12_to_planar_rgba>(
+  return nv12_to_rgb<detail::nv12_to_planar_rgb>(
       frames, cfg, matrix_coefficients);
 }
 
-CUDABufferPtr nv12_to_planar_bgra(
+CUDABufferPtr nv12_to_planar_bgr(
     const std::vector<CUDABuffer>& frames,
     const CUDAConfig& cfg,
     int matrix_coefficients) {
-  return nv12_to_rgb<detail::nv12_to_planar_bgra>(
+  return nv12_to_rgb<detail::nv12_to_planar_bgr>(
       frames, cfg, matrix_coefficients);
 }
 }; // namespace spdl::cuda

--- a/src/libspdl/cuda/color_conversion.h
+++ b/src/libspdl/cuda/color_conversion.h
@@ -15,12 +15,12 @@
 
 namespace spdl::cuda {
 
-CUDABufferPtr nv12_to_planar_rgba(
+CUDABufferPtr nv12_to_planar_rgb(
     const std::vector<CUDABuffer>& frames,
     const CUDAConfig& cfg,
     int matrix_coefficients = 1);
 
-CUDABufferPtr nv12_to_planar_bgra(
+CUDABufferPtr nv12_to_planar_bgr(
     const std::vector<CUDABuffer>& frames,
     const CUDAConfig& cfg,
     int matrix_coefficients = 1);

--- a/src/libspdl/cuda/detail/color_conversion.h
+++ b/src/libspdl/cuda/detail/color_conversion.h
@@ -15,7 +15,7 @@ typedef CUstream_st* CUstream;
 
 namespace spdl::cuda::detail {
 
-void nv12_to_planar_rgba(
+void nv12_to_planar_rgb(
     CUstream stream,
     uint8_t* src,
     int src_pitch,
@@ -25,7 +25,7 @@ void nv12_to_planar_rgba(
     int height,
     int matrix_coefficients);
 
-void nv12_to_planar_bgra(
+void nv12_to_planar_bgr(
     CUstream stream,
     uint8_t* src,
     int src_pitch,

--- a/src/libspdl/cuda/nvdec/detail/converter.cpp
+++ b/src/libspdl/cuda/nvdec/detail/converter.cpp
@@ -101,16 +101,16 @@ std::unique_ptr<Converter> get_converter(
       return std::unique_ptr<Converter>(new NV12Passthrough{stream, tracker});
     }
     auto pix_fmt_val = pix_fmt.value();
-    if (pix_fmt_val == "rgba") {
+    if (pix_fmt_val == "rgb") {
       return std::unique_ptr<Converter>(
-          new NV12ToRGB<nv12_to_planar_rgba>{stream, tracker, matrix_coeff});
+          new NV12ToRGB<nv12_to_planar_rgb>{stream, tracker, matrix_coeff});
     }
-    if (pix_fmt_val == "bgra") {
+    if (pix_fmt_val == "bgr") {
       return std::unique_ptr<Converter>(
-          new NV12ToRGB<nv12_to_planar_bgra>{stream, tracker, matrix_coeff});
+          new NV12ToRGB<nv12_to_planar_bgr>{stream, tracker, matrix_coeff});
     }
     SPDL_FAIL(fmt::format(
-        "Unsupported pixel format: {}. Supported formats are 'rgba', 'bgra'.",
+        "Unsupported pixel format: {}. Supported formats are 'rgb', 'bgr'.",
         pix_fmt_val));
   }
 

--- a/src/libspdl/cuda/nvdec/detail/decoder.cpp
+++ b/src/libspdl/cuda/nvdec/detail/decoder.cpp
@@ -502,8 +502,8 @@ CUDABufferPtr get_buffer(
   if (pix_fmt_val == "nv12") {
     c = 1;
     h = h + h / 2;
-  } else if (pix_fmt_val == "rgba" || pix_fmt_val == "bgra") {
-    c = 4;
+  } else if (pix_fmt_val == "rgb" || pix_fmt_val == "bgr") {
+    c = 3;
   } else {
     SPDL_FAIL(fmt::format("Unsupported pixel format: {}", pix_fmt_val));
   }

--- a/src/spdl/io/_core.py
+++ b/src/spdl/io/_core.py
@@ -393,7 +393,7 @@ def decode_packets_nvdec(
             cropping.
 
         pix_fmt (str or `None`): *Optional:* Change the format of the pixel.
-            Supported value is ``"rgba"``. Default: ``"rgba"``.
+            Supported value is ``"rgb"`` and ``"bgr"``. Default: ``"rgb"``.
 
     Returns:
         A CUDABuffer object.

--- a/src/spdl/io/lib/cuda/color_conversion.cpp
+++ b/src/spdl/io/lib/cuda/color_conversion.cpp
@@ -22,13 +22,13 @@ namespace nb = nanobind;
 namespace spdl::cuda {
 void register_color_conversion(nb::module_& m) {
   m.def(
-      "nv12_to_planar_rgba",
+      "nv12_to_planar_rgb",
 #ifndef SPDL_USE_CUDA
       [](nb::object, const CUDAConfig&, int) -> CUDABufferPtr {
         throw std::runtime_error("SPDL is not built with CUDA support.");
       },
 #else
-      &nv12_to_planar_rgba,
+      &nv12_to_planar_rgb,
 #endif
       nb::call_guard<nb::gil_scoped_release>(),
       nb::arg("buffers"),
@@ -36,13 +36,13 @@ void register_color_conversion(nb::module_& m) {
       nb::arg("device_config"),
       nb::arg("matrix_coeff") = 1);
   m.def(
-      "nv12_to_planar_bgra",
+      "nv12_to_planar_bgr",
 #ifndef SPDL_USE_CUDA
       [](nb::object, const CUDAConfig&, int) -> CUDABufferPtr {
         throw std::runtime_error("SPDL is not built with CUDA support.");
       },
 #else
-      &nv12_to_planar_bgra,
+      &nv12_to_planar_bgr,
 #endif
       nb::call_guard<nb::gil_scoped_release>(),
       nb::arg("buffers"),

--- a/src/spdl/io/lib/cuda/decoding.cpp
+++ b/src/spdl/io/lib/cuda/decoding.cpp
@@ -77,7 +77,7 @@ void register_decoding(nb::module_& m) {
           nb::arg("crop_bottom") = 0,
           nb::arg("width") = -1,
           nb::arg("height") = -1,
-          nb::arg("pix_fmt").none() = "rgba",
+          nb::arg("pix_fmt").none() = "rgb",
           nb::arg("flush") = false);
 #endif
   ;

--- a/tests/spdl_unittest/cuda/nvdec_video_decoding_test.py
+++ b/tests/spdl_unittest/cuda/nvdec_video_decoding_test.py
@@ -82,7 +82,7 @@ def test_nvdec_video_smoke_test(get_sample):
     tensor = spdl.io.to_torch(buffer)
     print(f"{tensor.shape=}, {tensor.dtype=}, {tensor.device=}")
     assert tensor.shape[0] == 1000
-    assert tensor.shape[1] == 4
+    assert tensor.shape[1] == 3
     assert tensor.shape[2] == 240
     assert tensor.shape[3] == 320
 
@@ -121,7 +121,7 @@ def test_nvdec_decode_h264_420p_basic(h264):
     # _save(v, "./base_v")
 
     assert array.dtype == torch.uint8
-    assert array.shape == (25, 4, h264.height, h264.width)
+    assert array.shape == (25, 3, h264.height, h264.width)
 
 
 # TODO: Test other formats like MJPEG, MPEG, HEVC, VC1 AV1 etc...
@@ -155,7 +155,7 @@ def test_nvdec_decode_video_torch_allocator(h264):
         assert allocator_called
         assert not deleter_called
         assert array.dtype == torch.uint8
-        assert array.shape == (25, 4, h264.height, h264.width)
+        assert array.shape == (25, 3, h264.height, h264.width)
 
     _test()
 
@@ -201,7 +201,7 @@ def test_nvdec_decode_h264_420p_resize(h264):
     # _save(array, "./resize")
 
     assert array.dtype == torch.uint8
-    assert array.shape == (25, 4, height, width)
+    assert array.shape == (25, 3, height, width)
 
 
 def test_nvdec_decode_h264_420p_crop(h264):
@@ -210,7 +210,7 @@ def test_nvdec_decode_h264_420p_crop(h264):
     h = h264.height - top - bottom
     w = h264.width - left - right
 
-    rgba = _decode_video(
+    rgb = _decode_video(
         h264.path,
         timestamp=(0, 1.0),
         crop_top=top,
@@ -219,16 +219,16 @@ def test_nvdec_decode_h264_420p_crop(h264):
         crop_right=right,
     )
 
-    assert rgba.dtype == torch.uint8
-    assert rgba.shape == (25, 4, h, w)
+    assert rgb.dtype == torch.uint8
+    assert rgb.shape == (25, 3, h, w)
 
     rgba0 = _decode_video(
         h264.path,
         timestamp=(0, 1.0),
     )
 
-    for i in range(4):
-        assert torch.equal(rgba[:, i], rgba0[:, i, top : top + h, left : left + w])
+    for i in range(3):
+        assert torch.equal(rgb[:, i], rgba0[:, i, top : top + h, left : left + w])
 
 
 def test_nvdec_decode_crop_resize(h264):
@@ -249,7 +249,7 @@ def test_nvdec_decode_crop_resize(h264):
     )
 
     assert array.dtype == torch.uint8
-    assert array.shape == (25, 4, h, w)
+    assert array.shape == (25, 3, h, w)
 
 
 def _is_ffmpeg4():
@@ -275,10 +275,10 @@ def test_color_conversion_rgba(get_sample):
     height, width = 64, 32
     sample = get_sample(cmd, height=height, width=3 * width)
 
-    array = _decode_video(sample.path, pix_fmt="rgba")
+    array = _decode_video(sample.path, pix_fmt="rgb")
 
     assert array.dtype == torch.uint8
-    assert array.shape == (25, 4, sample.height, sample.width)
+    assert array.shape == (25, 3, sample.height, sample.width)
 
     # Red
     assert torch.all(array[:, 0, :, :width] == 255)


### PR DESCRIPTION
The alpha channel is always 255, and in ML, alpha channel is not used.