### PR TITLE
Support overriding max_failures at each stage

### DIFF
--- a/src/spdl/pipeline/_build.py
+++ b/src/spdl/pipeline/_build.py
@@ -128,7 +128,7 @@ def _build_pipeline_coro(
                     in_queue,
                     out_queue,
                     cfg._args,
-                    _FailCounter(max_failures),
+                    _FailCounter(max_failures, cfg._max_failures),
                     task_hook_factory(name),
                 )
             case _PipeType.OrderedPipe:
@@ -137,7 +137,7 @@ def _build_pipeline_coro(
                     in_queue,
                     out_queue,
                     cfg._args,
-                    _FailCounter(max_failures),
+                    _FailCounter(max_failures, cfg._max_failures),
                     task_hook_factory(name),
                 )
             case _:  # pragma: no cover

--- a/src/spdl/pipeline/_builder.py
+++ b/src/spdl/pipeline/_builder.py
@@ -105,6 +105,7 @@ class PipelineBuilder(Generic[T, U]):
         executor: Executor | None = None,
         name: str | None = None,
         output_order: str = "completion",
+        max_failures: int | None = None,
     ) -> "PipelineBuilder[T, U]":
         """Apply an operation to items in the pipeline.
 
@@ -164,6 +165,11 @@ class PipelineBuilder(Generic[T, U]):
                 in the order their process is completed.
                 If ``"input"``, then the items are put to output queue in the order given
                 in the input queue.
+
+            max_failures: The maximnum number of failures allowed berfore the pipe operation
+                is considered failure and the whole Pipeline is shutdown.
+                This overrides the value provided to the :py:meth:`~PipelineBuilder.build`
+                method.
         """
         self._process_args.append(
             Pipe(
@@ -172,6 +178,7 @@ class PipelineBuilder(Generic[T, U]):
                 executor=executor,
                 name=name,
                 output_order=output_order,
+                max_failures=max_failures,
             )
         )
         return self

--- a/src/spdl/pipeline/defs/_defs.py
+++ b/src/spdl/pipeline/defs/_defs.py
@@ -117,6 +117,8 @@ class PipeConfig(Generic[T, U]):
 
     _args: _PipeArgs[T, U]
 
+    _max_failures: int | None = None
+
     def __post_init__(self) -> None:
         op = self._args.op
         if inspect.iscoroutinefunction(op) or inspect.isasyncgenfunction(op):
@@ -234,6 +236,7 @@ def Pipe(
     executor: Executor | None = None,
     name: str | None = None,
     output_order: str = "completion",
+    max_failures: int | None = None,
 ) -> PipeConfig[T, U]:
     """Create a :py:class:`PipeConfig`.
 
@@ -287,6 +290,10 @@ def Pipe(
             in the order their process is completed.
             If ``"input"``, then the items are put to output queue in the order given
             in the input queue.
+        max_failures: The maximnum number of failures allowed berfore the pipe operation
+            is considered failure and the whole Pipeline is shutdown.
+            This overrides the value provided to the :py:meth:`~PipelineBuilder.build`
+            method.
 
     Returns:
         The config object.
@@ -324,6 +331,7 @@ def Pipe(
             executor=executor,
             concurrency=concurrency,
         ),
+        _max_failures=max_failures,
     )
 
 


### PR DESCRIPTION
This commit adds `max_failures` argument to Pipe,
which overrides the Pipeline-level max_failures.

See the motivation https://github.com/facebookresearch/spdl/issues/942
Resolves https://github.com/facebookresearch/spdl/issues/942