### PR TITLE
Convert PipelineConfig to graph structure before build

### DIFF
--- a/src/spdl/pipeline/_node.py
+++ b/src/spdl/pipeline/_node.py
@@ -6,17 +6,30 @@
 
 import asyncio
 from asyncio import Task
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from typing import Coroutine, Generic, TypeVar
 
+from ._components._pipe import _FailCounter, _ordered_pipe, _pipe
+from ._components._sink import _sink
+from ._components._source import _source
+from ._hook import TaskHook
 from ._queue import AsyncQueue
 from ._utils import create_task
+from .defs._defs import (
+    _ConfigBase,
+    _PipeType,
+    PipeConfig,
+    PipelineConfig,
+    SinkConfig,
+    SourceConfig,
+)
 
 T = TypeVar("T")
 
 __all__ = [
     "_Node",
+    "_build_pipeline_node",
     "_run_pipeline_coroutines",
     "PipelineFailure",
 ]
@@ -29,25 +42,147 @@ __all__ = [
 @dataclass
 class _Node(Generic[T]):
     name: str
-    coro: Coroutine[None, None, None]
-    queue: AsyncQueue[T]
+    cfg: _ConfigBase
     upstream: "Sequence[_Node]"
+    queue: AsyncQueue[T]
+    _coro: Coroutine[None, None, None] | None = None
     _task: Task | None = None
+
+    @property
+    def coro(self) -> Coroutine[None, None, None]:
+        if self._coro is None:
+            raise RuntimeError(
+                "[Internal Error] Attempted to retrieve a coroutine object, "
+                f"but it is not created: {self}"
+            )
+        return self._coro
 
     @property
     def task(self) -> Task:
         if self._task is None:
-            raise AssertionError("[INTERNAL ERROR] task is not started.")
+            raise AssertionError(
+                "[INTERNAL ERROR] Attempted to retrieve a task object, "
+                f"but it is not created: {self}"
+            )
         return self._task
 
     def create_task(self) -> Task:
         if self._task is not None:
-            raise AssertionError("[INTERNAL ERROR] task is already started.")
+            raise AssertionError(
+                "[INTERNAL ERROR] Attempted to cteate a task, "
+                f"but it is already crated (started): {self}"
+            )
         task = create_task(self.coro, name=self.name)
         self._task = task
         return task
 
 
+################################################################################
+# Build logic
+################################################################################
+
+
+def _get_names(cfg: _ConfigBase, pipeline_id: int, stage_id: int) -> tuple[str, str]:
+    # Note: Do not change the pattern used for naming.
+    # They are used by dashboard to query runtime data.
+    match cfg:
+        case SourceConfig():
+            base = "src"
+        case SinkConfig():
+            base = "sink"
+        case PipeConfig():
+            base = cfg.name
+            if cfg._type == _PipeType.Pipe and cfg._args.concurrency > 1:
+                base = f"{base}[{cfg._args.concurrency}]"
+        case _:
+            raise NotImplementedError(f"`{type(cfg)}` is not supported.")
+    name = f"{pipeline_id}:{stage_id}:{base}"
+    return name, f"{name}_queue"
+
+
+# For queues other than Sink, we use buffer_size=2.
+# This makes it possible for queues to always have an item
+# as long as upstream is fast enough.
+# This make it possible for data readiness (occupancy rate)
+# to reach 100%, instead of 99.999999%
+_BUFFER_SIZE: int = 2
+
+
+def _convert_config(
+    plc: PipelineConfig,
+    q_class: type[AsyncQueue[...]],
+    pipeline_id: int,
+    stage_id: int,
+) -> _Node:
+    name, q_name = _get_names(plc.src, pipeline_id, stage_id)
+    stage_id += 1
+    n = _Node(name, plc.src, [], q_class(q_name, buffer_size=_BUFFER_SIZE))
+    for cfg in plc.pipes:
+        name, q_name = _get_names(cfg, pipeline_id, stage_id)
+        stage_id += 1
+        n = _Node(name, cfg, [n], q_class(q_name, buffer_size=_BUFFER_SIZE))
+    name, q_name = _get_names(plc.sink, pipeline_id, stage_id)
+    stage_id += 1
+    n = _Node(name, plc.sink, [n], q_class(q_name, buffer_size=plc.sink.buffer_size))
+    return n
+
+
+def _build_node(
+    node: _Node,
+    fc_class: type[_FailCounter],
+    task_hook_factory: Callable[[str], list[TaskHook]],
+    max_failures: int,
+) -> None:
+    if node._coro is not None:
+        raise RuntimeError(f"[Internal Error] coroutine cannot be built twice. {node}")
+
+    for n in node.upstream:
+        _build_node(n, fc_class, task_hook_factory, max_failures)
+
+    match node.cfg:
+        case SourceConfig():
+            cfg: SourceConfig = node.cfg
+            assert len(node.upstream) == 0
+            node._coro = _source(cfg.source, node.queue)
+        case SinkConfig():
+            cfg: SinkConfig = node.cfg
+            assert len(node.upstream) == 1
+            node._coro = _sink(node.upstream[0].queue, node.queue)
+        case PipeConfig():
+            cfg: PipeConfig = node.cfg
+            assert len(node.upstream) == 1
+
+            in_q, out_q = node.upstream[0].queue, node.queue
+            hooks = task_hook_factory(node.name)
+            fc = fc_class(max_failures, cfg._max_failures)
+            match cfg._type:
+                case _PipeType.Pipe | _PipeType.Aggregate | _PipeType.Disaggregate:
+                    node._coro = _pipe(node.name, in_q, out_q, cfg._args, fc, hooks)
+                case _PipeType.OrderedPipe:
+                    node._coro = _ordered_pipe(
+                        node.name, in_q, out_q, cfg._args, fc, hooks
+                    )
+                case _:  # pragma: no cover
+                    raise ValueError(f"Unexpected process type: {cfg._type}")
+
+
+def _build_pipeline_node(
+    plc: PipelineConfig,
+    pipeline_id: int,
+    stage_id: int,
+    q_class: type[AsyncQueue[...]],
+    fc_class: type[_FailCounter],
+    task_hook_factory: Callable[[str], list[TaskHook]],
+    max_failures: int,
+):
+    node = _convert_config(plc, q_class, pipeline_id, stage_id)
+    _build_node(node, fc_class, task_hook_factory, max_failures)
+    return node
+
+
+################################################################################
+# Coroutine execution logics
+################################################################################
 def _start_tasks(node: _Node[T]) -> set[Task]:
     node.create_task()
     ret = {node.task}
@@ -87,11 +222,6 @@ def _gather_error(node: _Node[T]) -> list[tuple[str, Exception]]:
         errs.extend(_gather_error(n))
     errs.sort(key=lambda i: i[0])
     return errs
-
-
-################################################################################
-# Coroutine execution logics
-################################################################################
 
 
 # TODO [Python 3.11]: Migrate to ExceptionGroup

--- a/src/spdl/pipeline/defs/_defs.py
+++ b/src/spdl/pipeline/defs/_defs.py
@@ -26,6 +26,7 @@ __all__ = [
     "Aggregate",
     "Disaggregate",
     "Pipe",
+    "_ConfigBase",
     "PipeConfig",
     "PipelineConfig",
     "SinkConfig",
@@ -33,11 +34,15 @@ __all__ = [
 ]
 
 
+class _ConfigBase:
+    pass
+
+
 ################################################################################
 # Source
 ################################################################################
 @dataclass
-class SourceConfig(Generic[T]):
+class SourceConfig(Generic[T], _ConfigBase):
     """A source configuration.
 
     A source in Pipeline yields a series of input data, that is going to be
@@ -94,7 +99,7 @@ class _PipeArgs(Generic[T, U]):
 
 
 @dataclass
-class PipeConfig(Generic[T, U]):
+class PipeConfig(Generic[T, U], _ConfigBase):
     """PipeConfig()
 
     A pipe configuration.
@@ -152,7 +157,7 @@ class PipeConfig(Generic[T, U]):
 # Sink
 ################################################################################
 @dataclass
-class SinkConfig(Generic[T]):
+class SinkConfig(Generic[T], _ConfigBase):
     """A sink configuration.
 
     The sink is where the final result of pipeline is buffered.
@@ -180,7 +185,7 @@ class SinkConfig(Generic[T]):
 # Top-level Config
 ##############################################################################
 @dataclass
-class PipelineConfig(Generic[T, U]):
+class PipelineConfig(Generic[T, U], _ConfigBase):
     """A pipeline configuration.
 
     A pipeline consists of source, a series of pipes and sink.

--- a/tests/spdl_unittest/dataloader/pipeline_node_test.py
+++ b/tests/spdl_unittest/dataloader/pipeline_node_test.py
@@ -9,6 +9,7 @@ import asyncio
 from spdl.pipeline._node import (
     _cancel_recursive,
     _cancel_upstreams_of_errors,
+    _ConfigBase,
     _gather_error,
     _Node,
     _start_tasks,
@@ -31,7 +32,9 @@ def _node(
         else:
             await asyncio.sleep(0)
 
-    return _Node(name, coro(), AsyncQueue(name), deps)
+    n = _Node(name, _ConfigBase(), deps, AsyncQueue(name))
+    n._coro = coro()
+    return n
 
 
 def test_node_chain_start_and_cancel() -> None:


### PR DESCRIPTION
Currently, the graph representation is constructed as components of PipelineConfig are converted into coroutines.

This works fine for simple straight chain structure, but when we start dealing with Y-shaped graph structure, with potential nesting, the recursive function calls becomes complicated and the function signature for build function becomes too verbose.

It is simpler to converting the PipelineConfig into a graph structure first because graph retains the necessary dependency information, so recursive operation is carried out in graph traversal, but not in the coroutine construction.

This makes it easier to add merge mechanism.