### PR TITLE
Use the regular decode function for partial decoding

### DIFF
--- a/src/libspdl/core/decoder.cpp
+++ b/src/libspdl/core/decoder.cpp
@@ -130,8 +130,9 @@ Decoder<media_type>::~Decoder() {
 
 template <MediaType media_type>
 FFmpegFramesPtr<media_type> Decoder<media_type>::decode(
-    PacketsPtr<media_type> packets) {
-  return pImpl->decode(std::move(packets));
+    PacketsPtr<media_type> packets,
+    int num_frames) {
+  return pImpl->decode(std::move(packets), num_frames);
 }
 
 template class Decoder<MediaType::Audio>;

--- a/src/libspdl/core/decoder.h
+++ b/src/libspdl/core/decoder.h
@@ -39,7 +39,9 @@ class Decoder {
 
   ~Decoder();
 
-  FFmpegFramesPtr<media_type> decode(PacketsPtr<media_type> packets);
+  FFmpegFramesPtr<media_type> decode(
+      PacketsPtr<media_type> packets,
+      int num_frames = -1);
 };
 
 template <MediaType media_type>

--- a/src/libspdl/core/detail/ffmpeg/decoder.h
+++ b/src/libspdl/core/detail/ffmpeg/decoder.h
@@ -55,7 +55,9 @@ class DecoderImpl {
   DecoderImpl(DecoderImpl&&) = delete;
   DecoderImpl& operator=(DecoderImpl&&) = delete;
 
-  FFmpegFramesPtr<media_type> decode(PacketsPtr<media_type> packets);
+  FFmpegFramesPtr<media_type> decode(
+      PacketsPtr<media_type> packets,
+      int num_frames = -1);
 };
 
 } // namespace spdl::core::detail

--- a/src/spdl/io/_composite.py
+++ b/src/spdl/io/_composite.py
@@ -538,10 +538,13 @@ def streaming_load_video_nvdec(
 def _decode_partial(packets, indices, decode_config, filter_desc):
     """Decode packets but return early when requested frames are decoded."""
     num_frames = max(indices) + 1
-    decoder = _core.streaming_decode_packets(
-        packets, num_frames, decode_config, filter_desc
+    frames = _core.decode_packets(
+        packets,
+        decode_config=decode_config,
+        filter_desc=filter_desc,
+        num_frames=num_frames,
     )
-    return next(decoder)[indices]
+    return frames[indices]
 
 
 def sample_decode_video(

--- a/src/spdl/io/lib/core/decoding.cpp
+++ b/src/spdl/io/lib/core/decoding.cpp
@@ -64,9 +64,10 @@ template <MediaType media_type>
 FFmpegFramesPtr<media_type> decode_packets(
     PacketsPtr<media_type> packets,
     const std::optional<DecodeConfig>& cfg,
-    const std::optional<std::string>& filter_desc) {
+    const std::optional<std::string>& filter_desc,
+    int num_frames) {
   Decoder<media_type> decoder{packets->codec, cfg, filter_desc};
-  return decoder.decode(std::move(packets));
+  return decoder.decode(std::move(packets), num_frames);
 }
 
 } // namespace
@@ -144,7 +145,8 @@ void register_decoding(nb::module_& m) {
       nb::kw_only(),
 #endif
       nb::arg("decode_config") = nb::none(),
-      nb::arg("filter_desc") = nb::none());
+      nb::arg("filter_desc") = nb::none(),
+      nb::arg("num_frames") = -1);
 
   m.def(
       "decode_packets",
@@ -155,7 +157,8 @@ void register_decoding(nb::module_& m) {
       nb::kw_only(),
 #endif
       nb::arg("decode_config") = nb::none(),
-      nb::arg("filter_desc") = nb::none());
+      nb::arg("filter_desc") = nb::none(),
+      nb::arg("num_frames") = -1);
 
   m.def(
       "decode_packets",
@@ -166,6 +169,7 @@ void register_decoding(nb::module_& m) {
       nb::kw_only(),
 #endif
       nb::arg("decode_config") = nb::none(),
-      nb::arg("filter_desc") = nb::none());
+      nb::arg("filter_desc") = nb::none(),
+      nb::arg("num_frames") = -1);
 }
 } // namespace spdl::core


### PR DESCRIPTION
So that we can remove streaming decoder while keeping the `sample_decode_video`.