### PR TITLE
[BC-Breaking] Do not copy attach codec when stream demuxing

### DIFF
--- a/src/libspdl/core/detail/ffmpeg/demuxer.cpp
+++ b/src/libspdl/core/detail/ffmpeg/demuxer.cpp
@@ -239,18 +239,8 @@ Generator<PacketsPtr<media>> DemuxerImpl::streaming_demux(
     return BitStreamFilter{*bsf, stream->codecpar};
   }();
 
-  Rational frame_rate;
-  if constexpr (media == MediaType::Video) {
-    frame_rate = av_guess_frame_rate(fmt_ctx, stream, nullptr);
-  }
-  auto make_packets =
-      [&](std::vector<AVPacketPtr>&& pkts) -> PacketsPtr<media> {
-    auto ret = std::make_unique<Packets<media>>(
-        di->get_src(),
-        Codec<media>{
-            bsf ? filter->get_output_codec_par() : stream->codecpar,
-            stream->time_base,
-            frame_rate});
+  auto make_packets = [&](std::vector<AVPacketPtr>&& pkts) {
+    auto ret = std::make_unique<Packets<media>>(di->get_src());
     for (auto& p : pkts) {
       ret->pkts.push(p.release());
     }

--- a/src/libspdl/core/packets.cpp
+++ b/src/libspdl/core/packets.cpp
@@ -77,6 +77,16 @@ Packets<media>::Packets(
 };
 
 template <MediaType media>
+Packets<media>::Packets(const std::string& src_)
+    : id(reinterpret_cast<uintptr_t>(this)),
+      src(src_),
+      time_base({}),
+      timestamp(std::nullopt),
+      codec(std::nullopt) {
+  TRACE_EVENT(
+      "decoding", "Packets::Packets", perfetto::Flow::ProcessScoped(id));
+};
+template <MediaType media>
 Packets<media>::Packets(uintptr_t id_, Rational time_base_)
     : id(id_),
       src(fmt::format("{}", id_)),

--- a/src/libspdl/core/packets.h
+++ b/src/libspdl/core/packets.h
@@ -90,11 +90,18 @@ struct Packets {
 
   Packets() = default;
 
-  // Constructing Packets from demuxer for decoding
+  // Constructing Packets from demuxer for one-time decoding
+  // Need codec to initialize the decoder.
+  // Optionally remember the timestamp user asked.
   Packets(
       const std::string& src,
       Codec<media>&& codec,
       const std::optional<std::tuple<double, double>>& timestamp = {});
+
+  // Constructing Packets from demuxer for streaming
+  // No need for codec and time base, as decoder is initialized
+  // seprately.
+  Packets(const std::string& src);
 
   // Constructing Packets from encoder for muxing
   Packets(uintptr_t id, Rational time_base);


### PR DESCRIPTION
It is wasteful to copy codec every time.
Also this makes it difficult to introduce media-type-agnostic stream demuxing.