### PR TITLE
Tweak the interface of parse_zip

### DIFF
--- a/src/spdl/io/_array.py
+++ b/src/spdl/io/_array.py
@@ -241,4 +241,5 @@ def load_npz(data: bytes) -> NpzFile:
        >>> assert np.array_equal(data["y"], y)
 
     """
-    return NpzFile(data, _libspdl._zip.parse_zip(data))
+    meta = {val[0]: val[1:] for val in _libspdl._zip.parse_zip(data)}
+    return NpzFile(data, meta)

--- a/src/spdl/io/lib/zip/register.cpp
+++ b/src/spdl/io/lib/zip/register.cpp
@@ -7,24 +7,23 @@
  */
 
 #include <nanobind/nanobind.h>
-#include <nanobind/stl/map.h>
 #include <nanobind/stl/string.h>
 #include <nanobind/stl/tuple.h>
+#include <nanobind/stl/vector.h>
 
 namespace nb = nanobind;
 
 namespace spdl::zip {
 
 using ZipMetaData = std::tuple<
+    std::string, // filename
     uint64_t, // offset
     uint64_t, // compressed_size
     uint64_t, // uncompressed_size
     uint16_t // compression_method
     >;
 
-std::map<std::string, ZipMetaData> parse_zip(
-    const char* root,
-    const size_t len);
+std::vector<ZipMetaData> parse_zip(const char* root, const size_t len);
 
 void inflate(
     const char* root,


### PR DESCRIPTION
Keep the ordering of the item in ZIP in C++ implementation just in case.