### PR TITLE
Reduce the constructor of Packets

### DIFF
--- a/src/libspdl/core/demuxing.cpp
+++ b/src/libspdl/core/demuxing.cpp
@@ -142,9 +142,11 @@ VideoPacketsPtr apply_bsf(VideoPacketsPtr packets, const std::string& name) {
   auto bsf = detail::BitStreamFilter{name, packets->codecpar};
 
   auto ret = std::make_unique<DemuxedPackets<MediaType::Video>>(
-      packets->src, bsf.get_output_codec_par(), packets->time_base);
-  ret->timestamp = packets->timestamp;
-  ret->frame_rate = packets->frame_rate;
+      packets->src,
+      bsf.get_output_codec_par(),
+      packets->time_base,
+      packets->timestamp,
+      packets->frame_rate);
   for (auto& packet : packets->get_packets()) {
     auto filtering = bsf.filter(packet);
     while (filtering) {

--- a/src/libspdl/core/packets.h
+++ b/src/libspdl/core/packets.h
@@ -57,10 +57,10 @@ class DemuxedPackets {
 
   //
   AVCodecParameters* codecpar = nullptr;
-  Rational time_base = {0, 1};
+  Rational time_base;
 
   // frame rate for video
-  Rational frame_rate = {0, 1};
+  Rational frame_rate;
 
  private:
   // Sliced raw packets
@@ -69,20 +69,10 @@ class DemuxedPackets {
  public:
   DemuxedPackets(
       std::string src,
-      std::tuple<double, double> timestamp,
-      AVCodecParameters* codecpar,
-      Rational time_base);
-
-  DemuxedPackets(
-      std::string src,
-      AVCodecParameters* codecpar,
-      Rational time_base);
-
-  DemuxedPackets(
-      std::string src,
       AVCodecParameters* codecpar,
       Rational time_base,
-      std::vector<AVPacket*>&& packets);
+      std::optional<std::tuple<double, double>> timestamp = std::nullopt,
+      Rational frame_rate = {0, 1});
 
   // Destructor releases AVPacket* resources
   ~DemuxedPackets();


### PR DESCRIPTION
1. Some are similar
2. Passing `vector<AVPacket*>` can cause memory leak