### PR TITLE
Add explicit dependency structure to Pipeline coroutines

### DIFF
--- a/src/spdl/pipeline/_node.py
+++ b/src/spdl/pipeline/_node.py
@@ -1,0 +1,81 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from asyncio import Task
+from dataclasses import dataclass
+from typing import Coroutine, Generic, TypeVar
+
+from ._queue import AsyncQueue
+from ._utils import create_task
+
+T = TypeVar("T")
+
+
+# Used to express the upstream relation ship of coroutines.
+# Currently only a chain is used, but we plan to extend it to
+# (possibly nested) "Y" shape.
+# Retaining relationship is necessary for graceful shutdown.
+@dataclass
+class _Node(Generic[T]):
+    name: str
+    coro: Coroutine[None, None, None]
+    queue: AsyncQueue[T]
+    upstream: list["_Node"]
+    _task: Task | None = None
+
+    @property
+    def task(self) -> Task:
+        if self._task is None:
+            raise AssertionError("[INTERNAL ERROR] task is not started.")
+        return self._task
+
+    def create_task(self) -> Task:
+        if self._task is not None:
+            raise AssertionError("[INTERNAL ERROR] task is already started.")
+        task = create_task(self.coro, name=self.name)
+        self._task = task
+        return task
+
+
+def _start_tasks(node: _Node[T]) -> set[Task]:
+    node.create_task()
+    ret = {node.task}
+    for n in node.upstream:
+        ret |= _start_tasks(n)
+    return ret
+
+
+def _cancel_recursive(node: _Node[T]) -> set[Task]:
+    task = node.task
+    task.cancel()
+    ret = {task}
+    for n in node.upstream:
+        ret |= _cancel_recursive(n)
+    return ret
+
+
+def _cancel_upstreams_of_errors(node: _Node[T]) -> set[Task]:
+    task = node.task
+    canceled = set()
+    if task.done() and not task.cancelled() and task.exception() is not None:
+        for n in node.upstream:
+            canceled |= _cancel_recursive(n)
+
+    for n in node.upstream:
+        canceled |= _cancel_upstreams_of_errors(n)
+    return canceled
+
+
+def _gather_error(node: _Node[T]) -> list[tuple[str, Exception]]:
+    task = node.task
+    errs = []
+    if not task.cancelled() and (err := task.exception()) is not None:
+        errs.append((task.get_name(), err))
+
+    for n in node.upstream:
+        errs.extend(_gather_error(n))
+    errs.sort(key=lambda i: i[0])
+    return errs

--- a/tests/spdl_unittest/dataloader/pipeline_node_test.py
+++ b/tests/spdl_unittest/dataloader/pipeline_node_test.py
@@ -1,0 +1,251 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import asyncio
+
+from spdl.pipeline._node import (
+    _cancel_recursive,
+    _cancel_upstreams_of_errors,
+    _gather_error,
+    _Node,
+    _start_tasks,
+)
+from spdl.pipeline._queue import AsyncQueue
+
+# pyre-strict
+
+
+class DummyException(Exception):
+    pass
+
+
+def _node(
+    name: str, deps: list[_Node[None]], exc: Exception | None = None
+) -> _Node[None]:
+    async def coro() -> None:
+        if exc:
+            raise exc
+        else:
+            await asyncio.sleep(0)
+
+    return _Node(name, coro(), AsyncQueue(name), deps)
+
+
+def test_node_chain_start_and_cancel() -> None:
+    #  A -> B -> C
+
+    async def run() -> None:
+        a = _node("A", [])
+        b = _node("B", [a])
+        c = _node("C", [b])
+        tasks = _start_tasks(c)
+        assert all(isinstance(t, asyncio.Task) for t in tasks)
+        assert len(tasks) == 3
+
+        canceled = _cancel_recursive(c)
+        assert canceled == tasks
+        await asyncio.gather(*tasks, return_exceptions=True)
+        assert all(t.cancelled() for t in tasks)
+
+    asyncio.run(run())
+
+
+def test_node_y_shape_upstream() -> None:
+    #  A1      B1
+    #   |      |
+    #  A2      B2
+    #    \    /
+    #      C1
+
+    async def run() -> None:
+        a1 = _node("A1", [])
+        a2 = _node("A2", [a1])
+        b1 = _node("B1", [])
+        b2 = _node("B2", [b1])
+        c1 = _node("C1", [a2, b2])
+        tasks = _start_tasks(c1)
+        assert len(tasks) == 5
+
+        canceled = _cancel_recursive(c1)
+        assert canceled == tasks
+        await asyncio.gather(*tasks, return_exceptions=True)
+        assert all(t.cancelled() for t in tasks)
+
+    asyncio.run(run())
+
+
+def test_cancel_error_upstreams_and_gather_error() -> None:
+    #  A1      B1
+    #   |      |
+    #  A2      B2 (raises)
+    #    \    /
+    #      C1
+
+    async def run() -> None:
+        a1 = _node("A1", [])
+        a2 = _node("A2", [a1])
+        b1 = _node("B1", [])
+        b2 = _node("B2", [b1], exc=DummyException("fail B2"))
+        c1 = _node("C1", [a2, b2])
+        tasks = _start_tasks(c1)
+        await asyncio.sleep(0)  # Let tasks start
+
+        # Let B2 fail
+        await asyncio.gather(b2.task, return_exceptions=True)
+
+        canceled = _cancel_upstreams_of_errors(c1)
+        # Only B1 should be canceled, since B2 errored
+        assert a1.task not in canceled
+        assert a2.task not in canceled
+        assert b1.task in canceled
+        assert b2.task not in canceled
+        assert c1.task not in canceled
+
+        errs = _gather_error(c1)
+        assert len(errs) == 1
+        name, err = errs[0]
+        assert name == "B2"
+        assert isinstance(err, DummyException) and err.args[0] == "fail B2"
+        await asyncio.gather(*tasks, return_exceptions=True)
+
+    asyncio.run(run())
+
+
+def test_cancel_error_upstreams_and_gather_error_multiple() -> None:
+    #          A1      B1
+    #           |      |
+    # (raises) A2      B2 (raises)
+    #            \    /
+    #              C1
+    async def run() -> None:
+        a1 = _node("A1", [])
+        a2 = _node("A2", [a1], exc=DummyException("fail A2"))
+        b1 = _node("B1", [])
+        b2 = _node("B2", [b1], exc=DummyException("fail B2"))
+        c1 = _node("C1", [a2, b2])
+
+        tasks = _start_tasks(c1)
+        await asyncio.sleep(0)  # Let tasks start
+
+        # Let A2, B2 fail
+        await asyncio.gather(a2.task, b2.task, return_exceptions=True)
+
+        canceled = _cancel_upstreams_of_errors(c1)
+        assert a1.task in canceled
+        assert a2.task not in canceled
+        assert b1.task in canceled
+        assert b2.task not in canceled
+        assert c1.task not in canceled
+
+        errs = _gather_error(c1)
+        assert len(errs) == 2
+        name, err = errs[0]
+        assert name == "A2"
+        assert isinstance(err, DummyException) and err.args[0] == "fail A2"
+        name, err = errs[1]
+        assert name == "B2"
+        assert isinstance(err, DummyException) and err.args[0] == "fail B2"
+
+        await asyncio.gather(*tasks, return_exceptions=True)
+
+    asyncio.run(run())
+
+
+def test_cancel_error_upstreams_and_gather_error_complex() -> None:
+    #           B1      C1
+    #            |      |
+    #  (raises) B2      C2 (raises)
+    #             \    /
+    #          A1   D1  E1
+    #           |   |   |
+    # (raises) A2   D2  E2
+    #            \  |  /
+    #               F1
+
+    async def run() -> None:
+        a1 = _node("A1", [])
+        a2 = _node("A2", [a1], exc=DummyException("fail A2"))
+        b1 = _node("B1", [])
+        b2 = _node("B2", [b1], exc=DummyException("fail B2"))
+        c1 = _node("C1", [])
+        c2 = _node("C2", [c1], exc=DummyException("fail C2"))
+        d1 = _node("D1", [b2, c2])
+        d2 = _node("D2", [d1])
+        e1 = _node("E1", [])
+        e2 = _node("E1", [e1])
+        f1 = _node("F1", [a2, d2, e2])
+
+        tasks = _start_tasks(f1)
+        await asyncio.sleep(0)  # Let tasks start
+
+        # Let A2, B2, C2 fail
+        await asyncio.gather(a2.task, b2.task, c2.task, return_exceptions=True)
+
+        canceled = _cancel_upstreams_of_errors(f1)
+        assert a1.task in canceled
+        assert a2.task not in canceled
+        assert b1.task in canceled
+        assert b2.task not in canceled
+        assert c1.task in canceled
+        assert c2.task not in canceled
+        assert d1.task not in canceled
+        assert d2.task not in canceled
+        assert e1.task not in canceled
+        assert e2.task not in canceled
+        assert f1.task not in canceled
+
+        errs = _gather_error(f1)
+        assert len(errs) == 3
+        name, err = errs[0]
+        assert name == "A2"
+        assert isinstance(err, DummyException) and err.args[0] == "fail A2"
+        name, err = errs[1]
+        assert name == "B2"
+        assert isinstance(err, DummyException) and err.args[0] == "fail B2"
+        name, err = errs[2]
+        assert name == "C2"
+        assert isinstance(err, DummyException) and err.args[0] == "fail C2"
+
+        await asyncio.gather(*tasks, return_exceptions=True)
+
+    asyncio.run(run())
+
+
+def test_gather_error_with_cancelled() -> None:
+    #  A1      B1
+    #   |      |
+    #  A2      B2
+    #    \    /
+    #      C1 (raises)
+
+    async def run() -> None:
+        a1 = _node("A1", [])
+        a2 = _node("A2", [a1])
+        b1 = _node("B1", [])
+        b2 = _node("B2", [b1])
+        c1 = _node("C1", [a2, b2], exc=DummyException("fail C"))
+
+        tasks = _start_tasks(c1)
+        await asyncio.sleep(0)  # Let tasks start
+
+        # Let C fail
+        await asyncio.gather(c1.task, return_exceptions=True)
+
+        canceled = _cancel_upstreams_of_errors(c1)
+        assert a1.task in canceled
+        assert a2.task in canceled
+        assert b1.task in canceled
+        assert b2.task in canceled
+        assert c1.task not in canceled
+
+        errs = _gather_error(c1)
+        assert len(errs) == 1
+        name, err = errs[0]
+        assert name == "C1"
+        assert isinstance(err, DummyException)
+        await asyncio.gather(*tasks, return_exceptions=True)
+
+    asyncio.run(run())


### PR DESCRIPTION
This commit introduces _Node structure which is used internally to represent the relationship of coroutines.

Currently, Pipeline only supports a chain. When we add support for merging multiple Pipeline, we need a proper way to handle cancellation for upstream tasks which might fork.

The _Node class helps implementing this.

The newly added unit test shows that it can handle complex cases (such as nested merges, and 3-way merges).