### PR TITLE
Add function to load WAV from bytes without making a copy

### DIFF
--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -17,3 +17,4 @@ Examples
    data_formats
    hydra_integration
    pipeline_definitions
+   benchmark_wav

--- a/examples/benchmark_wav.py
+++ b/examples/benchmark_wav.py
@@ -1,0 +1,458 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""Benchmark WAV audio loading performance.
+
+This module benchmarks and compares three different approaches for loading WAV files:
+
+- spdl.io.load_wav: Fast native WAV parser optimized for simple PCM formats
+- spdl.io.load_audio: General-purpose audio loader using FFmpeg backend
+- soundfile (libsndfile): Popular third-party audio I/O library
+
+The benchmark suite evaluates performance across multiple dimensions:
+
+- Various audio configurations (sample rates, channels, bit depths, durations)
+- Different thread counts (1, 2, 4, 8, 16) to measure parallel scaling
+- Statistical analysis with 95% confidence intervals using Student's t-distribution
+- Queries per second (QPS) as the primary performance metric
+
+Results can be output as CSV data to stdout and optionally plotted as
+publication-quality figures using matplotlib and seaborn.
+
+Example:
+   Run the benchmark suite with default configurations::
+
+   .. code-block:: shell
+
+      $ python benchmark_wav.py
+
+   Generate benchmark results with visualization::
+
+   .. code-block:: shell
+
+      $ python benchmark_wav.py --plot --output results.png
+"""
+
+__all__ = [
+    "BenchmarkResult",
+    "BenchmarkConfig",
+    "create_wav_data",
+    "load_sf",
+    "load_spdl_audio",
+    "load_spdl_wav",
+    "benchmark",
+    "run_benchmark_suite",
+    "plot_benchmark_results",
+    "main",
+]
+
+import argparse
+import io
+import time
+from collections.abc import Callable
+from concurrent.futures import as_completed, ThreadPoolExecutor
+from dataclasses import dataclass
+
+import matplotlib
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import scipy.io.wavfile
+import scipy.stats
+import seaborn as sns
+import soundfile as sf
+import spdl.io
+from numpy.typing import NDArray
+
+
+def create_wav_data(
+    sample_rate: int = 44100,
+    num_channels: int = 2,
+    bits_per_sample: int = 16,
+    duration_seconds: float = 1.0,
+) -> tuple[bytes, NDArray]:
+    """Create a WAV file in memory for benchmarking.
+
+    Args:
+        sample_rate: Sample rate in Hz
+        num_channels: Number of audio channels
+        bits_per_sample: Bits per sample (16 or 32)
+        duration_seconds: Duration of audio in seconds
+
+    Returns:
+        Tuple of (WAV file as bytes, audio samples array)
+    """
+    num_samples = int(sample_rate * duration_seconds)
+
+    # Generate audio samples with sine wave pattern
+    dtype_map = {
+        16: np.int16,
+        32: np.int32,
+    }
+    dtype = dtype_map[bits_per_sample]
+
+    # Create audio samples with a simple sine wave pattern
+    samples = np.zeros((num_samples, num_channels), dtype=dtype)
+    for channel_idx in range(num_channels):
+        frequency = 440.0 + (channel_idx * 110.0)  # A4 and harmonics
+        t = np.linspace(0, duration_seconds, num_samples)
+        wave = np.sin(2 * np.pi * frequency * t)
+
+        if bits_per_sample == 16:
+            samples[:, channel_idx] = (wave * 32767).astype(dtype)
+        elif bits_per_sample == 32:
+            samples[:, channel_idx] = (wave * 2147483647).astype(dtype)
+
+    # Use scipy to write WAV file to memory buffer
+    wav_buffer = io.BytesIO()
+    scipy.io.wavfile.write(wav_buffer, sample_rate, samples)
+    wav_data = wav_buffer.getvalue()
+
+    return wav_data, samples
+
+
+def load_sf(wav_data: bytes) -> NDArray:
+    """Load WAV data using soundfile library.
+
+    Args:
+        wav_data: WAV file data as bytes
+
+    Returns:
+        Audio samples array as int16 numpy array
+    """
+    audio_file = io.BytesIO(wav_data)
+    data, _ = sf.read(audio_file, dtype="int16")
+    return data
+
+
+def load_spdl_audio(wav_data: bytes) -> NDArray:
+    """Load WAV data using :py:func:`spdl.io.load_audio` function.
+
+    Args:
+        wav_data: WAV file data as bytes
+
+    Returns:
+        Audio samples array as numpy array
+    """
+    return spdl.io.to_numpy(spdl.io.load_audio(wav_data, filter_desc=None))
+
+
+def load_spdl_wav(wav_data: bytes) -> NDArray:
+    """Load WAV data using :py:func:`spdl.io.load_wav` function.
+
+    Args:
+        wav_data: WAV file data as bytes
+
+    Returns:
+        Audio samples array as numpy array
+    """
+    return spdl.io.to_numpy(spdl.io.load_wav(wav_data))
+
+
+@dataclass(frozen=True)
+class BenchmarkResult:
+    """Results from a single benchmark run."""
+
+    duration: float
+    qps: float
+    ci_lower: float
+    ci_upper: float
+    num_threads: int
+    function_name: str
+    duration_seconds: float
+
+
+def benchmark(
+    name: str,
+    func: Callable[[], NDArray],
+    iterations: int,
+    num_threads: int,
+    num_sets: int,
+    duration_seconds: float,
+) -> tuple[BenchmarkResult, NDArray]:
+    """Benchmark a function using multiple threads and calculate statistics.
+
+    Executes a warmup phase followed by multiple benchmark sets to compute
+    performance metrics including mean queries per second (QPS) and 95%
+    confidence intervals using Student's t-distribution.
+
+    Args:
+        name: Descriptive name for the benchmark (used in results)
+        func: Callable function to benchmark (takes no args, returns NDArray)
+        iterations: Total number of function calls per benchmark set
+        num_threads: Number of concurrent threads for parallel execution
+        num_sets: Number of independent benchmark sets for confidence interval
+        duration_seconds: Duration of audio file being processed (for metadata)
+
+    Returns:
+        Tuple containing:
+            - BenchmarkResult with timing statistics, QPS, confidence intervals
+            - Output NDArray from the last function execution
+    """
+
+    with ThreadPoolExecutor(max_workers=num_threads) as executor:
+        # Warmup
+        futures = [executor.submit(func) for _ in range(num_threads * 30)]
+        for future in as_completed(futures):
+            output = future.result()
+
+        # Run multiple sets for confidence interval
+        qps_samples = []
+        for _ in range(num_sets):
+            t0 = time.perf_counter()
+            futures = [executor.submit(func) for _ in range(iterations)]
+            for future in as_completed(futures):
+                output = future.result()
+            elapsed = time.perf_counter() - t0
+            qps_samples.append(iterations / elapsed)
+
+    # Calculate mean and 95% confidence interval
+    qps_mean = np.mean(qps_samples)
+    qps_std = np.std(qps_samples, ddof=1)
+    confidence_level = 0.95
+    degrees_freedom = num_sets - 1
+    confidence_interval = scipy.stats.t.interval(
+        confidence_level,
+        degrees_freedom,
+        loc=qps_mean,
+        scale=qps_std / np.sqrt(num_sets),
+    )
+
+    duration = 1.0 / qps_mean
+    result = BenchmarkResult(
+        duration=duration,
+        qps=qps_mean,
+        ci_lower=float(confidence_interval[0]),
+        ci_upper=float(confidence_interval[1]),
+        num_threads=num_threads,
+        function_name=name,
+        duration_seconds=duration_seconds,
+    )
+    return result, output  # pyre-ignore[61]
+
+
+def run_benchmark_suite(
+    wav_data: bytes,
+    ref: NDArray,
+    num_threads: int,
+    duration_seconds: float,
+) -> tuple[BenchmarkResult, BenchmarkResult, BenchmarkResult]:
+    """Run benchmarks for both libraries with given parameters.
+
+    Args:
+        wav_data: WAV file data as bytes
+        ref: Reference audio array for validation
+        num_threads: Number of threads (use 1 for single-threaded)
+        duration_seconds: Duration of audio in seconds
+
+    Returns:
+        Tuple of (spdl_wav_result, spdl_audio_result, soundfile_result)
+    """
+    # load_wav is fast but the performance is unstable, so we need to run more
+    iterations = 100 * num_threads
+    num_sets = 100
+
+    spdl_wav_result, output = benchmark(
+        name="spdl.io.load_wav",
+        func=lambda: load_spdl_wav(wav_data),
+        iterations=iterations,
+        num_threads=num_threads,
+        num_sets=num_sets,
+        duration_seconds=duration_seconds,
+    )
+    np.testing.assert_array_equal(output, ref)
+
+    # others are slow but the performance is stable.
+    iterations = 10 * num_threads
+    num_sets = 5
+
+    spdl_audio_result, output = benchmark(
+        name="spdl.io.load_audio",
+        func=lambda: load_spdl_audio(wav_data),
+        iterations=iterations,
+        num_threads=num_threads,
+        num_sets=num_sets,
+        duration_seconds=duration_seconds,
+    )
+    np.testing.assert_array_equal(output, ref)
+    soundfile_result, output = benchmark(
+        name="soundfile",
+        func=lambda: load_sf(wav_data),
+        iterations=iterations,
+        num_threads=num_threads,
+        num_sets=num_sets,
+        duration_seconds=duration_seconds,
+    )
+    if output.ndim == 1:
+        output = output[:, None]
+    np.testing.assert_array_equal(output, ref)
+
+    return spdl_wav_result, spdl_audio_result, soundfile_result
+
+
+@dataclass(frozen=True)
+class BenchmarkConfig:
+    """Configuration for audio file parameters used in benchmarking.
+
+    Attributes:
+        sample_rate: Audio sample rate in Hz (e.g., 44100 for CD quality)
+        num_channels: Number of audio channels (1=mono, 2=stereo, etc.)
+        bits_per_sample: Bit depth per sample (16 or 32)
+        duration_seconds: Duration of the audio file in seconds
+    """
+
+    sample_rate: int
+    num_channels: int
+    bits_per_sample: int
+    duration_seconds: float
+
+
+def plot_benchmark_results(
+    results: list[BenchmarkResult], output_file: str = "benchmark_results.png"
+) -> None:
+    """Plot benchmark results and save to file.
+
+    Args:
+        results: List of BenchmarkResult objects containing benchmark data
+        output_file: Output file path for the saved plot
+    """
+    matplotlib.use("Agg")  # Use non-interactive backend
+
+    # Convert results to DataFrame for easier plotting
+    data = [
+        {
+            "num_threads": r.num_threads,
+            "qps": r.qps,
+            "ci_lower": r.ci_lower,
+            "ci_upper": r.ci_upper,
+            "function": r.function_name,
+            "duration": f"{r.duration_seconds}s",
+        }
+        for r in results
+    ]
+    df = pd.DataFrame(data)
+
+    # Set seaborn style
+    sns.set_theme(style="whitegrid")
+
+    # Create figure
+    _, ax = plt.subplots(figsize=(12, 6))
+
+    # Create a combined label for function and duration
+    df["label"] = df["function"] + " (" + df["duration"] + ")"
+
+    # Plot lines for each function and duration combination
+    for label in df["label"].unique():
+        subset = df[df["label"] == label].sort_values("num_threads")
+        line = ax.plot(
+            subset["num_threads"],
+            subset["qps"],
+            marker="o",
+            label=label,
+            linewidth=2,
+        )
+
+        # Add confidence interval as shaded region
+        ax.fill_between(
+            subset["num_threads"],
+            subset["ci_lower"],
+            subset["ci_upper"],
+            alpha=0.2,
+            color=line[0].get_color(),
+        )
+
+    ax.set_xlabel("Number of Threads", fontsize=12)
+    ax.set_ylabel("QPS (Queries Per Second)", fontsize=12)
+    ax.set_title("WAV Loading Performance Benchmark", fontsize=14, fontweight="bold")
+    ax.legend(title="Function", bbox_to_anchor=(1.05, 1), loc="upper left")
+    ax.grid(True, alpha=0.3)
+
+    plt.tight_layout()
+    plt.savefig(output_file, dpi=300, bbox_inches="tight")
+    print(f"Plot saved to {output_file}")
+
+
+def _parse_args() -> argparse.Namespace:
+    """Parse command line arguments for the benchmark script.
+
+    Returns:
+        Parsed command line arguments
+    """
+    parser = argparse.ArgumentParser(description="Benchmark WAV loading performance")
+    parser.add_argument(
+        "--plot",
+        action="store_true",
+        help="Generate and save a plot of the benchmark results",
+    )
+    parser.add_argument(
+        "--output",
+        type=str,
+        default="benchmark_results.png",
+        help="Output file path for the plot (default: benchmark_results.png)",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    """Run comprehensive benchmark suite for WAV loading performance.
+
+    Benchmarks multiple configurations of audio files with different durations,
+    comparing spdl.io.load_wav, spdl.io.load_audio, and soundfile libraries
+    across various thread counts (1, 2, 4, 8, 16).
+    """
+    args = _parse_args()
+
+    benchmark_configs = [
+        # (sample_rate, num_channels, bits_per_sample, duration_seconds, iterations)
+        # BenchmarkConfig(8000, 1, 16, 1.0),  # Low quality mono
+        # BenchmarkConfig(16000, 1, 16, 1.0),  # Speech quality mono
+        # BenchmarkConfig(48000, 2, 16, 1.0),  # High quality stereo
+        # BenchmarkConfig(48000, 8, 16, 1.0),  # Multi-channel audio
+        BenchmarkConfig(44100, 2, 16, 1.0),  # CD quality stereo
+        BenchmarkConfig(44100, 2, 16, 10.0),  #
+        BenchmarkConfig(44100, 2, 16, 60.0),  #
+        # (44100, 2, 24, 1.0, 100),  # 24-bit audio
+    ]
+
+    results: list[BenchmarkResult] = []
+
+    for cfg in benchmark_configs:
+        print(cfg)
+        wav_data, ref = create_wav_data(
+            sample_rate=cfg.sample_rate,
+            num_channels=cfg.num_channels,
+            bits_per_sample=cfg.bits_per_sample,
+            duration_seconds=cfg.duration_seconds,
+        )
+        print(
+            f"Threads,"
+            f"SPDL WAV QPS ({cfg.duration_seconds} sec),CI Lower, CI Upper,"
+            f"SPDL Audio QPS ({cfg.duration_seconds} sec),CI Lower, CI Upper,"
+            f"soundfile QPS ({cfg.duration_seconds} sec),CI Lower, CI Upper"
+        )
+        for num_threads in [1, 2, 4, 8, 16]:
+            spdl_wav_result, spdl_audio_result, soundfile_result = run_benchmark_suite(
+                wav_data,
+                ref,
+                num_threads=num_threads,
+                duration_seconds=cfg.duration_seconds,
+            )
+            results.extend([spdl_wav_result, spdl_audio_result, soundfile_result])
+            print(
+                f"{num_threads},"
+                f"{spdl_wav_result.qps:.2f},{spdl_wav_result.ci_lower:.2f},{spdl_wav_result.ci_upper:.2f},"
+                f"{spdl_audio_result.qps:.2f},{spdl_audio_result.ci_lower:.2f},{spdl_audio_result.ci_upper:.2f},"
+                f"{soundfile_result.qps:.2f},{soundfile_result.ci_lower:.2f},{soundfile_result.ci_upper:.2f}"
+            )
+
+    if args.plot:
+        plot_benchmark_results(results, args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/spdl/io/__init__.py
+++ b/src/spdl/io/__init__.py
@@ -103,9 +103,13 @@ from ._preprocessing import (
     get_video_filter_desc,
 )
 from ._transfer import transfer_tensor
+from ._wav import (
+    load_wav,
+)
 
 __all__ = [
     # HIGH LEVEL API
+    "load_wav",
     "load_audio",
     "load_video",
     "load_image",
@@ -195,6 +199,7 @@ __all__ = [
     "NpzFile",
     "load_npz",
     "load_npy",
+    # WAV AUDIO
 ]
 
 

--- a/src/spdl/io/_wav.py
+++ b/src/spdl/io/_wav.py
@@ -1,0 +1,87 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-unsafe
+
+"""WAV audio processing utilities."""
+
+# Importing `spdl.io.lib` instead of `spdl.io.lilb._archive`
+# so as to delay the import of C++ extension module
+from . import lib as _libspdl
+
+__all__ = [
+    "load_wav",
+]
+
+
+def __dir__():
+    return __all__
+
+
+class WAVArrayInterface:
+    """Wrapper class that exposes WAV data through the Array Interface Protocol.
+
+    This class holds the array interface dictionary returned by the C++ binding
+    and exposes it through the __array_interface__ property, making it compatible
+    with NumPy and other libraries that support the array interface protocol.
+    """
+
+    def __init__(self, array_interface_dict: dict) -> None:
+        """Initialize with an array interface dictionary.
+
+        Args:
+            array_interface_dict: Dictionary containing array interface metadata
+                from the C++ binding, including version, shape, typestr, data, and owner.
+        """
+        self._array_interface = array_interface_dict
+
+    @property
+    def __array_interface__(self) -> dict:
+        """Return the array interface dictionary for NumPy compatibility.
+
+        Returns:
+            Dictionary containing array interface metadata:
+                - version: Protocol version (3)
+                - shape: Tuple of array dimensions
+                - typestr: Data type string
+                - data: Tuple of (data_pointer, read_only_flag)
+                - owner: Object owning the data buffer
+        """
+        return self._array_interface
+
+
+def load_wav(
+    data: bytes,
+    time_offset_seconds: float | None = None,
+    duration_seconds: float | None = None,
+) -> WAVArrayInterface:
+    """Extract audio samples from WAV data.
+
+    Args:
+        data: Binary WAV data as bytes
+        time_offset_seconds: Optional starting time in seconds (default: 0.0)
+        duration_seconds: Optional duration in seconds (default: until end)
+
+    Returns:
+        WAVArrayInterface: Object exposing audio samples through the Array Interface Protocol.
+            The object can be consumed by NumPy (np.asarray) and other libraries supporting
+            the array interface. The underlying array has shape (num_samples, num_channels).
+            The dtype depends on bits_per_sample:
+
+               - 8 bits: uint8
+               - 16 bits: int16
+               - 32 bits: int32 or float32
+               - 64 bits: float64
+
+    Raises:
+        ValueError: If the WAV data is invalid or time range is out of bounds.
+    """
+    array_interface_dict = _libspdl._wav.load_wav(
+        data,
+        time_offset_seconds=time_offset_seconds,
+        duration_seconds=duration_seconds,
+    )
+    return WAVArrayInterface(array_interface_dict)

--- a/src/spdl/io/lib/CMakeLists.txt
+++ b/src/spdl/io/lib/CMakeLists.txt
@@ -7,3 +7,4 @@
 add_subdirectory(core)
 add_subdirectory(cuda)
 add_subdirectory(archive)
+add_subdirectory(wav)

--- a/src/spdl/io/lib/__init__.py
+++ b/src/spdl/io/lib/__init__.py
@@ -25,7 +25,8 @@ _LG: logging.Logger = logging.getLogger(__name__)
 __all__ = [
     "_libspdl",
     "_libspdl_cuda",
-    "_zip",
+    "_archive",
+    "_wav",
 ]
 
 
@@ -48,6 +49,11 @@ def __getattr__(name: str) -> ModuleType:
         import spdl.io.lib._archive  # pyre-ignore: [21]
 
         return spdl.io.lib._archive
+
+    if name == "_wav":
+        import spdl.io.lib._wav  # pyre-ignore: [21]
+
+        return spdl.io.lib._wav
 
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 

--- a/src/spdl/io/lib/wav/CMakeLists.txt
+++ b/src/spdl/io/lib/wav/CMakeLists.txt
@@ -1,0 +1,35 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+message(STATUS "########################################")
+message(STATUS "# Configuring SPDL Python binding (archive)")
+message(STATUS "########################################")
+
+set(name _wav)
+message(STATUS "Building ${name}")
+
+set(srcs register.cpp wav_utils.cpp)
+set(nb_options
+  STABLE_ABI
+  NB_STATIC
+  LTO
+  NB_SUPPRESS_WARNINGS
+  )
+
+if (NOT SPDL_IS_GIL_ENABLED)
+  list(APPEND nb_options FREE_THREADED)
+endif()
+
+nanobind_add_module(${name} ${nb_options} ${srcs})
+target_link_libraries(${name} PRIVATE "${deps}")
+target_include_directories(${name} PRIVATE "${Python_INCLUDE_DIR}")
+target_compile_options(${name} PRIVATE "${SPDL_CXX_CPU_COMPILE_FLAGS}")
+
+install(
+  TARGETS ${name}
+  LIBRARY DESTINATION "${SPDL_PYTHON_BINDING_INSTALL_PREFIX}/lib"
+  RUNTIME DESTINATION "${SPDL_PYTHON_BINDING_INSTALL_PREFIX}/lib"
+  )

--- a/src/spdl/io/lib/wav/register.cpp
+++ b/src/spdl/io/lib/wav/register.cpp
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "wav_utils.h"
+
+#include <string>
+
+#include <nanobind/nanobind.h>
+#include <nanobind/ndarray.h>
+#include <nanobind/stl/optional.h>
+
+namespace nb = nanobind;
+
+namespace spdl::core {
+namespace {
+NB_MODULE(_wav, m) {
+  m.def(
+      "load_wav",
+      [](const nb::bytes& data,
+         std::optional<double> time_offset_seconds = std::nullopt,
+         std::optional<double> duration_seconds = std::nullopt) -> nb::dict {
+        const char* p = data.c_str();
+        size_t s = data.size();
+        WAVHeader header;
+        size_t num_samples;
+        std::string_view view;
+        {
+          nb::gil_scoped_release _{};
+          std::string_view d{p, s};
+          header = parse_wav_header(d);
+          view = extract_wav_samples(d, time_offset_seconds, duration_seconds);
+          num_samples = view.size() / header.block_align;
+        }
+
+        nb::dict array_interface;
+        array_interface["version"] = 3;
+        array_interface["shape"] =
+            nb::make_tuple(num_samples, header.num_channels);
+
+        nb::str typestr = [&header]() -> nb::str {
+          switch (header.bits_per_sample) {
+            case 8:
+              return nb::str{"|u1"};
+            case 16:
+              return nb::str{"<i2"};
+            case 32: {
+              return nb::str{header.audio_format == 3 ? "<f4" : "<i4"};
+            }
+            case 64:
+              return nb::str{"<f8"};
+            default:
+              throw std::domain_error(
+                  "Unsupported bits_per_sample: " +
+                  std::to_string(header.bits_per_sample));
+          }
+        }();
+        array_interface["typestr"] = typestr;
+        array_interface["data"] =
+            nb::make_tuple(reinterpret_cast<uintptr_t>(view.data()), false);
+        array_interface["owner"] = data;
+
+        return array_interface;
+      },
+      nb::arg("wav_data"),
+      nb::kw_only(),
+      nb::arg("time_offset_seconds") = nb::none(),
+      nb::arg("duration_seconds") = nb::none(),
+      "Extract audio samples from WAV data.\n\n"
+      "Args:\n"
+      "    wav_data: Binary WAV data as bytes or string\n"
+      "    time_offset_seconds: Optional starting time in seconds (default: 0.0)\n"
+      "    duration_seconds: Optional duration in seconds (default: until end)\n\n"
+      "Returns:\n"
+      "    dict: Dictionary compliant with Array Interface Protocol containing:\n"
+      "        - version: Protocol version (3)\n"
+      "        - shape: Tuple of (num_samples, num_channels)\n"
+      "        - typestr: Data type string\n"
+      "        - data: Tuple of (data_pointer, read_only_flag)\n"
+      "        - owner: Object owning the data buffer\n\n"
+      "Raises:\n"
+      "    WAVParseError: If the WAV data is invalid or time range is out of bounds");
+}
+} // namespace
+} // namespace spdl::core

--- a/src/spdl/io/lib/wav/register.h
+++ b/src/spdl/io/lib/wav/register.h
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <nanobind/nanobind.h>
+
+namespace spdl::core {
+void register_wav_utils(nanobind::module_&);
+}

--- a/src/spdl/io/lib/wav/wav_utils.cpp
+++ b/src/spdl/io/lib/wav/wav_utils.cpp
@@ -1,0 +1,195 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "wav_utils.h"
+
+#include <algorithm>
+#include <cstring>
+#include <stdexcept>
+
+namespace spdl::core {
+
+namespace {
+
+template <typename T>
+T read_little_endian(const char* data) {
+  T value;
+  std::memcpy(&value, data, sizeof(T));
+  return value;
+}
+
+bool check_fourcc(std::string_view data, size_t offset, const char* expected) {
+  if (offset + 4 > data.size()) {
+    return false;
+  }
+  return std::memcmp(data.data() + offset, expected, 4) == 0;
+}
+
+} // namespace
+
+WAVHeader parse_wav_header(std::string_view wav_data) {
+  if (wav_data.size() < 44) {
+    throw std::domain_error("WAV data too small to contain valid header");
+  }
+
+  // Verify RIFF header
+  if (!check_fourcc(wav_data, 0, "RIFF")) {
+    throw std::domain_error("Missing RIFF header");
+  }
+
+  // Verify WAVE format
+  if (!check_fourcc(wav_data, 8, "WAVE")) {
+    throw std::domain_error("Missing WAVE format identifier");
+  }
+
+  // Find and parse fmt chunk
+  size_t offset = 12;
+  bool found_fmt = false;
+  WAVHeader header{};
+
+  while (offset + 8 <= wav_data.size()) {
+    if (check_fourcc(wav_data, offset, "fmt ")) {
+      uint32_t fmt_size =
+          read_little_endian<uint32_t>(wav_data.data() + offset + 4);
+
+      if (offset + 8 + fmt_size > wav_data.size()) {
+        throw std::domain_error("fmt chunk extends beyond file size");
+      }
+
+      if (fmt_size < 16) {
+        throw std::domain_error("fmt chunk too small");
+      }
+
+      const char* fmt_data = wav_data.data() + offset + 8;
+      header.audio_format = read_little_endian<uint16_t>(fmt_data);
+      header.num_channels = read_little_endian<uint16_t>(fmt_data + 2);
+      header.sample_rate = read_little_endian<uint32_t>(fmt_data + 4);
+      header.byte_rate = read_little_endian<uint32_t>(fmt_data + 8);
+      header.block_align = read_little_endian<uint16_t>(fmt_data + 12);
+      header.bits_per_sample = read_little_endian<uint16_t>(fmt_data + 14);
+
+      found_fmt = true;
+      offset += 8 + fmt_size;
+      break;
+    }
+    offset += 4;
+  }
+
+  if (!found_fmt) {
+    throw std::domain_error("fmt chunk not found");
+  }
+
+  // Find data chunk
+  while (offset + 8 <= wav_data.size()) {
+    if (check_fourcc(wav_data, offset, "data")) {
+      header.data_size =
+          read_little_endian<uint32_t>(wav_data.data() + offset + 4);
+      return header;
+    }
+
+    // Skip this chunk
+    if (offset + 8 <= wav_data.size()) {
+      uint32_t chunk_size =
+          read_little_endian<uint32_t>(wav_data.data() + offset + 4);
+      offset += 8 + chunk_size;
+    } else {
+      break;
+    }
+  }
+
+  throw std::domain_error("data chunk not found");
+}
+
+std::string_view extract_wav_samples(
+    std::string_view wav_data,
+    std::optional<double> time_offset_seconds,
+    std::optional<double> duration_seconds) {
+  // Parse the WAV header
+  WAVHeader header = parse_wav_header(wav_data);
+
+  // Validate header
+  if (header.num_channels == 0) {
+    throw std::domain_error("Invalid number of channels: 0");
+  }
+  if (header.sample_rate == 0) {
+    throw std::domain_error("Invalid sample rate: 0");
+  }
+  if (header.block_align == 0) {
+    throw std::domain_error("Invalid block align: 0");
+  }
+
+  // Find the start of the data chunk
+  size_t offset = 12;
+  size_t data_offset = 0;
+
+  while (offset + 8 <= wav_data.size()) {
+    if (check_fourcc(wav_data, offset, "data")) {
+      data_offset = offset + 8;
+      break;
+    }
+
+    // Skip this chunk
+    uint32_t chunk_size =
+        read_little_endian<uint32_t>(wav_data.data() + offset + 4);
+    offset += 8 + chunk_size;
+  }
+
+  if (data_offset == 0) {
+    throw std::domain_error("data chunk not found");
+  }
+
+  // Calculate available data size
+  size_t available_data_size = std::min(
+      static_cast<size_t>(header.data_size), wav_data.size() - data_offset);
+
+  // If no time window specified, return entire waveform
+  if (!time_offset_seconds && !duration_seconds) {
+    return wav_data.substr(data_offset, available_data_size);
+  }
+
+  // Calculate byte offsets for time window
+  double offset_sec = time_offset_seconds.value_or(0.0);
+  if (offset_sec < 0.0) {
+    throw std::domain_error("Time offset cannot be negative");
+  }
+
+  // Calculate starting sample and byte offset
+  uint64_t start_sample =
+      static_cast<uint64_t>(offset_sec * header.sample_rate);
+  uint64_t start_byte = start_sample * header.block_align;
+
+  if (start_byte >= available_data_size) {
+    throw std::domain_error("Time offset exceeds audio duration");
+  }
+
+  // Calculate ending byte offset
+  uint64_t end_byte;
+  if (duration_seconds) {
+    double dur_sec = *duration_seconds;
+    if (dur_sec < 0.0) {
+      throw std::domain_error("Duration cannot be negative");
+    }
+
+    uint64_t num_samples = static_cast<uint64_t>(dur_sec * header.sample_rate);
+    uint64_t byte_length = num_samples * header.block_align;
+    end_byte = start_byte + byte_length;
+  } else {
+    end_byte = available_data_size;
+  }
+
+  end_byte = std::min(end_byte, static_cast<uint64_t>(available_data_size));
+
+  // Ensure we're aligned to block boundaries
+  start_byte = (start_byte / header.block_align) * header.block_align;
+  end_byte = (end_byte / header.block_align) * header.block_align;
+
+  size_t length = static_cast<size_t>(end_byte - start_byte);
+  return wav_data.substr(data_offset + start_byte, length);
+}
+
+} // namespace spdl::core

--- a/src/spdl/io/lib/wav/wav_utils.h
+++ b/src/spdl/io/lib/wav/wav_utils.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <optional>
+#include <string_view>
+
+namespace spdl::core {
+
+struct WAVHeader {
+  uint16_t audio_format;
+  uint16_t num_channels;
+  uint32_t sample_rate;
+  uint32_t byte_rate;
+  uint16_t block_align;
+  uint16_t bits_per_sample;
+  uint32_t data_size;
+};
+
+std::string_view extract_wav_samples(
+    std::string_view wav_data,
+    std::optional<double> time_offset_seconds = std::nullopt,
+    std::optional<double> duration_seconds = std::nullopt);
+
+WAVHeader parse_wav_header(std::string_view wav_data);
+
+} // namespace spdl::core

--- a/tests/spdl_unittest/io/wav_test.py
+++ b/tests/spdl_unittest/io/wav_test.py
@@ -1,0 +1,245 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-unsafe
+
+import io
+import unittest
+import wave
+
+import numpy as np
+import spdl.io
+from parameterized import parameterized
+
+
+def create_wav_data(
+    sample_rate: int = 8000,
+    num_channels: int = 2,
+    bits_per_sample: int = 16,
+    num_samples: int = 8000,
+) -> "tuple[bytes, np.ndarray]":
+    """Create a simple WAV file in memory for testing.
+
+    Returns:
+        tuple: (wav_data, reference_waveform)
+            - wav_data: Complete WAV file as bytes
+            - reference_waveform: numpy array with shape (num_samples, num_channels)
+                                  containing the expected audio samples
+    """
+
+    dtype_map = {
+        8: np.uint8,
+        16: np.int16,
+        32: np.int32,
+        64: np.float64,
+    }
+    dtype = dtype_map[bits_per_sample]
+
+    reference = np.zeros((num_samples, num_channels), dtype=dtype)
+    if bits_per_sample == 64:
+        for channel_idx in range(num_channels):
+            reference[:, channel_idx] = np.linspace(-1.0, 1.0, num_samples, dtype=dtype)
+    else:
+        # For integer types, use linspace to cover full dtype range
+        dtype_info = np.iinfo(dtype)
+        for channel_idx in range(num_channels):
+            reference[:, channel_idx] = np.linspace(
+                dtype_info.min, dtype_info.max, num_samples, dtype=dtype
+            )
+
+    wav_buffer = io.BytesIO()
+    with wave.open(wav_buffer, "wb") as wav_file:
+        wav_file.setnchannels(num_channels)
+        wav_file.setsampwidth(bits_per_sample // 8)
+        wav_file.setframerate(sample_rate)
+        wav_file.writeframes(reference.tobytes())
+
+    wav_data = wav_buffer.getvalue()
+    return wav_data, reference
+
+
+class WAVUtilsTest(unittest.TestCase):
+    def test_extract_full_waveform(self):
+        wav_data, reference = create_wav_data(num_samples=100)
+
+        wav_array_interface = spdl.io.load_wav(wav_data)
+        samples = spdl.io.to_numpy(wav_array_interface)
+
+        # Validate shape and dtype
+        self.assertEqual(samples.shape, (100, 2))
+        self.assertEqual(samples.dtype, np.int16)
+
+        # Validate against reference waveform
+        np.testing.assert_array_equal(samples, reference)
+
+    def test_extract_with_time_offset(self):
+        sample_rate = 8000
+        num_channels = 2
+        bits_per_sample = 16
+        duration_seconds = 2.0
+        num_samples = int(sample_rate * duration_seconds)
+
+        wav_data, reference = create_wav_data(
+            sample_rate=sample_rate,
+            num_channels=num_channels,
+            bits_per_sample=bits_per_sample,
+            num_samples=num_samples,
+        )
+
+        time_offset = 0.5
+        wav_array_interface = spdl.io.load_wav(
+            wav_data, time_offset_seconds=time_offset
+        )
+        samples = spdl.io.to_numpy(wav_array_interface)
+
+        # Calculate expected slice
+        start_sample = int(time_offset * sample_rate)
+        expected_reference = reference[start_sample:]
+
+        # Validate shape and dtype
+        self.assertEqual(samples.shape, expected_reference.shape)
+        self.assertEqual(samples.dtype, np.int16)
+
+        # Validate against reference waveform
+        np.testing.assert_array_equal(samples, expected_reference)
+
+    def test_extract_with_offset_and_duration(self):
+        sample_rate = 8000
+        num_channels = 2
+        bits_per_sample = 16
+        total_duration = 3.0
+        num_samples = int(sample_rate * total_duration)
+
+        wav_data, reference = create_wav_data(
+            sample_rate=sample_rate,
+            num_channels=num_channels,
+            bits_per_sample=bits_per_sample,
+            num_samples=num_samples,
+        )
+
+        time_offset = 1.0
+        duration = 1.0
+        wav_array_interface = spdl.io.load_wav(
+            wav_data, time_offset_seconds=time_offset, duration_seconds=duration
+        )
+        samples = spdl.io.to_numpy(wav_array_interface)
+
+        # Calculate expected slice
+        start_sample = int(time_offset * sample_rate)
+        end_sample = start_sample + int(duration * sample_rate)
+        expected_reference = reference[start_sample:end_sample]
+
+        # Validate shape and dtype
+        self.assertEqual(samples.shape, expected_reference.shape)
+        self.assertEqual(samples.dtype, np.int16)
+
+        # Validate against reference waveform
+        np.testing.assert_array_equal(samples, expected_reference)
+
+    def test_negative_time_offset(self):
+        wav_data, _ = create_wav_data(num_samples=8000)
+
+        with self.assertRaises(ValueError):
+            spdl.io.load_wav(wav_data, time_offset_seconds=-1.0)
+
+    def test_negative_duration(self):
+        wav_data, _ = create_wav_data(num_samples=8000)
+
+        with self.assertRaises(ValueError):
+            spdl.io.load_wav(wav_data, duration_seconds=-1.0)
+
+    def test_time_offset_exceeds_duration(self):
+        wav_data, _ = create_wav_data(sample_rate=8000, num_samples=8000)
+
+        with self.assertRaises(ValueError):
+            spdl.io.load_wav(wav_data, time_offset_seconds=10.0)
+
+    def test_load_wav_returns_numpy_array(self):
+        wav_data, reference = create_wav_data(
+            sample_rate=8000, num_channels=2, bits_per_sample=16, num_samples=100
+        )
+
+        wav_array_interface = spdl.io.load_wav(wav_data)
+        samples = spdl.io.to_numpy(wav_array_interface)
+
+        self.assertEqual(samples.shape, (100, 2))
+        self.assertEqual(samples.dtype, np.int16)
+        self.assertFalse(samples.flags["OWNDATA"])
+
+        # Validate against reference waveform
+        np.testing.assert_array_equal(samples, reference)
+
+    @parameterized.expand(
+        [
+            (1,),
+            (2,),
+            (3,),
+            (4,),
+            (8,),
+            (16,),
+            (32,),
+        ]
+    )
+    def test_load_wav_multi_channel(self, num_channels):
+        sample_rate = 8000
+        num_samples = 1000
+
+        wav_data, reference = create_wav_data(
+            sample_rate=sample_rate,
+            num_channels=num_channels,
+            bits_per_sample=16,
+            num_samples=num_samples,
+        )
+
+        # Test sample extraction
+        wav_array_interface = spdl.io.load_wav(wav_data)
+        samples = spdl.io.to_numpy(wav_array_interface)
+        self.assertEqual(samples.shape, (num_samples, num_channels))
+        self.assertEqual(samples.dtype, np.int16)
+        self.assertFalse(samples.flags["OWNDATA"])
+
+        # Validate against reference waveform
+        np.testing.assert_array_equal(samples, reference)
+
+    @parameterized.expand(
+        [
+            (3,),
+            (4,),
+            (8,),
+            (16,),
+            (32,),
+        ]
+    )
+    def test_load_wav_multi_channel_with_time_window(self, num_channels):
+        sample_rate = 8000
+        total_duration = 2.0
+        num_samples = int(sample_rate * total_duration)
+
+        wav_data, reference = create_wav_data(
+            sample_rate=sample_rate,
+            num_channels=num_channels,
+            bits_per_sample=16,
+            num_samples=num_samples,
+        )
+
+        # Extract 1 second starting at 0.5 seconds
+        time_offset = 0.5
+        duration = 1.0
+        wav_array_interface = spdl.io.load_wav(
+            wav_data, time_offset_seconds=time_offset, duration_seconds=duration
+        )
+        samples = spdl.io.to_numpy(wav_array_interface)
+
+        # Calculate expected slice
+        start_sample = int(time_offset * sample_rate)
+        end_sample = start_sample + int(duration * sample_rate)
+        expected_reference = reference[start_sample:end_sample]
+
+        self.assertEqual(samples.shape, expected_reference.shape)
+        self.assertEqual(samples.dtype, np.int16)
+
+        # Validate against reference waveform
+        np.testing.assert_array_equal(samples, expected_reference)


### PR DESCRIPTION
Summary:
This diff adds `spdl.io.load_wav` function, which interprets the WAV data in byte string as a NumPy array without making a copy.

It is similar to `spdl.io.load_npy` function which [yields faster performance but does not scale with multi-threading due to the GIL](https://www.internalfb.com/intern/staticdocs/spdl/case_studies/data_format.html).


<img width="3528" height="1755" alt="benchmark_results" src="https://github.com/user-attachments/assets/c2efda16-3d77-4584-ab4d-b756d5fba276" />
<img width="3528" height="1755" alt="benchmark_results png2" src="https://github.com/user-attachments/assets/b2055b49-f640-401d-afba-85efb2c4282e" />



Differential Revision: D84358793


