### PR TITLE
Remove the option for generating stub

### DIFF
--- a/.github/workflows/_build_linux.yml
+++ b/.github/workflows/_build_linux.yml
@@ -32,7 +32,6 @@ jobs:
       - name: Build
         env:
           SPDL_USE_TRACING: 1
-          SPDL_BUILD_STUB: 1
         run: |
           set -ex
           uv python list --only-installed

--- a/.github/workflows/_build_linux_cuda.yml
+++ b/.github/workflows/_build_linux_cuda.yml
@@ -33,7 +33,6 @@ on:
 env:
   ARTIFACT: wheel-linux-py${{ inputs.python-version }}-cuda${{ inputs.cuda-version }}${{ inputs.use-nvdec }}
   SPDL_USE_TRACING: 1
-  SPDL_BUILD_STUB: 0
   SPDL_USE_CUDA: 1
   SPDL_USE_NVCODEC: "${{ inputs.use-nvdec == 'nvdec' }}"
 

--- a/.github/workflows/_build_macos.yml
+++ b/.github/workflows/_build_macos.yml
@@ -32,7 +32,6 @@ jobs:
       - name: Build
         env:
           SPDL_USE_TRACING: 1
-          SPDL_BUILD_STUB: 1
         run: |
           curl -LsSf https://astral.sh/uv/install.sh | sh
           set -ex

--- a/packaging/spdl_io/setup.py
+++ b/packaging/spdl_io/setup.py
@@ -39,7 +39,6 @@ _SPDL_USE_FFMPEG_VERSION = os.environ.get("SPDL_USE_FFMPEG_VERSION", "all")
 _SPDL_USE_NVCODEC = _env("SPDL_USE_NVCODEC")
 _SPDL_USE_NVJPEG = _env("SPDL_USE_NVJPEG")
 _SPDL_USE_CUDA = _env("SPDL_USE_CUDA", _SPDL_USE_NVCODEC or _SPDL_USE_NVJPEG)
-_SPDL_BUILD_STUB = _env("SPDL_BUILD_STUB", _SPDL_USE_CUDA)
 
 
 def _is_gil_enabled():
@@ -59,11 +58,6 @@ def _get_ext_modules():
                     Extension(f"spdl.io.lib._spdl_ffmpeg{v}", sources=[]),
                 ]
             )
-    if ext_modules and _SPDL_BUILD_STUB:
-        ext_modules.append(
-            Extension("spdl.io.lib.__STUB__", sources=[]),
-        )
-
     return ext_modules
 
 
@@ -124,7 +118,6 @@ def _get_cmake_commands(build_dir, install_dir, debug):
             f"-DSPDL_LINK_STATIC_NVJPEG={_b(_env('SPDL_LINK_STATIC_NVJPEG'))}",
             f"-DSPDL_USE_FFMPEG_VERSION={_SPDL_USE_FFMPEG_VERSION}",
             f"-DSPDL_DEBUG_REFCOUNT={_b(_env('SPDL_DEBUG_REFCOUNT'))}",
-            f"-DSPDL_BUILD_STUB={_b(_SPDL_BUILD_STUB)}",
             ###################################################################
             f"-DPython_INCLUDE_DIR={sysconfig.get_paths()['include']}",
             "-GNinja",
@@ -193,11 +186,6 @@ class CMakeBuild(build_ext):
             if sys.platform == "darwin":
                 parts[-1] = "dylib"
             ext_filename = ".".join(parts)
-        elif "__STUB__" in ext_filename:
-            parts = ext_filename.split(".")
-            parts = [parts[0].replace("__STUB__", "_libspdl.pyi")]
-            ext_filename = ".".join(parts)
-            print(ext_filename)
         return ext_filename
 
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -10,7 +10,6 @@ option(SPDL_LINK_STATIC_NVJPEG "Link nvJPEG and NPPI statically." OFF)
 
 option(SPDL_DEBUG_REFCOUNT "Enable debug print for reference counting of AVFrame objects." OFF)
 option(SPDL_IS_GIL_ENABLED "Whether the target Python has the GIL enabled" ON)
-option(SPDL_BUILD_STUB "Build Python binding stub file" OFF)
 option(SPDL_BUILD_PYTHON_BINDING "Build Python binding" ON)
 
 if (SPDL_USE_NVCODEC OR SPDL_USE_NVJPEG)


### PR DESCRIPTION
Due to the fact that we use `_libspdl` surrogate module, which abstract away the underlying FFmpeg version, the out-of-box stub generation does not work.

So we remove it.

ref https://github.com/facebookresearch/spdl/pull/927