### PR TITLE
Fix test

### DIFF
--- a/tests/spdl_unittest/io/transfer_test.py
+++ b/tests/spdl_unittest/io/transfer_test.py
@@ -127,7 +127,7 @@ def test_gpu_transfer(
         # check 1
         mock_Stream.assert_called_once_with(device)
         # check 2
-        mock_stream_func.called_once_with(mock_stream_obj)
+        mock_stream_func.assert_called_once_with(mock_stream_obj)
         # Check 5
         mock_stream_obj.synchronize.assert_called_once()
 


### PR DESCRIPTION
> AttributeError: 'called_once_with' is not a valid assertion.
> Use a spec for the mock if 'called_once_with' is meant to be an attribute..
> Did you mean: 'assert_called_once_with'?

Ref https://github.com/python/cpython/issues/100690