### PR TITLE
Add CI build jobs for Windows

### DIFF
--- a/.github/scripts/build_windows.sh
+++ b/.github/scripts/build_windows.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+# Used by Windows CI build jobs.
+
+set -x
+
+curl -LsSf https://astral.sh/uv/install.sh | sh
+set -ex
+
+py_ver="${1}"
+if [[ "${2}" == 'ft' ]]; then
+    py_ver="${py_ver}t"
+fi
+
+export PATH="${PATH}:${HOME}/.local/bin/"
+
+uv python pin "${py_ver}"
+uv python list --only-installed
+uv venv
+uv build --no-python-downloads --all-packages --wheel
+mv ./dist ./package

--- a/.github/scripts/check_package.sh
+++ b/.github/scripts/check_package.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+# Used by Windows CI build jobs.
+
+pip install -r ./packaging/requirements.txt
+twine check --strict ./package/*.whl

--- a/.github/workflows/_build_windows.yml
+++ b/.github/workflows/_build_windows.yml
@@ -1,0 +1,58 @@
+name: " - Wheel (Windows)"
+
+on:
+  workflow_call:
+    inputs:
+      python-version:
+        required: true
+        type: string
+      free-threaded:
+        description: 'Whether FT Python or not. Valid value is "ft" or not.'
+        default: ''
+        type: string
+      run-test:
+        required: false
+        default: 'false'
+        type: string
+      os:
+        default: "windows-latest"
+        type: string
+
+env:
+  ARTIFACT: wheel-win-py${{ inputs.python-version }}${{ inputs.free-threaded }}
+
+jobs:
+  build:
+    runs-on: "${{ inputs.os }}"
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Build
+        env:
+          SPDL_USE_TRACING: 0
+          SPDL_BUILD_STUB: 0
+        shell: cmd
+        run: |
+          packaging/vc_env_helper.bat            ^
+            bash                                 ^
+              .github/scripts/build_windows.sh   ^
+              "${{ inputs.python-version }}"     ^
+              "${{ inputs.free-threaded }}"
+
+      - uses: actions/upload-artifact@v4
+        name: Upload build artifact
+        with:
+          name: "${{ env.ARTIFACT }}"
+          path: package
+          if-no-files-found: error
+          retention-days: 7
+          overwrite: true
+
+      - name: Check package
+        shell: cmd
+        run: |
+          packaging/vc_env_helper.bat            ^
+            bash                                 ^
+              .github/scripts/check_package.sh

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -35,6 +35,25 @@ jobs:
       run-test: "false"
 
   #############################################################################
+  # Windows
+  #############################################################################
+  windows:
+    name: "Windows"
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        free-threaded: [""]
+        include:
+          - python-version: "3.13"
+            free-threaded: "ft"
+    uses: ./.github/workflows/_build_windows.yml
+    with:
+      python-version: "${{ matrix.python-version }}"
+      free-threaded: "${{ matrix.free-threaded }}"
+      run-test: "${{ matrix.python-version == '3.11'}}"
+
+  #############################################################################
   # Linux (CPU)
   #############################################################################
   linux-aarch64:


### PR DESCRIPTION
Add Windows build CI jobs for CPU build.

Remaining TODO:
- Add unit test https://github.com/facebookresearch/spdl/pull/852
- Add CUDA/NVDEC extension (verified it works locally)
- Add CUDA/NVDEC unit test.

Part of #829 