### PR TITLE
Add self-diagnostic mode to pipeline

### DIFF
--- a/src/spdl/pipeline/_config.py
+++ b/src/spdl/pipeline/_config.py
@@ -1,0 +1,41 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import logging
+import os
+
+__all__ = [
+    "_diagnostic_mode_enabled",
+    "_diagnostic_mode_num_sources",
+]
+
+_LG: logging.Logger = logging.getLogger(__name__)
+
+
+def _env(name, default=False):
+    if name not in os.environ:
+        return default
+
+    val = os.environ.get(name, "0")
+    trues = ["1", "true", "TRUE", "on", "ON", "yes", "YES"]
+    falses = ["0", "false", "FALSE", "off", "OFF", "no", "NO"]
+    if val in trues:
+        return True
+    if val not in falses:
+        _LG.warning(
+            f"Unexpected environment variable value `{name}={val}`. "
+            f"Expected one of {trues + falses}",
+            stacklevel=2,
+        )
+    return False
+
+
+def _diagnostic_mode_enabled() -> bool:
+    return _env("SPDL_PIPELINE_DIAGNOSTIC_MODE")
+
+
+def _diagnostic_mode_num_sources() -> int:
+    return int(os.environ.get("SPDL_PIPELINE_DIAGNOSTIC_MODE_NUM_ITEMS", 1000))

--- a/tests/spdl_unittest/pipeline/test_build_pipeline.py
+++ b/tests/spdl_unittest/pipeline/test_build_pipeline.py
@@ -1,0 +1,45 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import os
+import unittest
+from unittest.mock import patch
+
+from spdl.pipeline import build_pipeline
+from spdl.pipeline._profile import _ProfilePipeline
+from spdl.pipeline.defs import Pipe, PipelineConfig, SinkConfig, SourceConfig
+
+# pyre-strict
+
+
+class TestBuildPipeline(unittest.TestCase):
+    """Test class for build_pipeline functionality."""
+
+    def test_build_pipeline_diagnostic_mode(self) -> None:
+        """Test that when SPDL_PIPELINE_DIAGNOSTIC_MODE=1, build_pipeline
+        calls _build_pipeline_diagnostic_mode and returns _ProfilePipeline.
+        """
+
+        def simple_op(i: int) -> int:
+            return i * 2
+
+        cfg = PipelineConfig(
+            src=SourceConfig(range(5)),
+            pipes=[
+                Pipe(simple_op),
+            ],
+            sink=SinkConfig(1),
+        )
+
+        with patch.dict("os.environ", {"SPDL_PIPELINE_DIAGNOSTIC_MODE": "1"}):
+            pipeline = build_pipeline(cfg, num_threads=2)
+            self.assertIsInstance(pipeline, _ProfilePipeline)
+
+        with patch.dict("os.environ", {}, clear=False):
+            os.environ.pop("SPDL_PIPELINE_DIAGNOSTIC_MODE", None)
+
+            pipeline = build_pipeline(cfg, num_threads=2)
+            self.assertNotIsInstance(pipeline, _ProfilePipeline)


### PR DESCRIPTION
This commit adds self-diagnostic mode, as outlined in https://github.com/facebookresearch/spdl/issues/903

When the environment variable `SPDL_PIPELINE_DIAGNOSTIC_MODE` is set, the build_pipeline function builds the pipeline in self-diagnostic mode.

In this mode, the pipeline benchmark the stage function one-by-one, and reports the performance.

This is useful when one needs to profile the pipeline in prod environment without changing the code.

We will add a mechanism to configure callback and hook in self-diagnostic mode.