### PR TITLE
Make disaggregate to async

### DIFF
--- a/src/spdl/pipeline/_components/_pipe.py
+++ b/src/spdl/pipeline/_components/_pipe.py
@@ -14,7 +14,7 @@ __all__ = [
 
 import asyncio
 import inspect
-from collections.abc import AsyncIterator, Awaitable, Callable, Coroutine, Iterator
+from collections.abc import AsyncIterator, Awaitable, Callable, Coroutine
 from concurrent.futures import Executor
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
@@ -332,6 +332,6 @@ class _Aggregate(Generic[T]):
         )
 
 
-def _disaggregate(items: list[T]) -> Iterator[T]:
+async def _disaggregate(items: list[T]) -> AsyncIterator[T]:
     for item in items:
         yield item


### PR DESCRIPTION
Without async, the Pipeline will delegate the work to background threads. The overhead can be large compared to the amount of the work actually done, so use async and let the event loop do the disaggregate directly.