### PR TITLE
Make FailCounter fail only on stages with actual failure

### DIFF
--- a/src/spdl/pipeline/_components/_pipe.py
+++ b/src/spdl/pipeline/_components/_pipe.py
@@ -57,10 +57,15 @@ class _FailCounter(TaskHook):
         self._max_stage_failures = max_stage_failures
 
         self._num_stage_failures: int = 0
+        self._exeeded: bool = False
 
     def _increment(self) -> None:
         self.__class__._num_global_failures += 1
         self._num_stage_failures += 1
+
+        if (threshold := self.max_failures) >= 0:
+            if self.num_failures >= threshold:
+                self._exeeded = True
 
     @property
     def max_failures(self) -> int:
@@ -79,9 +84,7 @@ class _FailCounter(TaskHook):
         )
 
     def too_many_failures(self) -> bool:
-        if (threshold := self.max_failures) >= 0:
-            return self.num_failures >= threshold
-        return False
+        return self._exeeded
 
     @asynccontextmanager
     async def task_hook(self) -> AsyncIterator[None]:


### PR DESCRIPTION
Currently, when a Pipeline fails due to the number of failures exceeding the allowed value, all the pipeline stages fail.

The error message thrown at the end of `pipeline.auto_stop` reports that all the stages exceeded the number of allowed failures, which is not correct.

This commit fixes the behavior by letting only the stages that actually encountered an error (and the error exceeded the threshold) fails, and the other stages are either cancelled or continued based on whether it's up/downstream to the failed node.

SPDL pipeline has a well-defined semantic around failure and cancellation. When a stage fails, then only the stages upstream to it are cancelled, and the stages downstream are continued until EOF.

The previous implementation disabled this semantic, but with the new fix, this is improved.

Example:

```python
def fail_fn(_: int) -> int:
    raise ValueError(f"Stage 2 failed.")

pipeline = (
    PipelineBuilder()
    .add_source(range(10))
    .pipe(lambda x: x, name="stage1", concurrency=1)
    .pipe(fail_fn, name="stage2", concurrency=1)
    .pipe(lambda x: x, name="stage3", concurrency=1)
    .add_sink(buffer_size=3)
    .build(num_threads=1, max_failures=2)
)

with pipeline.auto_stop():
    for _ in pipeline:
        pass
```

Before

All the stages are reported as failure. (incorrect)
```
spdl/pipeline/_node.py", line 318, in _run_pipeline_coroutines
    raise PipelineFailure(errs)
spdl.pipeline._node.PipelineFailure: 0:1:stage1:The pipeline stage (0:1:stage1) failed 2 times, which exceeds the threshold (2)., 0:2:stage2:The pipeline stage (0:2:stage2) failed 2 times, which exceeds the threshold (2)., 0:3:stage3:The pipeline stage (0:3:stage3) failed 2 times, which exceeds the threshold (2).
```

After

Only the failing stage is reported in the error message. (correct)
```
spdl/pipeline/_node.py", line 318, in _run_pipeline_coroutines
    raise PipelineFailure(errs)
spdl.pipeline._node.PipelineFailure: 0:2:stage2:The pipeline stage (0:2:stage2) failed 2 times, which exceeds the threshold (2).
```