### PR TITLE
Remove type parameter from AsyncQueue

### DIFF
--- a/examples/performance_analysis.py
+++ b/examples/performance_analysis.py
@@ -250,7 +250,7 @@ def build_pipeline(
         .add_sink()
         .build(
             num_threads=concurrency,
-            queue_class=partial(
+            queue_class=partial(  # pyre-ignore[6]
                 CustomQueue,
                 writer=writer,
                 interval=log_interval,

--- a/src/spdl/pipeline/_build.py
+++ b/src/spdl/pipeline/_build.py
@@ -13,7 +13,7 @@ import logging
 from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor
 from functools import partial
-from typing import Any, TypeVar
+from typing import TypeVar
 
 from . import _config
 from ._components._pipe import _get_fail_counter
@@ -81,7 +81,7 @@ _PIPELINE_ID: int = -1
 ################################################################################
 
 
-def _default_q(interval: float) -> type[AsyncQueue[Any]]:
+def _default_q(interval: float) -> type[AsyncQueue]:
     queue_class = _config.get_default_queue_class()
     return partial(queue_class, interval=interval)  # pyre-ignore[7]
 
@@ -109,7 +109,7 @@ def _build_pipeline(
     num_threads: int,
     max_failures: int = -1,
     report_stats_interval: float = -1,
-    queue_class: type[AsyncQueue[...]] | None = None,
+    queue_class: type[AsyncQueue] | None = None,
     task_hook_factory: Callable[[str], list[TaskHook]] | None = None,
     stage_id: int = 0,
 ) -> Pipeline[U]:
@@ -154,7 +154,7 @@ def build_pipeline(
     num_threads: int,
     max_failures: int = -1,
     report_stats_interval: float = -1,
-    queue_class: type[AsyncQueue[...]] | None = None,
+    queue_class: type[AsyncQueue] | None = None,
     task_hook_factory: Callable[[str], list[TaskHook]] | None = None,
     stage_id: int = 0,
 ) -> Pipeline[U]:

--- a/src/spdl/pipeline/_builder.py
+++ b/src/spdl/pipeline/_builder.py
@@ -222,7 +222,7 @@ class PipelineBuilder(Generic[T, U]):
         num_threads: int,
         max_failures: int = -1,
         report_stats_interval: float = -1,
-        queue_class: type[AsyncQueue[...]] | None = None,
+        queue_class: type[AsyncQueue] | None = None,
         task_hook_factory: Callable[[str], list[TaskHook]] | None = None,
         stage_id: int = 0,
     ) -> Pipeline[U]:
@@ -292,7 +292,7 @@ class _Wrapper(Generic[U]):
         num_threads: int,
         max_failures: int,
         report_stats_interval: float,
-        queue_class: type[AsyncQueue[T]] | None,
+        queue_class: type[AsyncQueue] | None,
         task_hook_factory: Callable[[str], list[TaskHook]] | None = None,
     ) -> None:
         self.builder = builder
@@ -320,7 +320,7 @@ def run_pipeline_in_subprocess(
     num_threads: int,
     max_failures: int = -1,
     report_stats_interval: float = -1,
-    queue_class: type[AsyncQueue[T]] | None = None,
+    queue_class: type[AsyncQueue] | None = None,
     task_hook_factory: Callable[[str], list[TaskHook]] | None = None,
     **kwargs: dict[str, Any],
 ) -> Iterable[T]:

--- a/src/spdl/pipeline/_components/_common.py
+++ b/src/spdl/pipeline/_components/_common.py
@@ -31,7 +31,7 @@ _EOF = _Sentinel("EOF")  # Indicate the end of stream.
 
 
 @asynccontextmanager
-async def _queue_stage_hook(queue: AsyncQueue[T]) -> AsyncGenerator[None, None]:
+async def _queue_stage_hook(queue: AsyncQueue) -> AsyncGenerator[None, None]:
     # Responsibility
     #   1. Call the `stage_hook`` context manager
     #   2. Put _EOF when the stage is done for reasons other than cancel.

--- a/src/spdl/pipeline/_components/_sink.py
+++ b/src/spdl/pipeline/_components/_sink.py
@@ -18,7 +18,7 @@ T = TypeVar("T")
 U = TypeVar("U")
 
 
-async def _sink(input_queue: AsyncQueue[T], output_queue: AsyncQueue[T]) -> None:
+async def _sink(input_queue: AsyncQueue, output_queue: AsyncQueue) -> None:
     async with output_queue.stage_hook():
         while True:
             item = await input_queue.get()

--- a/src/spdl/pipeline/_components/_source.py
+++ b/src/spdl/pipeline/_components/_source.py
@@ -21,7 +21,7 @@ U = TypeVar("U")
 
 async def _source(
     src: Iterable[T] | AsyncIterable[T],
-    queue: AsyncQueue[T],
+    queue: AsyncQueue,
     max_items: int | None = None,
 ) -> None:
     src_: AsyncIterable[T] = (  # pyre-ignore: [9]

--- a/src/spdl/pipeline/_node.py
+++ b/src/spdl/pipeline/_node.py
@@ -45,7 +45,7 @@ class _Node(Generic[T]):
     name: str
     cfg: _ConfigBase
     upstream: "Sequence[_Node]"
-    queue: AsyncQueue[T]
+    queue: AsyncQueue
     _coro: Coroutine[None, None, None] | None = None
     _task: Task | None = None
 
@@ -127,7 +127,7 @@ _BUFFER_SIZE: int = 2
 
 def _convert_config(
     plc: PipelineConfig,
-    q_class: type[AsyncQueue[...]],
+    q_class: type[AsyncQueue],
     pipeline_id: int,
     stage_id: _MutableInt,
     disable_sink: bool = False,
@@ -209,7 +209,7 @@ def _build_pipeline_node(
     plc: PipelineConfig,
     pipeline_id: int,
     stage_id: int,
-    q_class: type[AsyncQueue[...]],
+    q_class: type[AsyncQueue],
     fc_class: type[_FailCounter],
     task_hook_factory: Callable[[str], list[TaskHook]],
     max_failures: int,

--- a/src/spdl/pipeline/_pipeline.py
+++ b/src/spdl/pipeline/_pipeline.py
@@ -278,14 +278,14 @@ class Pipeline(Generic[T]):
     def __init__(
         self,
         coro: Coroutine[None, None, None],
-        output_queue: AsyncQueue[T],
+        output_queue: AsyncQueue,
         executor: ThreadPoolExecutor,
         *,
         desc: str,
     ) -> None:
         self._str: str = "\n".join([repr(self), desc])
 
-        self._output_queue: AsyncQueue[T] = output_queue
+        self._output_queue: AsyncQueue = output_queue
         self._event_loop = _EventLoop(coro, executor)
         self._event_loop_state: _EventLoopState = _EventLoopState.NOT_STARTED
 

--- a/tests/spdl_unittest/pipeline/config_test.py
+++ b/tests/spdl_unittest/pipeline/config_test.py
@@ -75,7 +75,7 @@ class ConfigTest(unittest.TestCase):
     def test_queue_class_can_be_set_and_retrieved(self) -> None:
         """Test that queue class can be set and retrieved correctly."""
 
-        class CustomQueue(StatsQueue[int]):
+        class CustomQueue(StatsQueue):
             pass
 
         set_default_queue_class(CustomQueue)
@@ -85,7 +85,7 @@ class ConfigTest(unittest.TestCase):
     def test_queue_class_via_config_module(self) -> None:
         """Test that queue class can be accessed via _config module."""
 
-        class CustomQueue(StatsQueue[int]):
+        class CustomQueue(StatsQueue):
             pass
 
         set_default_queue_class(CustomQueue)
@@ -170,7 +170,7 @@ class ConfigTest(unittest.TestCase):
         class CustomHook(TaskHook):
             pass
 
-        class CustomQueue(AsyncQueue[int]):
+        class CustomQueue(AsyncQueue):
             pass
 
         def custom_callback(_: object) -> None:


### PR DESCRIPTION
As Pipeline being higher-order function, queues receive various types, and sticking to one type is not helping as much.