### PR TITLE
Support len for SPDL dataloader

### DIFF
--- a/src/spdl/source/utils.py
+++ b/src/spdl/source/utils.py
@@ -13,7 +13,7 @@ import logging
 import random
 import sys
 import time
-from collections.abc import Iterable, Iterator, Sequence
+from collections.abc import Iterable, Iterator, Sequence, Sized
 from typing import TypeVar
 
 from ._type import IterableWithShuffle
@@ -219,6 +219,14 @@ class _ShuffleAndIterate(Iterable[T]):
 
         if self._shuffle_last:
             self._shuffle()
+
+    def __len__(self) -> int:
+        if isinstance(self.src, Sized):
+            return len(self.src)
+        else:
+            raise TypeError(
+                f"Source iterator of type {type(self.src)} does not support length"
+            )
 
 
 def embed_shuffle(


### PR DESCRIPTION
Summary: Dataloader length may be useful, in particular to estimate the number of steps in an epoch. We add support for dataloader length for SPDL HiveDataLoaders that use the SPDL datasource.

Reviewed By: ynonaolga

Differential Revision: D78133462


