### PR TITLE
Add support for DEFLATE algorithm

### DIFF
--- a/src/spdl/io/_array.py
+++ b/src/spdl/io/_array.py
@@ -197,8 +197,10 @@ class NpzFile(Mapping):
             case 0:
                 return load_npy(self._data[start : start + compressed_size])
             case 8:
-                raise NotImplementedError(
-                    "Compression method (DEFLATE) is not supported."
+                return load_npy(
+                    _libspdl._zip.inflate(
+                        self._data.obj, start, compressed_size, uncompressed_size
+                    )
                 )
             case _:
                 raise ValueError(

--- a/src/spdl/io/lib/zip/CMakeLists.txt
+++ b/src/spdl/io/lib/zip/CMakeLists.txt
@@ -12,7 +12,7 @@ set(name _zip)
 message(STATUS "Building ${name}")
 
 set(srcs register.cpp impl.cpp)
-set(deps libzip::zip fmt::fmt glog::glog)
+set(deps ZLIB::ZLIB fmt::fmt glog::glog)
 nanobind_add_module("${name}" "${srcs}")
 target_link_libraries("${name}" PRIVATE "${deps}")
 target_include_directories("${name}" PRIVATE "${Python_INCLUDE_DIR}")

--- a/src/spdl/io/lib/zip/register.cpp
+++ b/src/spdl/io/lib/zip/register.cpp
@@ -29,6 +29,12 @@ std::map<std::string, ZipMetaData> parse_zip(
     const char* root,
     const size_t len);
 
+void inflate(
+    const char* root,
+    uint32_t compressed_size,
+    void* dst,
+    uint32_t uncompressed_size);
+
 namespace {
 
 NB_MODULE(_zip, m) {
@@ -39,6 +45,24 @@ NB_MODULE(_zip, m) {
     nb::gil_scoped_release __g;
     return parse_zip(data, size);
   });
+
+  m.def(
+      "inflate",
+      [](const nb::bytes& bytes,
+         uint64_t offset,
+         uint32_t compressed_size,
+         uint32_t uncompressed_size) {
+        auto* data = bytes.c_str();
+        nb::bytearray ret{};
+        ret.resize(uncompressed_size);
+
+        {
+          nb::gil_scoped_release __g;
+          inflate(
+              data + offset, compressed_size, ret.data(), uncompressed_size);
+        }
+        return ret;
+      });
 }
 
 } // namespace

--- a/tests/spdl_unittest/io/array_test.py
+++ b/tests/spdl_unittest/io/array_test.py
@@ -180,3 +180,65 @@ def test_load_npz():
     np.testing.assert_array_equal(data["uint32_array"], uint32_array)
     np.testing.assert_array_equal(data["int64_array"], int64_array)
     np.testing.assert_array_equal(data["uint64_array"], uint64_array)
+
+
+def _dump_npz_compressed(*arrays, **kwarrays):
+    with io.BytesIO() as buf:
+        np.savez_compressed(buf, *arrays, allow_pickle=False, **kwarrays)
+        buf.seek(0)
+        return buf.read()
+
+
+def test_load_npz_compressed():
+    """Can load files compressed with DEFLATED method"""
+    x = np.arange(10)
+    y = np.sin(x)
+
+    zeros = np.zeros((0, 0))
+    ones = np.ones((3, 4, 5))
+    bool_array = np.array([False, True], dtype=bool)
+    float16_array = _get_test_float_arr(np.float16)
+    float32_array = _get_test_float_arr(np.float32)
+    float64_array = _get_test_float_arr(np.float64)
+    uint8_array = _get_test_int_arr(np.uint8)
+    int16_array = _get_test_int_arr(np.int16)
+    uint16_array = _get_test_int_arr(np.uint16)
+    int32_array = _get_test_int_arr(np.int32)
+    uint32_array = _get_test_int_arr(np.uint32)
+    int64_array = _get_test_int_arr(np.int64)
+    uint64_array = _get_test_int_arr(np.uint64)
+
+    dumped = _dump_npz_compressed(
+        x,
+        y,
+        zeros=zeros,
+        ones=ones,
+        bool_array=bool_array,
+        float16_array=float16_array,
+        float32_array=float32_array,
+        float64_array=float64_array,
+        uint8_array=uint8_array,
+        int16_array=int16_array,
+        uint16_array=uint16_array,
+        int32_array=int32_array,
+        uint32_array=uint32_array,
+        int64_array=int64_array,
+        uint64_array=uint64_array,
+    )
+    data = spdl.io.load_npz(dumped)
+
+    np.testing.assert_array_equal(data["arr_0"], x)
+    np.testing.assert_array_equal(data["arr_1"], y)
+    np.testing.assert_array_equal(data["zeros"], zeros)
+    np.testing.assert_array_equal(data["ones"], ones)
+    np.testing.assert_array_equal(data["bool_array"], bool_array)
+    np.testing.assert_array_equal(data["float16_array"], float16_array)
+    np.testing.assert_array_equal(data["float32_array"], float32_array)
+    np.testing.assert_array_equal(data["float64_array"], float64_array)
+    np.testing.assert_array_equal(data["uint8_array"], uint8_array)
+    np.testing.assert_array_equal(data["int16_array"], int16_array)
+    np.testing.assert_array_equal(data["uint16_array"], uint16_array)
+    np.testing.assert_array_equal(data["int32_array"], int32_array)
+    np.testing.assert_array_equal(data["uint32_array"], uint32_array)
+    np.testing.assert_array_equal(data["int64_array"], int64_array)
+    np.testing.assert_array_equal(data["uint64_array"], uint64_array)


### PR DESCRIPTION
This commit add support for NPZ file created with
DEFLATE compression (i.e. created with `np.savez_compressed`)