### PR TITLE
Adherence to PEP 561 (Fixes a mypy bug)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,9 @@ packages = []
 [tool.setuptools.dynamic]
 version = { file = "VERSION" }
 
+[tool.setuptools.package-data]
+spdl = ["py.typed"]
+
 [tool.uv.sources]
 spdl_core = { workspace = true }
 spdl_io = { workspace = true }


### PR DESCRIPTION
According to [these docs], spdl can be properly type-checked with mypy if it includes a `py.typed` file inside the main package. This PR adds such a file and makes sure it's included in the built wheel by adding it as package-data to the pyproject.toml.

[these docs]: https://mypy.readthedocs.io/en/stable/installed_packages.html#installed-packages