### PR TITLE
Add packaging test

### DIFF
--- a/.github/scripts/check_deps.py
+++ b/.github/scripts/check_deps.py
@@ -1,0 +1,76 @@
+import sys
+import importlib.metadata
+
+
+def check_package_meta():
+    print("Verifying spdl_core package lists no dependency.")
+    if importlib.metadata.requires("spdl_core"):
+        raise ValueError("The spdl_core package must have no dependency.")
+
+    print("Verifying spdl_io package lists only NumPy as dependency")
+    deps = importlib.metadata.requires("spdl_io")
+    if not (len(deps) == 1 and deps[0].startswith("numpy")):
+        raise ValueError("Only NumPy is allowed as spdl_io package dependency.")
+
+
+def _get_imported_3rd_party_modules():
+    ret = set()
+    for name, mod in sys.modules.items():
+        if hasattr(mod, '__path__'):
+            if any('site-packages' in p for p in mod.__path__):
+                ret.add(name)
+    return ret
+
+
+def check_imported_modules():
+    #--------------------------------------------------------------------------
+    # Pre-condition
+    #--------------------------------------------------------------------------
+    print('Checking the target modules are not yet imported.')
+    base_mods  = _get_imported_3rd_party_modules()
+    if violation := base_mods & set(('torch', 'numpy', 'jax', 'spdl')):
+        raise RuntimeError(
+            "The following modules must not be imported before testing: "
+            f"{violation}")
+
+    #--------------------------------------------------------------------------
+    # Import must success without third party packages installed
+    #--------------------------------------------------------------------------
+    print('Testing the spdl_core module import')
+
+    import spdl.pipeline
+
+    mods = _get_imported_3rd_party_modules()
+    assert 'spdl.pipeline' in mods
+    mods = {m for m in mods - base_mods if not m.startswith('spdl')}
+    print(f"Modules imported with spdl.pipeline: {mods}")
+    if violation := mods & set(('torch', 'numpy', 'jax')):
+        raise RuntimeError(
+            "`import spdl.pipeline` must not import third-party libraries. "
+            f"Found: {violation}")
+
+    #--------------------------------------------------------------------------
+    # Import (Same as above but NumPy is allowed
+    #--------------------------------------------------------------------------
+    print('Testing the spdl_io module import')
+
+    import spdl.io
+
+    mods = _get_imported_3rd_party_modules()
+    assert 'spdl.io' in mods
+    mods = {m for m in mods - base_mods if not m.startswith('spdl')}
+    print(f"Modules imported with spdl.io: {mods}")
+    if violation := mods & set(('torch', 'jax')):
+        raise RuntimeError(
+            "`import spdl.io` must not import third-party libraries except NumPy."
+            f"Found: {violation}")
+
+
+def main():
+    check_package_meta()
+    check_imported_modules()
+    print('OK')
+
+
+if __name__ == '__main__':
+    main()

--- a/.github/workflows/_build_linux.yml
+++ b/.github/workflows/_build_linux.yml
@@ -60,7 +60,28 @@ jobs:
           "${python_exe}" -m pip install -r ./packaging/requirements.txt
           "${python_exe}" -m twine check --strict ~/package/*.whl
 
-  test:
+  check-package-dependency:
+    if: "${{ inputs.run-test == 'true' }}"
+    needs: ["build"]
+    runs-on: ${{ inputs.os }}
+    steps:
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '${{ inputs.python-version }}'
+      - uses: actions/download-artifact@v4
+        with:
+          name: "${{ env.ARTIFACT }}"
+          path: ~/package
+      - uses: actions/checkout@v4
+      - name: Dependency Check
+        run: |
+          # Install NumPy (the only dep) of SPDL manually, so that
+          # if a dependency is introduced accidentally, check_deps will catch
+          pip install numpy
+          pip install --no-dependencies $(find "${HOME}/package" -name '*.whl' -depth -maxdepth 1)
+          python .github/scripts/check_deps.py
+
+  unit-test:
     if: "${{ inputs.run-test == 'true' }}"
     needs: ["build"]
     name: "test ffmpeg ${{ matrix.ffmpeg-version }}"
@@ -68,7 +89,7 @@ jobs:
       fail-fast: false
       matrix:
         ffmpeg-version: ["4.4.2", "5.1", "6.1", "7.1"]
-    runs-on:  ${{ inputs.os }}
+    runs-on: ${{ inputs.os }}
     defaults:
       run:
         shell: bash -el {0}

--- a/.github/workflows/_build_linux_cuda.yml
+++ b/.github/workflows/_build_linux_cuda.yml
@@ -90,6 +90,27 @@ jobs:
           "${python_exe}" -m pip install -r ./packaging/requirements.txt
           "${python_exe}" -m twine check --strict ~/package/*.whl
 
+  check-package-dependency:
+    if: ${{ inputs.run-test == 'true' }}
+    needs: ["build"]
+    runs-on: ${{ inputs.machine }}
+    steps:
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '${{ inputs.python-version }}'
+      - uses: actions/download-artifact@v4
+        with:
+          name: "${{ env.ARTIFACT }}"
+          path: ~/package
+      - uses: actions/checkout@v4
+      - name: Dependency Check
+        run: |
+          # Install NumPy (the only dep) of SPDL manually, so that
+          # if a dependency is introduced accidentally, check_deps will catch
+          pip install numpy
+          pip install --no-dependencies $(find "${HOME}/package" -name '*.whl' -depth -maxdepth 1)
+          python .github/scripts/check_deps.py
+
   test-gpu:
     if: ${{ inputs.run-test == 'true' }}
     needs: ["build"]

--- a/.github/workflows/_build_macos.yml
+++ b/.github/workflows/_build_macos.yml
@@ -14,13 +14,16 @@ on:
         required: false
         default: 'false'
         type: string
+      os:
+        default: "macos-latest"
+        type: string
 
 env:
   ARTIFACT: wheel-macos-py${{ inputs.python-version }}${{ inputs.free-threaded }}
         
 jobs:
   build:
-    runs-on:  macos-latest
+    runs-on: "${{ inputs.os }}"
     steps:
       - uses: actions/checkout@v4
         with:
@@ -59,7 +62,7 @@ jobs:
           pip install -r ./packaging/requirements.txt
           twine check --strict ~/package/*.whl
 
-  test:
+  unit-test:
     if: "${{ inputs.run-test == 'true' }}"
     name: "test ffmpeg"
     needs: ["build"]
@@ -67,7 +70,7 @@ jobs:
       fail-fast: false
       matrix:
         ffmpeg-version: ["4.4.2", "5.1", "6.1", "7.1"]
-    runs-on:  macos-latest
+    runs-on:  "${{ inputs.os }}"
     defaults:
       run:
         shell: bash -el {0}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,10 +25,12 @@ repos:
     hooks:
       # Run the linter.
       - id: ruff
+        exclude: .github/scripts
         types_or: [ python, pyi ]
         args: [ "--fix" ]
         # Run the formatter.
       - id: ruff-format
+        exclude: .github/scripts
         types_or: [ python, pyi ]
 
   # This check is set to never fail, but will print all current mypy failures. See:
@@ -37,6 +39,7 @@ repos:
     rev: v1.16.1
     hooks:
       - id: mypy
+        exclude: .github/scripts
         verbose: true
         entry: bash -c
         args:


### PR DESCRIPTION
Add test to ensure that `spdl_core` and `spdl_io` does not accidentally depend on third-party libraries (except NumPy for IO), and they can be installed without other third-party libraries.