### PR TITLE
Refactor 1 - Move queue and hook

### DIFF
--- a/src/spdl/pipeline/__init__.py
+++ b/src/spdl/pipeline/__init__.py
@@ -10,11 +10,11 @@
 
 from ._build import build_pipeline
 from ._builder import PipelineBuilder, run_pipeline_in_subprocess
-from ._hook import TaskHook, TaskPerfStats, TaskStatsHook
+from ._components._hook import TaskHook, TaskPerfStats, TaskStatsHook
+from ._components._queue import AsyncQueue, QueuePerfStats, StatsQueue
 from ._node import PipelineFailure
 from ._pipeline import Pipeline
 from ._profile import profile_pipeline, ProfileHook, ProfileResult
-from ._queue import AsyncQueue, QueuePerfStats, StatsQueue
 from ._utils import cache_iterator, create_task, iterate_in_subprocess
 
 __all__ = [

--- a/src/spdl/pipeline/_build.py
+++ b/src/spdl/pipeline/_build.py
@@ -16,11 +16,11 @@ from functools import partial
 from typing import TypeVar
 
 from . import _config
+from ._components._hook import TaskHook
 from ._components._pipe import _get_fail_counter
-from ._hook import TaskHook
+from ._components._queue import AsyncQueue
 from ._node import _build_pipeline_node, _run_pipeline_coroutines
 from ._pipeline import Pipeline
-from ._queue import AsyncQueue
 from .defs._defs import PipelineConfig
 
 # pyre-strict

--- a/src/spdl/pipeline/_builder.py
+++ b/src/spdl/pipeline/_builder.py
@@ -15,9 +15,9 @@ from typing import Any, Generic, TypeVar
 from spdl._internal import log_api_usage_once
 
 from ._build import build_pipeline
-from ._hook import TaskHook
+from ._components._hook import TaskHook
+from ._components._queue import AsyncQueue
 from ._pipeline import Pipeline
-from ._queue import AsyncQueue
 from ._utils import iterate_in_subprocess
 from .defs._defs import (
     _TPipeInputs,

--- a/src/spdl/pipeline/_components/_common.py
+++ b/src/spdl/pipeline/_components/_common.py
@@ -4,12 +4,21 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-__all__ = ["_queue_stage_hook", "_EOF"]
+__all__ = [
+    "_EOF",
+    "_periodic_dispatch",
+    "_StatsCounter",
+    "_time_str",
+]
 
-from contextlib import asynccontextmanager
-from typing import AsyncGenerator, TypeVar
+import asyncio
+import time
+from asyncio import Task
+from collections.abc import Callable, Coroutine, Iterator
+from contextlib import contextmanager
+from typing import TypeVar
 
-from .._queue import AsyncQueue
+from .._utils import create_task
 
 # pyre-strict
 
@@ -30,20 +39,65 @@ class _Sentinel:
 _EOF = _Sentinel("EOF")  # Indicate the end of stream.
 
 
-@asynccontextmanager
-async def _queue_stage_hook(queue: AsyncQueue) -> AsyncGenerator[None, None]:
-    # Responsibility
-    #   1. Call the `stage_hook`` context manager
-    #   2. Put _EOF when the stage is done for reasons other than cancel.
+def _time_str(val: float) -> str:
+    if val < 0.0001:
+        val *= 1e6
+        unit = "us"
+    elif val < 1:
+        val *= 1e3
+        unit = "ms"
+    else:
+        unit = "sec"
 
-    # Note:
-    # `asyncio.CancelledError` is a subclass of BaseException, so it won't be
-    # caught in the following, and EOF won't be passed to the output queue.
-    async with queue.stage_hook():
-        try:
-            yield
-        except Exception:
-            await queue.put(_EOF)  # pyre-ignore: [6]
-            raise
-        else:
-            await queue.put(_EOF)  # pyre-ignore: [6]
+    return f"{val:6.1f} [{unit:>3s}]"
+
+
+class _StatsCounter:
+    def __init__(self) -> None:
+        self._n: int = 0
+        self._t: float = 0.0
+
+    @property
+    def num_items(self) -> int:
+        return self._n
+
+    @property
+    def ave_time(self) -> float:
+        return self._t
+
+    def update(self, t: float, n: int = 1) -> None:
+        if n > 0:
+            self._n += n
+            self._t += (t - self._t) * n / self._n
+
+    @contextmanager
+    def count(self) -> Iterator[None]:
+        t0 = time.monotonic()
+        yield
+        elapsed = time.monotonic() - t0
+        self.update(elapsed)
+
+
+async def _periodic_dispatch(
+    afun: Callable[[], Coroutine[None, None, None]],
+    done: asyncio.Event,
+    interval: float,
+) -> None:
+    assert interval > 0, "[InternalError] `interval` must be greater than 0."
+    pending: set[Task] = set()
+    target = time.monotonic() + interval
+    while True:
+        if (dt := target - time.monotonic()) > 0:
+            await asyncio.wait([create_task(done.wait())], timeout=dt)
+
+        if done.is_set():
+            break
+
+        target = time.monotonic() + interval
+        pending.add(create_task(afun()))
+
+        # Assumption interval >> task duration.
+        _, pending = await asyncio.wait(pending, return_when="FIRST_COMPLETED")
+
+    if pending:
+        await asyncio.wait(pending)

--- a/src/spdl/pipeline/_components/_pipe.py
+++ b/src/spdl/pipeline/_components/_pipe.py
@@ -21,11 +21,11 @@ from functools import partial
 from typing import Generic, TypeVar
 
 from .._convert import convert_to_async
-from .._hook import _stage_hooks, _task_hooks, TaskHook
-from .._queue import AsyncQueue
 from .._utils import create_task
 from ..defs._defs import _PipeArgs
-from ._common import _EOF, _queue_stage_hook
+from ._common import _EOF
+from ._hook import _stage_hooks, _task_hooks, TaskHook
+from ._queue import _queue_stage_hook, AsyncQueue
 
 # pyre-strict
 

--- a/src/spdl/pipeline/_components/_queue.py
+++ b/src/spdl/pipeline/_components/_queue.py
@@ -9,14 +9,15 @@
 import asyncio
 import logging
 import time
-from collections.abc import AsyncIterator
+from collections.abc import AsyncGenerator, AsyncIterator
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
 
-from ._hook import _periodic_dispatch, _StatsCounter, _time_str
-from ._utils import create_task
+from .._utils import create_task
+from ._common import _EOF, _periodic_dispatch, _StatsCounter, _time_str
 
 __all__ = [
+    "_queue_stage_hook",
     "AsyncQueue",
     "StatsQueue",
     "QueuePerfStats",
@@ -54,6 +55,25 @@ class AsyncQueue(asyncio.Queue):
     async def stage_hook(self) -> AsyncIterator[None]:
         """Context manager, which handles init/final logic for the stage."""
         yield
+
+
+@asynccontextmanager
+async def _queue_stage_hook(queue: AsyncQueue) -> AsyncGenerator[None, None]:
+    # Responsibility
+    #   1. Call the `stage_hook`` context manager
+    #   2. Put _EOF when the stage is done for reasons other than cancel.
+
+    # Note:
+    # `asyncio.CancelledError` is a subclass of BaseException, so it won't be
+    # caught in the following, and EOF won't be passed to the output queue.
+    async with queue.stage_hook():
+        try:
+            yield
+        except Exception:
+            await queue.put(_EOF)  # pyre-ignore: [6]
+            raise
+        else:
+            await queue.put(_EOF)  # pyre-ignore: [6]
 
 
 @dataclass

--- a/src/spdl/pipeline/_components/_sink.py
+++ b/src/spdl/pipeline/_components/_sink.py
@@ -8,8 +8,8 @@ __all__ = ["_sink"]
 
 from typing import TypeVar
 
-from .._queue import AsyncQueue
 from ._common import _EOF
+from ._queue import AsyncQueue
 
 # pyre-strict
 

--- a/src/spdl/pipeline/_components/_source.py
+++ b/src/spdl/pipeline/_components/_source.py
@@ -10,8 +10,7 @@ from collections.abc import AsyncIterable, Iterable
 from typing import TypeVar
 
 from .._convert import _to_async_gen
-from .._queue import AsyncQueue
-from ._common import _queue_stage_hook
+from ._queue import _queue_stage_hook, AsyncQueue
 
 # pyre-strict
 

--- a/src/spdl/pipeline/_config.py
+++ b/src/spdl/pipeline/_config.py
@@ -7,14 +7,14 @@
 import logging
 import os
 
-from ._hook import get_default_hook_class, set_default_hook_class
+from ._components._hook import get_default_hook_class, set_default_hook_class
+from ._components._queue import get_default_queue_class, set_default_queue_class
 from ._profile import (
     get_default_profile_callback,
     get_default_profile_hook,
     set_default_profile_callback,
     set_default_profile_hook,
 )
-from ._queue import get_default_queue_class, set_default_queue_class
 
 __all__ = [
     "_diagnostic_mode_enabled",

--- a/src/spdl/pipeline/_node.py
+++ b/src/spdl/pipeline/_node.py
@@ -10,11 +10,11 @@ from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from typing import Coroutine, Generic, TypeVar
 
+from ._components._hook import TaskHook
 from ._components._pipe import _FailCounter, _merge, _ordered_pipe, _pipe
+from ._components._queue import AsyncQueue
 from ._components._sink import _sink
 from ._components._source import _source
-from ._hook import TaskHook
-from ._queue import AsyncQueue
 from ._utils import create_task
 from .defs._defs import (
     _ConfigBase,

--- a/tests/spdl_unittest/dataloader/pipeline_node_test.py
+++ b/tests/spdl_unittest/dataloader/pipeline_node_test.py
@@ -6,6 +6,7 @@
 
 import asyncio
 
+from spdl.pipeline._components._queue import AsyncQueue
 from spdl.pipeline._node import (
     _cancel_recursive,
     _cancel_upstreams_of_errors,
@@ -14,7 +15,6 @@ from spdl.pipeline._node import (
     _Node,
     _start_tasks,
 )
-from spdl.pipeline._queue import AsyncQueue
 
 # pyre-strict
 

--- a/tests/spdl_unittest/dataloader/pipeline_test.py
+++ b/tests/spdl_unittest/dataloader/pipeline_test.py
@@ -33,6 +33,7 @@ from spdl.pipeline import (
     TaskStatsHook,
 )
 from spdl.pipeline._components._common import _EOF
+from spdl.pipeline._components._hook import _periodic_dispatch
 from spdl.pipeline._components._pipe import (
     _FailCounter,
     _get_fail_counter,
@@ -41,7 +42,6 @@ from spdl.pipeline._components._pipe import (
 )
 from spdl.pipeline._components._sink import _sink
 from spdl.pipeline._components._source import _source
-from spdl.pipeline._hook import _periodic_dispatch
 from spdl.source.utils import embed_shuffle
 
 T = TypeVar("T")


### PR DESCRIPTION
Summary:
Refactor the pipeline module.
The majority of the code is related to pipeline execution logic, which is not a public API.

To make the relationship of execution logic and public APIs, we perform the refactoring.

<img width="3527" height="1233" alt="pipeline_imports_final" src="https://github.com/user-attachments/assets/9e1b084c-48ee-41e6-9ebb-d1c1aa65f846" />

In this first commit, the following changes are made

- Move `_queue, _hook` to `_components` for better locality
- Move `_queue_stage_hook` to `_queue` for better locality
- Move `_periodic_dispatch`, `_StatsCounter`, `_time_str` from `_hook` to `_common` to make `_queue` independent from `_hook`

Differential Revision: D84854069
