### PR TITLE
Fix FailCounter's global failure count mechanism

### DIFF
--- a/src/spdl/pipeline/_components/_pipe.py
+++ b/src/spdl/pipeline/_components/_pipe.py
@@ -58,7 +58,7 @@ class _FailCounter(TaskHook):
         self._num_stage_failures: int = 0
 
     def _increment(self) -> None:
-        self._num_global_failures += 1
+        self.__class__._num_global_failures += 1
         self._num_stage_failures += 1
 
     @property
@@ -97,7 +97,7 @@ class _FailCounter(TaskHook):
 # so that we can also track the Pipeline-global failures.
 def _get_fail_counter() -> type[_FailCounter]:
     class _FC(_FailCounter):
-        num_global_failures: int = 0
+        pass
 
     return _FC
 


### PR DESCRIPTION
In https://github.com/facebookresearch/spdl/commit/f8b9904b84e2cecc9a846e5544fbaebcfb0bd2dd, the `_FailCounter.increment` method was changed from class method to instance method.

It turned out that `+=` operator in instance method creates an instance attribute.
So the global failure counter value was not shared among the pipe stages.

I thought such pattern is caught by the tests but it seems not.
This commit fixes it and add a test to verify that.

