### PR TITLE
Merge QueueClass and hook creation interface

### DIFF
--- a/src/spdl/pipeline/_hook.py
+++ b/src/spdl/pipeline/_hook.py
@@ -170,6 +170,9 @@ class PipelineHook(ABC):
                   # Add logic that should be executed even if stage fails
                   ...
 
+    Args:
+        name: The name of the stage. Assigned by :py:class:`~spdl.pipeline.PipelineBuilder`.
+
     """
 
     @asynccontextmanager


### PR DESCRIPTION
Summary:
Currently, task hooks and queues have to be passed to each pipe, but this is tedious.

As of now, there are no usecase that requre different kinds of queue and hooks.

This commit merge the interface for customzing the queue/hooks.

Rollback Plan:

Differential Revision: D73931314


