### PR TITLE
Remove stub generation

### DIFF
--- a/src/spdl/io/lib/core/CMakeLists.txt
+++ b/src/spdl/io/lib/core/CMakeLists.txt
@@ -62,23 +62,6 @@ function(add_spdl_extension ffmpeg_version)
     RUNTIME DESTINATION "${SPDL_PYTHON_BINDING_INSTALL_PREFIX}/lib"
   )
 
-  if (SPDL_BUILD_STUB)
-    if (NOT TARGET "_libspdl_stub")
-      nanobind_add_stub(
-        _libspdl_stub
-        MODULE ${name}
-        OUTPUT _libspdl.pyi
-        PYTHON_PATH $<TARGET_FILE_DIR:${name}>
-        DEPENDS ${name}
-        )
-
-      install(
-        FILES "${CMAKE_CURRENT_BINARY_DIR}/_libspdl.pyi"
-        DESTINATION "${SPDL_PYTHON_BINDING_INSTALL_PREFIX}/lib"
-        )
-    endif()
-  endif()
-
 endfunction()
 
 set(ffmpeg_versions 8 7 6 5 4)

--- a/src/spdl/io/lib/cuda/CMakeLists.txt
+++ b/src/spdl/io/lib/cuda/CMakeLists.txt
@@ -52,23 +52,6 @@ function(add_spdl_cuda_extension ffmpeg_version)
     LIBRARY DESTINATION "${SPDL_PYTHON_BINDING_INSTALL_PREFIX}/lib"
     RUNTIME DESTINATION "${SPDL_PYTHON_BINDING_INSTALL_PREFIX}/lib"
   )
-
-  if (SPDL_BUILD_STUB)
-    if (NOT TARGET "_libspdl_cuda_stub")
-      nanobind_add_stub(
-        _libspdl_cuda_stub
-        MODULE ${name}
-        OUTPUT _libspdl_cuda.pyi
-        PYTHON_PATH $<TARGET_FILE_DIR:${name}>
-        DEPENDS ${name}
-        )
-
-      install(
-        FILES "${CMAKE_CURRENT_BINARY_DIR}/_libspdl_cuda.pyi"
-        DESTINATION "${SPDL_PYTHON_BINDING_INSTALL_PREFIX}/lib"
-        )
-    endif()
-  endif()
 endfunction()
 
 set(ffmpeg_versions 8 7 6 5 4)


### PR DESCRIPTION
Due to the fact that we use `_libspdl` surrogate module, which abstract away the underlying FFmpeg version, the out-of-box stub generation does not work.

So we remove it.