### PR TITLE
Fix tests for Windows

### DIFF
--- a/tests/spdl_unittest/cuda/buffer_transfer_test.py
+++ b/tests/spdl_unittest/cuda/buffer_transfer_test.py
@@ -23,7 +23,7 @@ if not spdl.io.utils.built_with_cuda():
 DEFAULT_CUDA = 0
 
 CMDS = {
-    "audio": f"{FFMPEG_CLI} -hide_banner -y -f lavfi -i 'sine=frequency=1000:sample_rate=48000:duration=3' -c:a pcm_s16le sample.wav",
+    "audio": f'{FFMPEG_CLI} -hide_banner -y -f lavfi -i "sine=frequency=1000:sample_rate=48000:duration=3" -c:a pcm_s16le sample.wav',
     "video": f"{FFMPEG_CLI} -hide_banner -y -f lavfi -i testsrc -frames:v 1000 sample.mp4",
     "image": f"{FFMPEG_CLI} -hide_banner -y -f lavfi -i color=0x000000,format=gray -frames:v 1 sample.png",
 }

--- a/tests/spdl_unittest/fixture.py
+++ b/tests/spdl_unittest/fixture.py
@@ -50,7 +50,7 @@ class SrcInfo:
 
 def get_sample(cmd: str) -> SrcInfo:
     samples = get_samples(cmd)
-    assert len(samples) == 1
+    assert len(samples) == 1, f"There must be one sample. Found: {len(samples)}"
     return samples[0]
 
 
@@ -58,7 +58,7 @@ def get_samples(cmd: str) -> list[SrcInfo]:
     tmp_dir = TemporaryDirectory()
     tmp_path = Path(tmp_dir.name)
 
-    _run_in_tmpdir(cmd, tmp_path)
+    _run_in_tmpdir(cmd.strip(), tmp_path)
     return [SrcInfo(str(f), tmp_dir) for f in tmp_path.glob("**/*") if f.is_file()]
 
 

--- a/tests/spdl_unittest/io/async_test.py
+++ b/tests/spdl_unittest/io/async_test.py
@@ -52,7 +52,7 @@ def _test_decode(demux_fn, timestamps):
 
 def test_decode_audio_clips():
     """Can decode audio clips."""
-    cmd = f"{FFMPEG_CLI} -hide_banner -y -f lavfi -i 'sine=frequency=1000:sample_rate=48000:duration=3' -c:a pcm_s16le sample.wav"
+    cmd = f"{FFMPEG_CLI} -hide_banner -y -f lavfi -i sine=frequency=1000:sample_rate=48000:duration=3 -c:a pcm_s16le sample.wav"
     sample = get_sample(cmd)
 
     def _test():
@@ -71,7 +71,7 @@ def test_decode_audio_clips():
 
 def test_decode_audio_clips_num_frames():
     """Can decode audio clips with padding/dropping."""
-    cmd = f"{FFMPEG_CLI} -hide_banner -y -f lavfi -i 'sine=frequency=1000:sample_rate=16000:duration=1' -c:a pcm_s16le sample.wav"
+    cmd = f"{FFMPEG_CLI} -hide_banner -y -f lavfi -i sine=frequency=1000:sample_rate=16000:duration=1 -c:a pcm_s16le sample.wav"
     sample = get_sample(cmd)
 
     def _decode(src, num_frames=None):
@@ -284,7 +284,7 @@ def test_decode_video_frame_rate_pts():
 
 def test_convert_audio():
     """convert_frames can convert AudioFrames to Buffer"""
-    cmd = f"{FFMPEG_CLI} -hide_banner -y -f lavfi -i 'sine=frequency=1000:sample_rate=48000:duration=3' -c:a pcm_s16le sample.wav"
+    cmd = f"{FFMPEG_CLI} -hide_banner -y -f lavfi -i sine=frequency=1000:sample_rate=48000:duration=3 -c:a pcm_s16le sample.wav"
     sample = get_sample(cmd)
 
     def _test(src):

--- a/tests/spdl_unittest/io/audio_decoding_test.py
+++ b/tests/spdl_unittest/io/audio_decoding_test.py
@@ -32,8 +32,8 @@ def test_load_audio(sample_fmt):
     # fmt: off
     cmd = f"""
     {FFMPEG_CLI} -hide_banner -y \
-    -f lavfi -i 'sine=sample_rate=8000:frequency=305:duration=5' \
-    -f lavfi -i 'sine=sample_rate=8000:frequency=300:duration=5' \
+    -f lavfi -i sine=sample_rate=8000:frequency=305:duration=5 \
+    -f lavfi -i sine=sample_rate=8000:frequency=300:duration=5 \
     -filter_complex amerge  -c:a pcm_s16le sample.wav
     """
     # fmt: on
@@ -58,8 +58,8 @@ def test_batch_audio_conversion():
     # fmt: off
     cmd = f"""
     {FFMPEG_CLI} -hide_banner -y \
-    -f lavfi -i 'sine=sample_rate=8000:frequency=305:duration=5' \
-    -f lavfi -i 'sine=sample_rate=8000:frequency=300:duration=5' \
+    -f lavfi -i sine=sample_rate=8000:frequency=305:duration=5 \
+    -f lavfi -i sine=sample_rate=8000:frequency=300:duration=5 \
     -filter_complex amerge  -c:a pcm_s16le sample.wav
     """
     # fmt: on

--- a/tests/spdl_unittest/io/audio_encoding_test.py
+++ b/tests/spdl_unittest/io/audio_encoding_test.py
@@ -44,6 +44,8 @@ def test_encode_audio_integer(sample_fmt):
     ref = np.random.randint(ii.min, ii.max, size=shape, dtype=dtype)
 
     with NamedTemporaryFile(suffix=".wav") as f:
+        f.close()  # for windows
+
         muxer = spdl.io.Muxer(f.name)
         encoder = muxer.add_encode_stream(
             config=spdl.io.audio_encode_config(
@@ -99,6 +101,8 @@ def test_encode_audio_float(sample_fmt):
     ref = np.random.rand(*shape).astype(dtype=dtype)
 
     with NamedTemporaryFile(suffix=".wav") as f:
+        f.close()  # for windows
+
         muxer = spdl.io.Muxer(f.name)
         encoder = muxer.add_encode_stream(
             config=spdl.io.audio_encode_config(
@@ -154,6 +158,8 @@ def test_encode_audio_integer_planar(sample_fmt):
     ref = np.random.randint(ii.min, ii.max, size=shape, dtype=dtype)
 
     with NamedTemporaryFile(suffix=".nut") as f:
+        f.close()  # windows
+
         muxer = spdl.io.Muxer(f.name)
         encoder = muxer.add_encode_stream(
             config=spdl.io.audio_encode_config(
@@ -219,6 +225,8 @@ def test_encode_audio_smoke_test(ext, sample_fmt):
         ref = np.random.random(shape).astype(dtype)
 
     with NamedTemporaryFile(suffix=ext) as f:
+        f.close()  # for windows
+
         muxer = spdl.io.Muxer(f.name)
         encoder = muxer.add_encode_stream(
             config=spdl.io.audio_encode_config(
@@ -226,6 +234,10 @@ def test_encode_audio_smoke_test(ext, sample_fmt):
                 sample_fmt=sample_fmt,
                 sample_rate=sample_rate,
             ),
+            # on Windows, the default might be mp3_mf, which
+            # does not support planar format.
+            # So we specify lame
+            encoder="libmp3lame" if ext == ".mp3" else None,
         )
 
         frame_size = encoder.frame_size or 1024
@@ -259,8 +271,8 @@ def test_remux_audio():
     # fmt: off
     cmd = f"""
     {FFMPEG_CLI} -hide_banner -y \
-    -f lavfi -i 'sine=sample_rate=8000:frequency=305:duration=5' \
-    -f lavfi -i 'sine=sample_rate=8000:frequency=300:duration=5' \
+    -f lavfi -i sine=sample_rate=8000:frequency=305:duration=5 \
+    -f lavfi -i sine=sample_rate=8000:frequency=300:duration=5 \
     -filter_complex amerge  -c:a pcm_s16le sample.wav
     """
     # fmt: on
@@ -269,6 +281,8 @@ def test_remux_audio():
     demuxer = spdl.io.Demuxer(sample.path)
 
     with NamedTemporaryFile(suffix=".wav") as f:
+        f.close()  # for windows
+
         muxer = spdl.io.Muxer(f.name)
         muxer.add_remux_stream(demuxer.audio_codec)
 

--- a/tests/spdl_unittest/io/configs_test.py
+++ b/tests/spdl_unittest/io/configs_test.py
@@ -14,7 +14,7 @@ from ..fixture import FFMPEG_CLI, get_sample
 
 def test_demux_config_smoketest():
     """"""
-    cmd = f"{FFMPEG_CLI} -hide_banner -y -f lavfi -i 'sine=frequency=1000:sample_rate=48000:duration=3' -c:a pcm_s16le sample.wav"
+    cmd = f"{FFMPEG_CLI} -hide_banner -y -f lavfi -i sine=frequency=1000:sample_rate=48000:duration=3 -c:a pcm_s16le sample.wav"
     sample = get_sample(cmd)
 
     demux_config = spdl.io.demux_config()
@@ -32,7 +32,7 @@ def test_demux_config_smoketest():
 
 def test_demux_config_headless():
     """Providing demux_config allows to load headeless audio"""
-    cmd = f"{FFMPEG_CLI} -hide_banner -y -f lavfi -i 'sine=frequency=1000:sample_rate=48000:duration=3' -f s16le -c:a pcm_s16le sample.raw"
+    cmd = f"{FFMPEG_CLI} -hide_banner -y -f lavfi -i sine=frequency=1000:sample_rate=48000:duration=3 -f s16le -c:a pcm_s16le sample.raw"
     sample = get_sample(cmd)
 
     with pytest.raises(RuntimeError):

--- a/tests/spdl_unittest/io/demuxer_test.py
+++ b/tests/spdl_unittest/io/demuxer_test.py
@@ -13,9 +13,7 @@ from ..fixture import FFMPEG_CLI, get_sample
 
 def test_demuxer_query_codec():
     """Can fetch the codec properly."""
-    cmd = (
-        f"{FFMPEG_CLI} -hide_banner -y -f lavfi -i testsrc -f lavfi -i sine -t 5  sample.mp4",
-    )
+    cmd = f"{FFMPEG_CLI} -hide_banner -y -f lavfi -i testsrc -f lavfi -i sine -t 5  sample.mp4"
 
     sample = get_sample(cmd)
 
@@ -39,9 +37,7 @@ def test_demuxer_query_codec():
 
 def test_demuxer_query_stream_index():
     """Can fetch the stream index properly."""
-    cmd = (
-        f"{FFMPEG_CLI} -hide_banner -y -f lavfi -i testsrc -f lavfi -i sine -t 5  sample.mp4",
-    )
+    cmd = f"{FFMPEG_CLI} -hide_banner -y -f lavfi -i testsrc -f lavfi -i sine -t 5  sample.mp4"
 
     sample = get_sample(cmd)
     demuxer = spdl.io.Demuxer(sample.path)
@@ -49,9 +45,7 @@ def test_demuxer_query_stream_index():
     assert demuxer.video_stream_index == 0
     assert demuxer.audio_stream_index == 1
 
-    cmd = (
-        f"{FFMPEG_CLI} -hide_banner -y -f lavfi -i sine -f lavfi -i testsrc -t 5 -map 0:a -map 1:v  sample.mp4",
-    )
+    cmd = f"{FFMPEG_CLI} -hide_banner -y -f lavfi -i sine -f lavfi -i testsrc -t 5 -map 0:a -map 1:v  sample.mp4"
 
     sample = get_sample(cmd)
     demuxer = spdl.io.Demuxer(sample.path)

--- a/tests/spdl_unittest/io/encoding_test.py
+++ b/tests/spdl_unittest/io/encoding_test.py
@@ -26,6 +26,7 @@ def test_encode_image_parity_simple(pix_fmt, torch_tensor):
     ref = np.random.randint(256, size=shape, dtype=np.uint8)
 
     with NamedTemporaryFile(suffix=".png") as f:
+        f.close()  # for windows
         spdl.io.save_image(
             f.name,
             torch.from_numpy(ref) if torch_tensor else ref,
@@ -44,6 +45,7 @@ def test_encode_image_parity_png_gray16be():
         ref = ref.byteswap()
 
     with NamedTemporaryFile(suffix=".png") as f:
+        f.close()  # for windows
         spdl.io.save_image(
             f.name,
             ref,
@@ -62,6 +64,7 @@ def test_encode_image_parity_png_gray16be():
 def _test_rejects(pix_fmt, dtype):
     data = np.ones((32, 64), dtype=dtype)
     with NamedTemporaryFile(suffix=".png") as f:
+        f.close()  # for windows
         with pytest.raises(ValueError):
             spdl.io.save_image(
                 f.name,

--- a/tests/spdl_unittest/io/frames_clone_test.py
+++ b/tests/spdl_unittest/io/frames_clone_test.py
@@ -13,7 +13,7 @@ import spdl.io
 from ..fixture import FFMPEG_CLI, get_sample
 
 CMDS = {
-    "audio": f"{FFMPEG_CLI} -hide_banner -y -f lavfi -i 'sine=frequency=1000:sample_rate=48000:duration=3' -c:a pcm_s16le sample.wav",
+    "audio": f"{FFMPEG_CLI} -hide_banner -y -f lavfi -i sine=frequency=1000:sample_rate=48000:duration=3 -c:a pcm_s16le sample.wav",
     "video": f"{FFMPEG_CLI} -hide_banner -y -f lavfi -i testsrc -frames:v 25 sample.mp4",
     "image": f"{FFMPEG_CLI} -hide_banner -y -f lavfi -i color=0x000000,format=gray -frames:v 1 sample.png",
 }

--- a/tests/spdl_unittest/io/packets_test.py
+++ b/tests/spdl_unittest/io/packets_test.py
@@ -15,7 +15,7 @@ import spdl.io
 from ..fixture import FFMPEG_CLI, get_sample
 
 CMDS = {
-    "audio": f"{FFMPEG_CLI} -hide_banner -y -f lavfi -i 'sine=frequency=1000:sample_rate=48000:duration=3' -c:a pcm_s16le sample.wav",
+    "audio": f"{FFMPEG_CLI} -hide_banner -y -f lavfi -i sine=frequency=1000:sample_rate=48000:duration=3 -c:a pcm_s16le sample.wav",
     "video": f"{FFMPEG_CLI} -hide_banner -y -f lavfi -i testsrc -frames:v 25 sample.mp4",
     "image": f"{FFMPEG_CLI} -hide_banner -y -f lavfi -i color=0x000000,format=gray -frames:v 1 sample.png",
 }
@@ -46,7 +46,7 @@ def test_demux_with_codec(media_type):
 def test_demux_without_codec():
     """When using streaming_demux, the resulting packets does not contain codec"""
 
-    cmd = f"{FFMPEG_CLI} -lavfi 'testsrc;sine' -t 10 out.mp4"
+    cmd = f'{FFMPEG_CLI} -lavfi "testsrc;sine" -t 10 out.mp4'
 
     sample = get_sample(cmd)
 
@@ -82,8 +82,8 @@ def test_audio_packets_attributes():
     # fmt: off
     cmd = f"""
     {FFMPEG_CLI} -hide_banner -y \
-    -f lavfi -i 'sine=sample_rate=8000:frequency=305:duration=5' \
-    -f lavfi -i 'sine=sample_rate=8000:frequency=300:duration=5' \
+    -f lavfi -i sine=sample_rate=8000:frequency=305:duration=5 \
+    -f lavfi -i sine=sample_rate=8000:frequency=300:duration=5 \
     -filter_complex amerge  -c:a pcm_s16le sample.wav
     """
     # fmt: on
@@ -193,7 +193,7 @@ def test_sample_decoding_time():
     # https://stackoverflow.com/questions/63725248/how-can-i-set-gop-size-to-be-a-multiple-of-the-input-framerate
     cmd = (
         f"{FFMPEG_CLI} -hide_banner -y -f lavfi -i testsrc "
-        "-force_key_frames 'expr:eq(mod(n, 25), 0)' "
+        '-force_key_frames "expr:eq(mod(n, 25), 0)" '
         "-frames:v 5000 sample.mp4"
     )
     # Note: You can use the following command to check that the generated video has the keyframes
@@ -230,7 +230,7 @@ def test_sample_decoding_time_sync():
     # https://stackoverflow.com/questions/63725248/how-can-i-set-gop-size-to-be-a-multiple-of-the-input-framerate
     cmd = (
         f"{FFMPEG_CLI} -hide_banner -y -f lavfi -i testsrc "
-        "-force_key_frames 'expr:eq(mod(n, 25), 0)' "
+        '-force_key_frames "expr:eq(mod(n, 25), 0)" '
         "-frames:v 5000 sample.mp4"
     )
     # Note: You can use the following command to check that the generated video has the keyframes
@@ -267,7 +267,7 @@ def test_packet_len():
     # 3 seconds of video with only one keyframe at the beginning.
     # Use the following command to check
     # `ffprobe -loglevel error -select_streams v:0 -show_entries packet=pts_time,flags -of csv=print_section=0 sample.mp4 | grep K__`
-    cmd = f"{FFMPEG_CLI} -hide_banner -y -f lavfi -i testsrc -force_key_frames 'expr:eq(n, 0)' -frames:v 75 sample.mp4"
+    cmd = f'{FFMPEG_CLI} -hide_banner -y -f lavfi -i testsrc -force_key_frames "expr:eq(n, 0)" -frames:v 75 sample.mp4'
     sample = get_sample(cmd)
 
     ref_array = spdl.io.to_numpy(spdl.io.load_video(sample.path))
@@ -289,7 +289,7 @@ def test_sample_decoding_window():
     # 10 seconds of video with only one keyframe at the beginning.
     # Use the following command to check
     # `ffprobe -loglevel error -select_streams v:0 -show_entries packet=pts_time,flags -of csv=print_section=0 sample.mp4 | grep K__`
-    cmd = f"{FFMPEG_CLI} -hide_banner -y -f lavfi -i testsrc -force_key_frames 'expr:eq(n, 0)' -frames:v 250 sample.mp4"
+    cmd = f'{FFMPEG_CLI} -hide_banner -y -f lavfi -i testsrc -force_key_frames "expr:eq(n, 0)" -frames:v 250 sample.mp4'
     sample = get_sample(cmd)
 
     # 250 frames
@@ -320,7 +320,7 @@ def test_sample_decoding_window_sync():
     # 10 seconds of video with only one keyframe at the beginning.
     # Use the following command to check
     # `ffprobe -loglevel error -select_streams v:0 -show_entries packet=pts_time,flags -of csv=print_section=0 sample.mp4 | grep K__`
-    cmd = f"{FFMPEG_CLI} -hide_banner -y -f lavfi -i testsrc -force_key_frames 'expr:eq(n, 0)' -frames:v 250 sample.mp4"
+    cmd = f'{FFMPEG_CLI} -hide_banner -y -f lavfi -i testsrc -force_key_frames "expr:eq(n, 0)" -frames:v 250 sample.mp4'
     sample = get_sample(cmd)
 
     # 250 frames

--- a/tests/spdl_unittest/io/streaming_decoding_test.py
+++ b/tests/spdl_unittest/io/streaming_decoding_test.py
@@ -18,7 +18,7 @@ from ..fixture import FFMPEG_CLI, get_sample
     "cmd,expected",
     [
         (
-            f"{FFMPEG_CLI} -hide_banner -y -f lavfi -i 'sine=duration=3' -c:a pcm_s16le sample.wav",
+            f"{FFMPEG_CLI} -hide_banner -y -f lavfi -i sine=duration=3 -c:a pcm_s16le sample.wav",
             True,
         ),
         (
@@ -129,7 +129,7 @@ def test_streaming_video_demuxing_parity():
 
 
 def test_demuxer_get_codec():
-    cmd = f"{FFMPEG_CLI} -hide_banner -y -f lavfi -i testsrc -f lavfi -i sine=sample_rate=48000 -af pan='stereo| c0=FR | c1=FR' -frames:v 30 sample.mp4"
+    cmd = f'{FFMPEG_CLI} -hide_banner -y -f lavfi -i testsrc -f lavfi -i sine=sample_rate=48000 -af "pan=stereo|c0=FR|c1=FR" -frames:v 30 sample.mp4'
 
     sample = get_sample(cmd)
     demuxer = spdl.io.Demuxer(sample.path)

--- a/tests/spdl_unittest/io/video_encoding_test.py
+++ b/tests/spdl_unittest/io/video_encoding_test.py
@@ -31,6 +31,7 @@ def test_encode_video_multi_color(pix_fmt):
     ref = np.random.randint(0, 255, size=shape, dtype=np.uint8)
 
     with NamedTemporaryFile(suffix=".raw") as f:
+        f.close()  # for windows
         muxer = spdl.io.Muxer(f.name, format="rawvideo")
         encoder = muxer.add_encode_stream(
             config=spdl.io.video_encode_config(
@@ -86,6 +87,7 @@ def test_encode_video_gray(pix_fmt):
     ref = np.random.randint(0, 255, size=shape, dtype=dtype)
 
     with NamedTemporaryFile(suffix=".raw") as f:
+        f.close()  # for windows
         muxer = spdl.io.Muxer(f.name, format="rawvideo")
         encoder = muxer.add_encode_stream(
             config=spdl.io.video_encode_config(
@@ -136,6 +138,7 @@ def test_remux_video():
     demuxer = spdl.io.Demuxer(sample.path)
 
     with NamedTemporaryFile(suffix=".mp4") as f:
+        f.close()  # for windows
         muxer = spdl.io.Muxer(f.name)
         muxer.add_remux_stream(demuxer.video_codec)
 

--- a/tests/spdl_unittest/io/zero_copy_bytes_passing_test.py
+++ b/tests/spdl_unittest/io/zero_copy_bytes_passing_test.py
@@ -13,7 +13,7 @@ import spdl.io
 from ..fixture import FFMPEG_CLI, get_sample
 
 CMDS = {
-    "audio": f"{FFMPEG_CLI} -hide_banner -y -f lavfi -i 'sine=frequency=1000:sample_rate=48000:duration=3' -c:a pcm_s16le sample.wav",
+    "audio": f"{FFMPEG_CLI} -hide_banner -y -f lavfi -i sine=frequency=1000:sample_rate=48000:duration=3 -c:a pcm_s16le sample.wav",
     "video": f"{FFMPEG_CLI} -hide_banner -y -f lavfi -i testsrc -frames:v 1000 sample.mp4",
     "image": f"{FFMPEG_CLI} -hide_banner -y -f lavfi -i color=0x000000,format=gray -frames:v 1 sample.png",
 }
@@ -61,7 +61,7 @@ def _decode(media_type, src):
 
 def test_decode_audio_bytes():
     """audio can be decoded from bytes."""
-    cmd = f"{FFMPEG_CLI} -hide_banner -y -f lavfi -i 'sine=frequency=1000:sample_rate=16000:duration=3' -c:a pcm_s16le sample.wav"
+    cmd = f"{FFMPEG_CLI} -hide_banner -y -f lavfi -i sine=frequency=1000:sample_rate=16000:duration=3 -c:a pcm_s16le sample.wav"
     sample = get_sample(cmd)
 
     ref = _decode("audio", sample.path)


### PR DESCRIPTION
On Windows there are several different behaviors around subprocess.

- It cannot pickle locally defined functions/classes. (I thought this was also the case for Linux/macOS, but seems not)
- Module-level global variables do not inherit their values from the parent process.
- Even for simple async pipeline with single concurrency, the output order can be changed.

- In subprocess call, quoting is different.
- When writing to a NamedTemporaryFile, the file must be closed before writing.

Towards: #829 