### PR TITLE
Update code and tests to accommodate FFmpeg8 API changes

### DIFF
--- a/tests/spdl_unittest/io/image_decoding_test.py
+++ b/tests/spdl_unittest/io/image_decoding_test.py
@@ -40,8 +40,10 @@ def test_decode_image_gray16_native():
     ref = load_ref_image(sample.path, shape, dtype=np.uint16, filter_desc=None)
     np.testing.assert_array_equal(hyp, ref, strict=True)
 
-    assert np.all(hyp[..., :32] == 65022)
-    assert np.all(hyp[..., 32:] == 256)
+    ffmpeg8 = get_ffmpeg_versions()["libavutil"][0] >= 60
+
+    assert np.all(hyp[..., :32] == 65535 if ffmpeg8 else 65022)
+    assert np.all(hyp[..., 32:] == 0 if ffmpeg8 else 256)
 
 
 def test_decode_image_16be_rgb24():


### PR DESCRIPTION
https://github.com/FFmpeg/FFmpeg/blob/2296a9c1bc0636c9ccf5217a49d87d29638ea65a/doc/APIchanges#L260-L263

The following attributes are deprecated.

- `AVCodec.pix_fmts`
- `AVCodec.sample_fmts`
- `AVCodec.supported_framerates`
- `AVCodec.supported_samplerates`
- `AVCodec.ch_layouts`

Replace it with `avcodec_get_supported_config()`

Ref: https://cgit.freedesktop.org/gstreamer/gstreamer/commit/?id=78b5b798d06f070c6b8007d931f7345682ba03ac