### PR TITLE
Correctly detect that callable is a generator when it is a class's __call__ method

### DIFF
--- a/src/spdl/pipeline/_convert.py
+++ b/src/spdl/pipeline/_convert.py
@@ -126,6 +126,9 @@ def convert_to_async(
     op: Callables[T, U],
     executor: Executor | None,
 ) -> AsyncCallables[T, U]:
+    if inspect.ismethod(op.__call__):
+        op = op.__call__
+
     if inspect.iscoroutinefunction(op) or inspect.isasyncgenfunction(op):
         # op is async function. No need to convert.
         assert executor is None  # This has been checked in `PipelineBuilder.pipe()`


### PR DESCRIPTION
Summary:
Apply this fix:

https://github.com/fastapi/fastapi/issues/1204#issuecomment-607439942

Differential Revision: D81042203


