### PR TITLE
Shuffle Before Iterating by Default for embed_shuffle

### DIFF
--- a/src/spdl/source/utils.py
+++ b/src/spdl/source/utils.py
@@ -222,7 +222,7 @@ class _ShuffleAndIterate(Iterable[T]):
 
 
 def embed_shuffle(
-    src: IterableWithShuffle[T], /, *, shuffle_last: bool = True, epoch: int = 0
+    src: IterableWithShuffle[T], /, *, shuffle_last: bool = False, epoch: int = 0
 ) -> Iterable[T]:
     """**[Experimental]** Convert :py:class:`~spdl.source.IterableWithShuffle` to
     :py:class:`Iterable` by embedding the :py:meth:`~spdl.source.IterableWithShuffle.shuffle`
@@ -245,19 +245,12 @@ def embed_shuffle(
 
     Args:
         src: The original iterable with ``shuffle`` method.
-        shuffle_last: If ``True`` (default), then ``shuffle`` is called
-            at the end of the iteration. Other wise ``shuffle`` is called
-            before each iteration.
+        shuffle_last: If ``False`` (default), then ``shuffle`` is called
+            before the iteration. Other wise ``shuffle`` is called
+            at the end of iteration.
         epoch: The initial seed value passed to
             :py:meth:`~spdl.source.IterableWithShuffle.shuffle`.
 
-    .. admonition:: Why default to shuffle after iteration?
-       :class: note
-
-       Shuffling at the beginning of an iteration blocks the pipeline
-       entirely.
-       Shuffling after the iteration gives an opportunity to hide the
-       overhead of shuffling behind the pipeline execution.
     """
     return _ShuffleAndIterate(src, epoch=epoch, shuffle_last=shuffle_last)
 

--- a/tests/spdl_unittest/dataloader/iterator_test.py
+++ b/tests/spdl_unittest/dataloader/iterator_test.py
@@ -241,29 +241,30 @@ def test_repeat_source_iterable_with_shuffle():
     gen = iter(repeat_source(src, epoch=2))
 
     with patch.object(src, "shuffle", side_effect=src.shuffle) as mock_method:
-        assert next(gen) == 0
         assert next(gen) == 1
+        mock_method.assert_called_with(seed=0)
         assert next(gen) == 2
+        assert next(gen) == 0
 
-        assert next(gen) == 1
+        assert next(gen) == 2
         mock_method.assert_called_with(seed=1)
-        assert next(gen) == 2
         assert next(gen) == 0
+        assert next(gen) == 1
 
-        assert next(gen) == 2
+        assert next(gen) == 0
         mock_method.assert_called_with(seed=2)
-        assert next(gen) == 0
         assert next(gen) == 1
+        assert next(gen) == 2
 
-        assert next(gen) == 0
+        assert next(gen) == 1
         mock_method.assert_called_with(seed=3)
-        assert next(gen) == 1
-        assert next(gen) == 2
-
-        assert next(gen) == 1
-        mock_method.assert_called_with(seed=4)
         assert next(gen) == 2
         assert next(gen) == 0
+
+        assert next(gen) == 2
+        mock_method.assert_called_with(seed=4)
+        assert next(gen) == 0
+        assert next(gen) == 1
 
 
 def test_repeat_source_iterable():
@@ -726,11 +727,11 @@ def test_shuffle_and_iterate():
 
     ref = list(range(N))
     for i in range(3):
+        random.seed(i)
+        random.shuffle(ref)
+
         hyp = list(src)
         assert hyp == ref
-
-        random.seed(i + 1)
-        random.shuffle(ref)
 
 
 def _fail_initializer():
@@ -801,6 +802,6 @@ def test_move_iterable_to_subprocess_success_iterable_with_shuffle():
         partial(embed_shuffle, SourceIterableWithShuffle(3))
     )
 
-    assert list(iterator) == [0, 1, 2]
     assert list(iterator) == [1, 2, 0]
     assert list(iterator) == [2, 0, 1]
+    assert list(iterator) == [0, 1, 2]

--- a/tests/spdl_unittest/dataloader/pipeline_test.py
+++ b/tests/spdl_unittest/dataloader/pipeline_test.py
@@ -1781,16 +1781,15 @@ def test_run_pipeline_in_subprocess_state():
     builder = PipelineBuilder().add_source(src).add_sink()
     iterable = run_pipeline_in_subprocess(builder, num_threads=1)
 
-    assert list(iterable) == [0, 1, 2, 3, 4]
     assert list(iterable) == [1, 2, 3, 4, 0]
     assert list(iterable) == [2, 3, 4, 0, 1]
+    assert list(iterable) == [3, 4, 0, 1, 2]
 
     # since the src is copied to the subprocess iterating it yields the original state
 
-    assert src.src.seed == 0
-    assert list(src) == [0, 1, 2, 3, 4]
-    assert src.src.seed == 1
     assert list(src) == [1, 2, 3, 4, 0]
-    assert src.src.seed == 2
+    assert src.src.seed == 0
     assert list(src) == [2, 3, 4, 0, 1]
-    assert src.src.seed == 3
+    assert src.src.seed == 1
+    assert list(src) == [3, 4, 0, 1, 2]
+    assert src.src.seed == 2


### PR DESCRIPTION
Summary: Change the default behavior to shuffle before the first iteration, to align with most ML workflows (shuffle then iterate). Otherwise, the data may not be shuffled in the first epoch.

Reviewed By: moto-meta

Differential Revision: D76935971
