### PR TITLE
Add `transfer_tensor` function

### DIFF
--- a/docs/source/getting_started/parallelism.rst
+++ b/docs/source/getting_started/parallelism.rst
@@ -100,6 +100,11 @@ instance, or put it in a
 The following example shows how to initialize and store a CUDA stream
 in a thread-local storage.
 
+.. admonition::
+   :class: note
+
+   The following code is now available as :py:func:`spdl.io.transfer_tensor`.
+
 .. code-block:: python
 
    import threading

--- a/src/spdl/io/__init__.py
+++ b/src/spdl/io/__init__.py
@@ -100,6 +100,7 @@ from ._preprocessing import (
     get_filter_desc,
     get_video_filter_desc,
 )
+from ._transfer import transfer_tensor
 
 __all__ = [
     # HIGH LEVEL API
@@ -157,6 +158,7 @@ __all__ = [
     # DATA TRANSFER
     "transfer_buffer",
     "transfer_buffer_cpu",
+    "transfer_tensor",
     # COLORSPACE CONVERSION
     "nv12_to_rgb",
     "nv12_to_bgr",

--- a/src/spdl/io/_transfer.py
+++ b/src/spdl/io/_transfer.py
@@ -1,0 +1,151 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+__all__ = [
+    "transfer_tensor",
+]
+
+import logging
+import os
+import threading
+from collections import defaultdict
+from collections.abc import Callable, Mapping
+from dataclasses import fields, is_dataclass
+from types import ModuleType
+from typing import TYPE_CHECKING, TypeVar
+
+from ._internal import import_utils
+
+if TYPE_CHECKING:
+    import torch
+    from torch import device as TDevice
+else:
+    torch: ModuleType = import_utils.lazy_import("torch")
+    TDevice = object
+
+_LG: logging.Logger = logging.getLogger(__name__)
+
+
+T = TypeVar("T")
+S = TypeVar("S")
+
+# pyre-strict
+
+
+def _recursive_apply(fn: Callable[[T], T], obj: T) -> T:
+    """Recursively apply the given function to the given (container) object.
+
+    Args:
+        fn: The function to apply.
+        obj: The object to which the function is applied.
+
+    Returns:
+        The result of applying the function.
+    """
+    Class = type(obj)
+    match obj:
+        case list():
+            return Class(_recursive_apply(fn, v) for v in obj)
+        case tuple():
+            if hasattr(obj, "_asdict") and hasattr(obj, "_fields"):  # namedtuple
+                return Class(**_recursive_apply(fn, obj._asdict()))
+            return Class(_recursive_apply(fn, v) for v in obj)
+        case defaultdict():
+            return Class(
+                obj.default_factory,
+                {k: _recursive_apply(fn, v) for k, v in obj.items()},
+            )
+        case Mapping():
+            return Class({k: _recursive_apply(fn, v) for k, v in obj.items()})
+        case obj if is_dataclass(obj) and not isinstance(obj, type):
+            new_obj = Class(
+                **{
+                    field.name: _recursive_apply(fn, getattr(obj, field.name))
+                    for field in fields(obj)
+                    if field.init
+                }
+            )
+            for field in fields(obj):
+                if not field.init:
+                    val = _recursive_apply(fn, getattr(obj, field.name))
+                    setattr(new_obj, field.name, val)
+            return new_obj
+
+        case _:
+            return fn(obj)  # pyre-ignore: [6]
+
+
+def _transfer(obj: T, device: TDevice) -> T:
+    if isinstance(obj, torch.Tensor):
+        obj = obj.pin_memory().to(device, non_blocking=True)
+    return obj
+
+
+class _DataTransfer:
+    def __init__(self, device: TDevice) -> None:
+        self._device = device
+        self._stream = torch.cuda.Stream(device)
+
+    def _transfer(self, obj: T) -> T:
+        return _transfer(obj, self._device)
+
+    def __call__(self, batch: T) -> T:
+        with torch.cuda.stream(self._stream):
+            batch = _recursive_apply(self._transfer, batch)
+        self._stream.synchronize()
+        return batch
+
+
+_THREAD_LOCAL = threading.local()
+
+
+def _get_trancfer_func() -> _DataTransfer:
+    if not hasattr(_THREAD_LOCAL, "transfer"):
+        local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+        if local_rank >= torch.cuda.device_count():
+            raise RuntimeError(
+                "The local rank is larger than the number of available GPUs."
+            )
+        device = torch.device(f"cuda:{local_rank}")
+        _LG.info("Creating transfer stream on %s", device)
+        _THREAD_LOCAL.transfer = _DataTransfer(device)  # pyre-ignore: [16]
+    return _THREAD_LOCAL.transfer
+
+
+def transfer_tensor(batch: T, /) -> T:
+    """Transfers PyTorch CPU Tensors to CUDA in a background.
+
+    This function wraps calls to :py:meth:`torch.Tensor.pin_memory` and
+    :py:meth:`torch.Tensor.to`, and execute them in a dedicated CUDA stream,
+    so that when called in a background thread, data transfer is carried out
+    in a way it overlaps with the GPU computation happening in the foreground
+    thread (such as training and inference).
+
+    Concretely, it performs the following operations.
+
+    1. If a dedicated CUDA stream local to the calling thread is not found
+       in a thread-local storage, creates and stashes one.
+       (The target device is deetrmined by ``"LOCAL_RANK"`` environment
+       variable.)
+    2. Activates the CUDA stream.
+    3. Traverses the given object recursively, and transfer tensors to GPU.
+       Data are first copied to page-locked memory by calling ``pin_memory``
+       method, then the data is transferred to the GPU in asynchronous manner.
+       (i.e. ``.to(non_blocking=True)``)
+    4. Synchronizes the stream, to ensure that all the data transfers are
+       completed.
+
+    Args:
+        batch: A :py:class:`Torch.Tensor` or a composition of tensors
+            with container types such as ``list``, ``tuple``, ``dict``
+            and ``dataclass``.
+
+    Returns:
+        An object of the same type as the input, but the PyTorch
+        tensors are transferred to CUDA device.
+    """
+    transfer = _get_trancfer_func()
+    return transfer(batch)

--- a/tests/spdl_unittest/cuda/transfer_test.py
+++ b/tests/spdl_unittest/cuda/transfer_test.py
@@ -1,0 +1,20 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import torch
+from spdl.io import transfer_tensor
+
+# pyre-unsafe
+
+
+def test_gpu_transfer():
+    ref = torch.randint(256, (16, 3, 4608, 5328), dtype=torch.uint8)
+    print(ref)
+
+    cuda = transfer_tensor(ref)
+    print(cuda)
+    assert cuda.device.type == "cuda"
+    assert torch.equal(cuda, ref.cuda())

--- a/tests/spdl_unittest/io/transfer_test.py
+++ b/tests/spdl_unittest/io/transfer_test.py
@@ -1,0 +1,137 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-unsafe
+
+from collections import defaultdict
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass, field
+from unittest.mock import MagicMock, patch
+
+import spdl.io._transfer
+import torch
+from spdl.io import transfer_tensor
+from spdl.io._transfer import _recursive_apply
+
+
+def fn(x: int) -> int:
+    return 2 * x
+
+
+@dataclass
+class _Item:
+    x: int
+    y: int
+    z: int = field(default=1, init=False)
+
+
+def test_recursive_apply_basic():
+    obj = (1, 2, 3)
+    assert _recursive_apply(fn, obj) == (2, 4, 6)
+
+    obj = [4, 5, 6]
+    assert _recursive_apply(fn, obj) == [8, 10, 12]
+
+    obj = {"a": 7, "b": 8}
+    assert _recursive_apply(fn, obj) == {"a": 14, "b": 16}
+
+    obj = defaultdict(list)
+    obj["a"].append(9)
+    obj["b"].append(10)
+
+    ref = defaultdict(list)
+    ref["a"].append(18)
+    ref["b"].append(20)
+
+    assert _recursive_apply(fn, obj) == ref
+
+    obj = _Item(11, 12)
+    ref = _Item(22, 24)
+    ref.z = fn(ref.z)
+    assert _recursive_apply(fn, obj) == ref
+
+
+def test_recursive_apply_nested():
+    obj = (1, 2, (3, 4, 5), 6)
+    assert _recursive_apply(fn, obj) == (2, 4, (6, 8, 10), 12)
+
+    obj = [1, 2, [3, 4, 5], 6]
+    assert _recursive_apply(fn, obj) == [2, 4, [6, 8, 10], 12]
+
+    obj = {"a": 1, "b": 2, "c": [3, 4, 5], "d": 6}
+    assert _recursive_apply(fn, obj) == {"a": 2, "b": 4, "c": [6, 8, 10], "d": 12}
+
+    obj = (1, 2, (3, 4, (5, 6, 7), 8), 9)
+    assert _recursive_apply(fn, obj) == (2, 4, (6, 8, (10, 12, 14), 16), 18)
+
+    obj = [1, 2, [3, 4, [5, 6, [7, 8, 9]]], 10]
+    assert _recursive_apply(fn, obj) == [2, 4, [6, 8, [10, 12, [14, 16, 18]]], 20]
+
+    obj = {"a": 1, "b": 2, "c": {"d": 3, "e": 4, "f": {"g": 5, "h": 6, "i": 7}}, "j": 8}
+    assert _recursive_apply(fn, obj) == {
+        "a": 2,
+        "b": 4,
+        "c": {"d": 6, "e": 8, "f": {"g": 10, "h": 12, "i": 14}},
+        "j": 16,
+    }
+
+    obj = _Item(1, 2)
+    obj.z = _Item(5, 6)
+    ref = _Item(2, 4)
+    ref.z = _Item(10, 12)
+    ref.z.z = 2
+    assert _recursive_apply(fn, obj) == ref
+
+
+@patch("torch.cuda.stream")
+@patch("torch.cuda.Stream")
+@patch("torch.cuda.device_count")
+def test_gpu_transfer(
+    mock_device_count,
+    mock_Stream,
+    mock_stream_func,
+):
+    """The data is transferred to CUDA asynchronously.
+
+    transfer_tensor() does the following 5 things.
+
+    1. Create CUDA stream. (call torch.cuda.Stream with cuda device)
+    2. Activate the stream. (call torch.cuda.stream with 1)
+    3. `pin_memory` is called.
+    4. `to` is called with CUDA device and non_blocking=True
+    5. The stream is synchronized.
+    """
+
+    def _test():
+        assert not hasattr(spdl.io._transfer._THREAD_LOCAL, "transfer")
+
+        mock_stream_obj = MagicMock()
+        device = torch.device("cuda:0")
+        data = torch.zeros((3, 4, 5))
+
+        mock_device_count.return_value = 1
+        mock_Stream.return_value = mock_stream_obj
+        with (
+            patch.object(data, "pin_memory", return_value=data) as mock_pin_memory,
+            patch.object(data, "to", return_value=data) as mock_to,
+        ):
+            _ = transfer_tensor({"foo": data})
+            # Check 3
+            mock_pin_memory.assert_called_once()
+            # Check 4
+            mock_to.assert_called_once_with(device, non_blocking=True)
+
+        # check 1
+        mock_Stream.assert_called_once_with(device)
+        # check 2
+        mock_stream_func.called_once_with(mock_stream_obj)
+        # Check 5
+        mock_stream_obj.synchronize.assert_called_once()
+
+        assert hasattr(spdl.io._transfer._THREAD_LOCAL, "transfer")
+
+    with ThreadPoolExecutor(max_workers=1) as exec:
+        exec.submit(_test).result()


### PR DESCRIPTION
PyTorch's interface for transfering data to GPU is simple on the surface, but it is more complicated when attempting to use it in performant manner.

The `transfer_tensor` function combines related APIs together and execute the data transfer in a way more suited for multi-threading.