### PR TITLE
Build zlib in Windows

### DIFF
--- a/src/third_party/CMakeLists.txt
+++ b/src/third_party/CMakeLists.txt
@@ -22,4 +22,7 @@ set(CMAKE_EXPORT_NO_PACKAGE_REGISTRY true)
 
 add_subdirectory(fmt)
 add_subdirectory(glog)
+if (MSVC)
+add_subdirectory(zlib)
+endif (MSVC)
 add_subdirectory(libdeflate)

--- a/src/third_party/zlib/CMakeLists.txt
+++ b/src/third_party/zlib/CMakeLists.txt
@@ -1,0 +1,12 @@
+message(STATUS "########################################")
+message(STATUS "# Configuring zlib")
+message(STATUS "########################################")
+
+set(BUILD_SHARED_LIBS OFF)
+FetchContent_Declare(
+  zlib
+  URL https://github.com/madler/zlib/releases/download/v1.3.1/zlib-1.3.1.tar.gz
+  URL_HASH SHA256=9a93b2b7dfdac77ceba5a558a580e74667dd6fede4585b91eefb60f03b72df23
+  DOWNLOAD_DIR "${CMAKE_CURRENT_SOURCE_DIR}"
+  )
+FetchContent_MakeAvailable(zlib)


### PR DESCRIPTION
There is no easy-to-install zlib binary distribution in Windows.

Turned out building zlib from CMake simply works in Windows. Interestingly, the build fails in macOS / Linux, so it's limited to Windows for now.

Towards: https://github.com/facebookresearch/spdl/issues/829