### PR TITLE
Add `SizedIterable[WithShuffle]` protocol

### DIFF
--- a/src/spdl/source/__init__.py
+++ b/src/spdl/source/__init__.py
@@ -8,9 +8,13 @@
 
 # pyre-strict
 
-from ._type import IterableWithShuffle
+from ._type import IterableWithShuffle, SizedIterable, SizedIterableWithShuffle
 
-__all__ = ["IterableWithShuffle"]
+__all__ = [
+    "IterableWithShuffle",
+    "SizedIterable",
+    "SizedIterableWithShuffle",
+]
 
 
 def __dir__() -> list[str]:

--- a/src/spdl/source/_type.py
+++ b/src/spdl/source/_type.py
@@ -6,23 +6,47 @@
 
 # pyre-unsafe
 
-__all__ = ["IterableWithShuffle"]
+__all__ = [
+    "IterableWithShuffle",
+    "SizedIterable",
+    "SizedIterableWithShuffle",
+]
 
-from collections.abc import Iterator
+from collections.abc import Iterable, Sized
 from typing import Protocol, runtime_checkable, TypeVar
 
 T = TypeVar("T")
 
 
 @runtime_checkable
-class IterableWithShuffle(Protocol[T]):
+class IterableWithShuffle(Iterable[T], Protocol):
     """IterableWithShuffle()
+
     A protocol that is often used to represent data source."""
 
     def shuffle(self, seed: int) -> None:
         """Apply in-place shuffling"""
         ...
 
-    def __iter__(self) -> Iterator[T]:
-        """Iterate over the source and yields the source data."""
+
+@runtime_checkable
+class SizedIterable(Sized, Iterable[T], Protocol):
+    """SizedIterable()
+    A protocol that is often used to represent data source."""
+
+    pass
+
+
+@runtime_checkable
+class SizedIterableWithShuffle(SizedIterable[T], Protocol):
+    """SizedIterableWithShuffle()
+    A protocol that is often used to represent data source."""
+
+    def shuffle(self, seed: int) -> None:
+        """Apply in-place shuffling.
+
+        .. note::
+
+           The result of shuffle may not be observable until the iteration starts.
+        """
         ...

--- a/src/spdl/source/utils.py
+++ b/src/spdl/source/utils.py
@@ -14,9 +14,9 @@ import random
 import sys
 import time
 from collections.abc import Iterable, Iterator, Sequence, Sized
-from typing import TypeVar
+from typing import overload, TypeVar
 
-from ._type import IterableWithShuffle
+from ._type import IterableWithShuffle, SizedIterable, SizedIterableWithShuffle
 
 T = TypeVar("T")
 K = TypeVar("K")
@@ -198,7 +198,11 @@ class MergeIterator(Iterable[T]):
 
 class _ShuffleAndIterate(Iterable[T]):
     def __init__(
-        self, src: IterableWithShuffle[T], *, epoch: int, shuffle_last: bool
+        self,
+        src: IterableWithShuffle[T] | SizedIterableWithShuffle[T],
+        *,
+        epoch: int,
+        shuffle_last: bool,
     ) -> None:
         self.src = src
         self._epoch = epoch
@@ -229,9 +233,25 @@ class _ShuffleAndIterate(Iterable[T]):
             )
 
 
+@overload
+def embed_shuffle(
+    src: SizedIterableWithShuffle[T], /, *, shuffle_last: bool = False, epoch: int = 0
+) -> SizedIterable[T]: ...
+
+
+@overload
 def embed_shuffle(
     src: IterableWithShuffle[T], /, *, shuffle_last: bool = False, epoch: int = 0
-) -> Iterable[T]:
+) -> Iterable[T]: ...
+
+
+def embed_shuffle(
+    src: IterableWithShuffle[T] | SizedIterableWithShuffle[T],
+    /,
+    *,
+    shuffle_last: bool = False,
+    epoch: int = 0,
+) -> Iterable[T] | SizedIterable[T]:
     """**[Experimental]** Convert :py:class:`~spdl.source.IterableWithShuffle` to
     :py:class:`Iterable` by embedding the :py:meth:`~spdl.source.IterableWithShuffle.shuffle`
     call into :py:meth:`~Iterable.__iter__`.


### PR DESCRIPTION
This commit adds the `SizedIterable[WithShuffle]` protocol, which is an extension of `Iterable[WithShuffle]`.

The rational is as follow

1. Users expect that the length of the dataset (i.e. the length of the source) is known thus retrievable.
2. In distributed training, knowing the size of dataset is required so that all ranks iterate the same number of items.