### PR TITLE
Name threads

### DIFF
--- a/src/spdl/pipeline/_builder.py
+++ b/src/spdl/pipeline/_builder.py
@@ -102,7 +102,7 @@ def _build_pipeline(
 
     executor = ThreadPoolExecutor(
         max_workers=num_threads,
-        thread_name_prefix="spdl_",
+        thread_name_prefix="spdl_worker_thread_",
     )
     return Pipeline(coro, queues, executor, desc=_get_desc(src, process_args, sink))
 

--- a/src/spdl/pipeline/_pipeline.py
+++ b/src/spdl/pipeline/_pipeline.py
@@ -131,6 +131,7 @@ class _EventLoop:
         self._thread = Thread(
             # Using lambda to delay the creation of coroutine object.
             target=lambda: asyncio.run(self._execute_task()),
+            name="spdl_event_loop_thread",
             daemon=daemon,
         )
         self._thread.start()


### PR DESCRIPTION
When we look at PyTorch Profiler, the name is not important, but when we print the thread name manually, this is rather important.