### PR TITLE
Increase test time out

### DIFF
--- a/tests/spdl_unittest/dataloader/iterator_test.py
+++ b/tests/spdl_unittest/dataloader/iterator_test.py
@@ -28,7 +28,7 @@ from spdl.source.utils import (
 )
 
 
-def iterate_in_subprocess(fn, *, timeout=5, **kwargs):
+def iterate_in_subprocess(fn, *, timeout=10, **kwargs):
     return _iterate_in_subprocess(fn, timeout=timeout, **kwargs)
 
 


### PR DESCRIPTION
On GitHub, `test_iterate_in_subprocess_buffer_size_64` fails sporadically, on Windows and Linux (both aarch64 and x86_64).

```
>   assert int(f.read()) == 9
           ^^^^^^^^^^^^^
E   ValueError: invalid literal for int() with base 10: ''
```

As far as I recall, the value is always empty when test fails, so perhaps it's timeout.

This commit increases the timeout to 10 seconds.