### PR TITLE
Fix the handling of StopAsyncIterator for FailCounter

### DIFF
--- a/src/spdl/pipeline/_components/_pipe.py
+++ b/src/spdl/pipeline/_components/_pipe.py
@@ -69,6 +69,8 @@ class _FailCounter(TaskHook):
     async def task_hook(self) -> AsyncIterator[None]:
         try:
             yield
+        except StopAsyncIteration:
+            raise
         except Exception:
             self._increment()
             raise
@@ -96,7 +98,7 @@ async def _wrap_agen(
         # The following explains why.
         #
         # We want to give hooks opportunity to react to StopAsyncIteration,
-        # for example, so that StatsHook will note record the task stats
+        # for example, so that StatsHook will not record the task stats
         # for StopAsyncIteration case.
         #
         # When users implement hook, they might mistakenly absorb the

--- a/src/spdl/pipeline/_convert.py
+++ b/src/spdl/pipeline/_convert.py
@@ -110,9 +110,11 @@ def _to_async_gen(
             """Wrapper around generator.
             This is necessary as we cannot raise StopIteration in async func."""
             try:
-                return next(gen)
+                item = next(gen)
             except StopIteration:
                 return sentinel  # type: ignore[return-value]
+            else:
+                return item
 
         while (val := await loop.run_in_executor(executor, _next)) is not sentinel:
             yield val

--- a/tests/spdl_unittest/dataloader/pipeline_test.py
+++ b/tests/spdl_unittest/dataloader/pipeline_test.py
@@ -1366,6 +1366,27 @@ def test_pipeline_pipe_agen():
     assert expected == output
 
 
+def test_pipeline_pipe_agen_max_failures():
+    """pipe works with async generator function and max_failure"""
+
+    async def dup_increment(v):
+        for i in range(3):
+            yield v + i
+
+    apl = (
+        PipelineBuilder()
+        .add_source(range(3))
+        .pipe(dup_increment)
+        .add_sink(1)
+        .build(num_threads=1, max_failures=1)
+    )
+
+    expected = [0, 1, 2, 1, 2, 3, 2, 3, 4]
+    with apl.auto_stop():
+        output = list(apl.get_iterator(timeout=3))
+    assert expected == output
+
+
 def test_pipeline_pipe_gen():
     """pipe works with sync generator function"""
 
@@ -1379,6 +1400,27 @@ def test_pipeline_pipe_gen():
         .pipe(dup_increment)
         .add_sink(1)
         .build(num_threads=1)
+    )
+
+    expected = [0, 1, 2, 1, 2, 3, 2, 3, 4]
+    with apl.auto_stop():
+        output = list(apl.get_iterator(timeout=3))
+    assert expected == output
+
+
+def test_pipeline_pipe_gen_max_failures():
+    """pipe works with sync generator function and max_failure"""
+
+    def dup_increment(v):
+        for i in range(3):
+            yield v + i
+
+    apl = (
+        PipelineBuilder()
+        .add_source(range(3))
+        .pipe(dup_increment)
+        .add_sink(1)
+        .build(num_threads=1, max_failures=1)
     )
 
     expected = [0, 1, 2, 1, 2, 3, 2, 3, 4]


### PR DESCRIPTION
Summary:
When `max_failure` is enabled, a hook which counts the number of exception raised is installed.

This hook should not count `StopAsyncIterator`, because `StopAsyncIterator` exception is used in Python language itself to notify the termination of an iteration.

This commit fixes it by making the hook ignores `StopAsyncIterator` when `max_failure` is enabled.


The following code now works.

```
from spdl.pipeline import PipelineBuilder


def generator_fn(arg):
    for i in range(arg):
        yield i


def main():
    src = list(range(100))
    pipeline = (
        PipelineBuilder()
        .add_source(src)
        .pipe(generator_fn)
        .add_sink()
        .build(num_threads=1, max_failures=1)
    )
    with pipeline.auto_stop():
        for i in pipeline:
            print(i, flush=True)


if __name__ == "__main__":
    main()
```

Differential Revision: D80941146


