### PR TITLE
Fix the export path of Profile results

### DIFF
--- a/examples/pipeline_profiling.py
+++ b/examples/pipeline_profiling.py
@@ -38,6 +38,7 @@ concurrency, and it degrades as more threads are added. (``"op_with_contention"`
 import argparse
 import logging
 import time
+from collections.abc import Sequence
 from pathlib import Path
 
 from spdl.pipeline import profile_pipeline, ProfileResult
@@ -169,7 +170,7 @@ def print_profile_result(result: ProfileResult) -> None:
 
 
 def plot_profile_results(
-    results: list[ProfileResult], output_path: Path | None = None
+    results: Sequence[ProfileResult], output_path: Path | None = None
 ) -> None:
     """Plot profiling results showing QPS vs concurrency for each stage.
 
@@ -207,7 +208,7 @@ def plot_profile_results(
         plt.show()
 
 
-def run_profiling_example(num_inputs: int = 500) -> list[ProfileResult]:
+def run_profiling_example(num_inputs: int = 500) -> Sequence[ProfileResult]:
     """Run the profiling example.
 
     Args:

--- a/src/spdl/pipeline/__init__.py
+++ b/src/spdl/pipeline/__init__.py
@@ -13,7 +13,7 @@ from ._builder import PipelineBuilder, run_pipeline_in_subprocess
 from ._hook import TaskHook, TaskPerfStats, TaskStatsHook
 from ._node import PipelineFailure
 from ._pipeline import Pipeline
-from ._profile import profile_pipeline, ProfileResult
+from ._profile import profile_pipeline, ProfileHook, ProfileResult
 from ._queue import AsyncQueue, QueuePerfStats, StatsQueue
 from ._utils import cache_iterator, create_task, iterate_in_subprocess
 
@@ -21,6 +21,7 @@ __all__ = [
     "build_pipeline",
     "profile_pipeline",
     "ProfileResult",
+    "ProfileHook",
     "Pipeline",
     "PipelineBuilder",
     "PipelineFailure",

--- a/src/spdl/pipeline/_profile.py
+++ b/src/spdl/pipeline/_profile.py
@@ -9,7 +9,7 @@ import os
 import random
 import time
 from abc import ABC, abstractmethod
-from collections.abc import Callable, Iterator
+from collections.abc import Callable, Iterator, Sequence
 from contextlib import contextmanager
 from dataclasses import dataclass
 from typing import Any, TypeVar
@@ -30,6 +30,7 @@ from .defs._defs import (
 
 __all__ = [
     "profile_pipeline",
+    "ProfileHook",
     "ProfileResult",
     "_build_pipeline_diagnostic_mode",
 ]
@@ -130,20 +131,19 @@ class _ProfileStats:
 
 @dataclass
 class ProfileResult:
-    """A data class contains profiling result, returned by :py:func:`profile_pipeline`."""
+    """ProfileResult()
+
+    A data class contains profiling result, returned by :py:func:`profile_pipeline`."""
 
     name: str
     """The name of the pipe stage."""
 
-    stats: list["_ProfileStats"]
+    stats: Sequence["_ProfileStats"]
     """Dataclass objects for each concurrency level tested, where each stat includes:
 
       - ``concurrency``: The concurrency level used for this benchmark.
       - ``qps``: The number of items the stage processed per second.
       - ``occupancy_rate``: The percentage of time the queue was occupied (0.0 to 1.0)."""
-
-
-_ProfileResult = ProfileResult  # temp
 
 
 def no_op(_: ProfileResult) -> None:
@@ -241,7 +241,7 @@ def profile_pipeline(
     *,
     callback: Callable[[ProfileResult], None] | None = None,
     hook: ProfileHook | None = None,
-) -> list[ProfileResult]:
+) -> Sequence[ProfileResult]:
     """**[Experimental]** Profile pipeline by running pipes separately
     while changing the concurrency, measuring performance and logging results.
 


### PR DESCRIPTION
Also tweak the signature around list just for the sake of doc rendering, as Sphinx does not handle `list[T]` for whatever reason.
`Sequence[T]` renders fine.

```
list[ProfileResult] -> list[spdl._profile.ProfileResult]
Sequence[ProfileResult] -> Sequence[ProfileResult]
```