### PR TITLE
Introduce config system to change default queue/hook/callbacks

### DIFF
--- a/src/spdl/pipeline/_config.py
+++ b/src/spdl/pipeline/_config.py
@@ -7,9 +7,26 @@
 import logging
 import os
 
+from ._hook import get_default_hook_class, set_default_hook_class
+from ._profile import (
+    get_default_profile_callback,
+    get_default_profile_hook,
+    set_default_profile_callback,
+    set_default_profile_hook,
+)
+from ._queue import get_default_queue_class, set_default_queue_class
+
 __all__ = [
     "_diagnostic_mode_enabled",
     "_diagnostic_mode_num_sources",
+    "set_default_hook_class",
+    "get_default_hook_class",
+    "set_default_queue_class",
+    "get_default_queue_class",
+    "set_default_profile_hook",
+    "get_default_profile_hook",
+    "set_default_profile_callback",
+    "get_default_profile_callback",
 ]
 
 _LG: logging.Logger = logging.getLogger(__name__)

--- a/src/spdl/pipeline/_hook.py
+++ b/src/spdl/pipeline/_hook.py
@@ -26,6 +26,8 @@ __all__ = [
     "TaskHook",
     "TaskStatsHook",
     "TaskPerfStats",
+    "set_default_hook_class",
+    "get_default_hook_class",
 ]
 
 _LG: logging.Logger = logging.getLogger(__name__)
@@ -431,3 +433,26 @@ class TaskStatsHook(TaskHook):
             _time_str(stats.ave_time),
             stacklevel=2,
         )
+
+
+_default_hook_class: type[TaskHook] | None = TaskStatsHook
+
+
+def set_default_hook_class(hook_class: type[TaskHook] | None = TaskStatsHook) -> None:
+    """Set the default hook class to be used for pipeline stages.
+
+    Args:
+        hook_class: The hook class to use as default.
+            If ``None``, then it disables hook.
+    """
+    global _default_hook_class
+    _default_hook_class = hook_class
+
+
+def get_default_hook_class() -> type[TaskHook] | None:
+    """Get the currently configured default hook class.
+
+    Returns:
+        The default hook class, or None if it is disabled.
+    """
+    return _default_hook_class

--- a/src/spdl/pipeline/_queue.py
+++ b/src/spdl/pipeline/_queue.py
@@ -12,7 +12,7 @@ import time
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
-from typing import TypeVar
+from typing import Any, TypeVar
 
 from ._hook import _periodic_dispatch, _StatsCounter, _time_str
 from ._utils import create_task
@@ -21,6 +21,8 @@ __all__ = [
     "AsyncQueue",
     "StatsQueue",
     "QueuePerfStats",
+    "set_default_queue_class",
+    "get_default_queue_class",
 ]
 
 T = TypeVar("T")
@@ -280,3 +282,25 @@ class StatsQueue(AsyncQueue[T]):
             100 * stats.occupancy_rate,
             stacklevel=2,
         )
+
+
+_default_queue_class: type[AsyncQueue[Any]] = StatsQueue
+
+
+def set_default_queue_class(queue_class: type[AsyncQueue[Any]] = StatsQueue) -> None:
+    """Set the default queue class to be used for connecting pipeline stages.
+
+    Args:
+        queue_class: The queue class to use as default.
+    """
+    global _default_queue_class
+    _default_queue_class = StatsQueue if queue_class is None else queue_class
+
+
+def get_default_queue_class() -> type[AsyncQueue[Any]]:
+    """Get the currently configured default queue class.
+
+    Returns:
+        The default queue class, or None if not configured.
+    """
+    return _default_queue_class

--- a/tests/spdl_unittest/pipeline/config_test.py
+++ b/tests/spdl_unittest/pipeline/config_test.py
@@ -1,0 +1,200 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import unittest
+from collections.abc import Iterator
+from contextlib import contextmanager
+
+from spdl.pipeline import (
+    AsyncQueue,
+    ProfileHook,
+    ProfileResult,
+    StatsQueue,
+    TaskHook,
+    TaskStatsHook,
+)
+from spdl.pipeline._config import (
+    get_default_hook_class,
+    get_default_profile_callback,
+    get_default_profile_hook,
+    get_default_queue_class,
+    set_default_hook_class,
+    set_default_profile_callback,
+    set_default_profile_hook,
+    set_default_queue_class,
+)
+
+
+class ConfigTest(unittest.TestCase):
+    """Test the configuration setter/getter functions."""
+
+    def setUp(self) -> None:
+        """Reset all configuration state before each test."""
+        set_default_hook_class()
+        set_default_queue_class()
+        set_default_profile_hook()
+        set_default_profile_callback()
+
+    def test_hook_class_default_is_none(self) -> None:
+        """Test that default hook class is None when not configured."""
+        result = get_default_hook_class()
+        self.assertIs(result, TaskStatsHook)
+
+    def test_hook_class_can_be_set_and_retrieved(self) -> None:
+        """Test that hook class can be set and retrieved correctly."""
+
+        class CustomHook(TaskHook):
+            pass
+
+        set_default_hook_class(CustomHook)
+        result = get_default_hook_class()
+
+        self.assertIs(result, CustomHook)
+
+    def test_hook_class_via_config_module(self) -> None:
+        """Test that hook class can be accessed via _config module."""
+
+        class CustomHook(TaskHook):
+            pass
+
+        set_default_hook_class(CustomHook)
+        result = get_default_hook_class()
+
+        self.assertIs(result, CustomHook)
+
+    def test_queue_class_default_is_none(self) -> None:
+        """Test that default queue class is None when not configured."""
+        result = get_default_queue_class()
+        self.assertIs(result, StatsQueue)
+
+    def test_queue_class_can_be_set_and_retrieved(self) -> None:
+        """Test that queue class can be set and retrieved correctly."""
+
+        class CustomQueue(StatsQueue[int]):
+            pass
+
+        set_default_queue_class(CustomQueue)
+        result = get_default_queue_class()
+        self.assertIs(result, CustomQueue)
+
+    def test_queue_class_via_config_module(self) -> None:
+        """Test that queue class can be accessed via _config module."""
+
+        class CustomQueue(StatsQueue[int]):
+            pass
+
+        set_default_queue_class(CustomQueue)
+        result = get_default_queue_class()
+        self.assertIs(result, CustomQueue)
+
+    def test_profile_hook_default_is_none(self) -> None:
+        """Test that default profile hook is None when not configured."""
+        result = get_default_profile_hook()
+        self.assertIsNone(result)
+
+    def test_profile_hook_can_be_set_and_retrieved(self) -> None:
+        """Test that profile hook can be set and retrieved correctly."""
+
+        class MockProfileHook(ProfileHook):
+            @contextmanager
+            def stage_profile_hook(
+                self,
+                stage: str,  # noqa: ARG002
+                concurrency: int,  # noqa: ARG002
+            ) -> Iterator[None]:
+                yield
+
+            @contextmanager
+            def pipeline_profile_hook(self) -> Iterator[None]:
+                yield
+
+        hook_instance = MockProfileHook()
+        set_default_profile_hook(hook_instance)
+        result = get_default_profile_hook()
+        self.assertIs(result, hook_instance)
+
+    def test_profile_hook_via_config_module(self) -> None:
+        """Test that profile hook can be accessed via _config module."""
+
+        class MockProfileHook(ProfileHook):
+            @contextmanager
+            def stage_profile_hook(
+                self,
+                stage: str,  # noqa: ARG002
+                concurrency: int,  # noqa: ARG002
+            ) -> Iterator[None]:
+                yield
+
+            @contextmanager
+            def pipeline_profile_hook(self) -> Iterator[None]:
+                yield
+
+        hook_instance = MockProfileHook()
+        set_default_profile_hook(hook_instance)
+        result = get_default_profile_hook()
+        self.assertIs(result, hook_instance)
+
+    def test_profile_callback_default_is_none(self) -> None:
+        """Test that default profile callback is None when not configured."""
+        result = get_default_profile_callback()
+        self.assertIsNone(result)
+
+    def test_profile_callback_can_be_set_and_retrieved(self) -> None:
+        """Test that profile callback can be set and retrieved correctly."""
+
+        def mock_callback(_: ProfileResult) -> None:
+            pass
+
+        set_default_profile_callback(mock_callback)
+        result = get_default_profile_callback()
+        self.assertIs(result, mock_callback)
+
+    def test_profile_callback_via_config_module(self) -> None:
+        """Test that profile callback can be accessed via _config module."""
+
+        def mock_callback(_: object) -> None:
+            pass
+
+        set_default_profile_callback(mock_callback)
+        result = get_default_profile_callback()
+        self.assertIs(result, mock_callback)
+
+    def test_multiple_configurations_independent(self) -> None:
+        """Test that different configuration settings are independent."""
+
+        class CustomHook(TaskHook):
+            pass
+
+        class CustomQueue(AsyncQueue[int]):
+            pass
+
+        def custom_callback(_: object) -> None:
+            pass
+
+        set_default_hook_class(CustomHook)
+        set_default_queue_class(CustomQueue)
+        set_default_profile_callback(custom_callback)
+
+        self.assertIs(get_default_hook_class(), CustomHook)
+        self.assertIs(get_default_queue_class(), CustomQueue)
+        self.assertIs(get_default_profile_callback(), custom_callback)
+
+    def test_configuration_can_be_updated(self) -> None:
+        """Test that configuration can be updated to new values."""
+
+        class FirstHook(TaskHook):
+            pass
+
+        class SecondHook(TaskHook):
+            pass
+
+        # Set first value, then update to second value
+        set_default_hook_class(FirstHook)
+        set_default_hook_class(SecondHook)
+        result = get_default_hook_class()
+        self.assertIs(result, SecondHook)


### PR DESCRIPTION
Summary:
This commit adds functions for configuring the default queue/hook/callbacks.

The intended usage is so that a project can set the logging/monitoring that is tied to infrastructure
globally.

This allows to set the default callback/profiling hook for pipeline diagnostic mode.

Differential Revision: D84461461


