### PR TITLE
Remove private _get_pts method from VideoFrames

### DIFF
--- a/src/spdl/io/lib/core/frames.cpp
+++ b/src/spdl/io/lib/core/frames.cpp
@@ -154,7 +154,6 @@ void register_frames(nb::module_& m) {
           [](const VideoFrames& self, const std::vector<int64_t>& idx) {
             return self.slice(idx);
           })
-      .def("_get_pts", get_timestamps, nb::call_guard<nb::gil_scoped_release>())
       .def(
           "get_timestamps",
           get_timestamps,


### PR DESCRIPTION
This method is equivalent to the public `get_timestamp` method.