### PR TITLE
Revise the way periodic task is terminated

### DIFF
--- a/src/spdl/pipeline/_hook.py
+++ b/src/spdl/pipeline/_hook.py
@@ -262,16 +262,25 @@ def _task_hooks(hooks: Sequence[TaskHook]) -> AsyncContextManager[None]:
 
 
 async def _periodic_dispatch(
-    afun: Callable[[], Coroutine[None, None, None]], interval: float
+    afun: Callable[[], Coroutine[None, None, None]],
+    done: asyncio.Event,
+    interval: float,
 ) -> None:
     assert interval > 0, "[InternalError] `interval` must be greater than 0."
-    tasks: set[Task] = set()
-    while True:
-        await asyncio.sleep(interval)
+    pending: set[Task] = set()
+    target = time.monotonic() + interval
+    while not done.is_set():
+        if (dt := target - time.monotonic()) > 0:
+            await asyncio.sleep(dt)
 
-        task = create_task(afun())
-        tasks.add(task)
-        task.add_done_callback(tasks.discard)
+        target = time.monotonic() + interval
+        pending.add(create_task(afun()))
+
+        # Assumption interval >> task duration.
+        _, pending = await asyncio.wait(pending, return_when="FIRST_COMPLETED")
+
+    if pending:
+        await asyncio.wait(pending)
 
 
 @dataclass
@@ -332,8 +341,9 @@ class TaskStatsHook(TaskHook):
         """Track the stage runtime and log the task stats."""
         if self.interval > 0:
             self._lap_t0 = time.monotonic()
+            done = asyncio.Event()
             report = create_task(
-                _periodic_dispatch(self._log_interval_stats, self.interval),
+                _periodic_dispatch(self._log_interval_stats, done, self.interval),
                 name="f{self.name}_periodic_report",
                 log_cancelled=False,
             )
@@ -342,7 +352,8 @@ class TaskStatsHook(TaskHook):
             yield
         finally:
             if self.interval > 0:
-                report.cancel()
+                done.set()
+                await report  # pyre-ignore: [61]
             self._log_stats(
                 TaskPerfStats(
                     num_tasks=self.num_tasks,

--- a/tests/spdl_unittest/dataloader/pipeline_test.py
+++ b/tests/spdl_unittest/dataloader/pipeline_test.py
@@ -726,15 +726,19 @@ def test_periodic_dispatch_smoke_test():
 
     async def afun():
         nonlocal calls
+        print("afun: ", time.time())
         calls.append(time.monotonic())
 
     async def _test():
-        task = asyncio.create_task(_periodic_dispatch(afun, 1))
+        done = asyncio.Event()
+        task = asyncio.create_task(_periodic_dispatch(afun, done, 1))
 
-        await asyncio.sleep(3.2)
+        await asyncio.sleep(3)
 
-        task.cancel()
+        done.set()
+        await task
 
+    print("start: ", time.time())
     asyncio.run(_test())
 
     assert len(calls) == 3


### PR DESCRIPTION
Originally, the periodic report task was simply cancelled.

However, that is not enough. One has to await the task after the cancellation, then handle the outcome.

https://discuss.python.org/t/asyncio-cancel-a-cancellation-utility-as-a-coroutine-this-time-with-feeling/26304

I am not sure if cancel and await is enough as we used `while True` loop in the periodic task.
Also, having a complex error handling logic in the `finally` clause feels not simple enough.

So we change the implementation of _periodic_dispatch, so that the signal is stop is sent via Event.
Also get rid of the fire-and-forget idiom.