### PR TITLE
Introduce public config module

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -9,6 +9,7 @@ API Reference
 
    spdl.pipeline
    spdl.pipeline.defs
+   spdl.pipeline.config
    spdl.dataloader
    spdl.source
 

--- a/examples/benchmark_wav.py
+++ b/examples/benchmark_wav.py
@@ -47,7 +47,7 @@ And since parsing WAV is instant, the spdl.io.load_wav function spends more time
 creation of NumPy Array.
 It needs to acquire the GIL, thus the performance does not scale in multi-threading.
 (This performance pattern of this function is pretty same as the
-:ref:`spdl.io.load_npz <data-format>`.)
+:ref:`spdl.io.load_npz <example-data-formats>`.)
 
 The following is the same plot without ``load_wav``.
 

--- a/src/spdl/pipeline/_build.py
+++ b/src/spdl/pipeline/_build.py
@@ -172,7 +172,7 @@ def build_pipeline(
     """
     from . import _profile
 
-    if _profile._is_diagnostic_mode_enabled():
+    if _profile.is_diagnostic_mode_enabled():
         return _profile._build_pipeline_diagnostic_mode(pipeline_cfg)
 
     return _build_pipeline(

--- a/src/spdl/pipeline/_components/_hook.py
+++ b/src/spdl/pipeline/_components/_hook.py
@@ -372,7 +372,7 @@ class TaskStatsHook(TaskHook):
         )
 
 
-_default_hook_class: type[TaskHook] | None = TaskStatsHook
+_DEFAULT_HOOK_CLASS: type[TaskHook] | None = TaskStatsHook
 
 
 def set_default_hook_class(hook_class: type[TaskHook] | None = TaskStatsHook) -> None:
@@ -381,15 +381,16 @@ def set_default_hook_class(hook_class: type[TaskHook] | None = TaskStatsHook) ->
     Args:
         hook_class: The hook class to use as default.
             If ``None``, then it disables hook.
+            Default: :py:class:`~spdl.pipeline.TaskStatsHook`.
     """
-    global _default_hook_class
-    _default_hook_class = hook_class
+    global _DEFAULT_HOOK_CLASS
+    _DEFAULT_HOOK_CLASS = hook_class
 
 
 def get_default_hook_class() -> type[TaskHook] | None:
     """Get the currently configured default hook class.
 
     Returns:
-        The default hook class, or None if it is disabled.
+        The default hook class, or ``None`` if it is disabled.
     """
-    return _default_hook_class
+    return _DEFAULT_HOOK_CLASS

--- a/src/spdl/pipeline/_components/_queue.py
+++ b/src/spdl/pipeline/_components/_queue.py
@@ -71,10 +71,10 @@ async def _queue_stage_hook(queue: AsyncQueue) -> AsyncGenerator[None, None]:
         try:
             yield
         except Exception:
-            await queue.put(_EOF)  # pyre-ignore: [6]
+            await queue.put(_EOF)
             raise
         else:
-            await queue.put(_EOF)  # pyre-ignore: [6]
+            await queue.put(_EOF)
 
 
 @dataclass
@@ -303,7 +303,7 @@ class StatsQueue(AsyncQueue):
         )
 
 
-_default_queue_class: type[AsyncQueue] = StatsQueue
+_DEFAULT_QUEUE_CLASS: type[AsyncQueue] = StatsQueue
 
 
 def set_default_queue_class(queue_class: type[AsyncQueue] = StatsQueue) -> None:
@@ -311,15 +311,16 @@ def set_default_queue_class(queue_class: type[AsyncQueue] = StatsQueue) -> None:
 
     Args:
         queue_class: The queue class to use as default.
+            Default: :py:class:`~spdl.pipeline.StatsQueue`.
     """
-    global _default_queue_class
-    _default_queue_class = StatsQueue if queue_class is None else queue_class
+    global _DEFAULT_QUEUE_CLASS
+    _DEFAULT_QUEUE_CLASS = StatsQueue if queue_class is None else queue_class
 
 
 def get_default_queue_class() -> type[AsyncQueue]:
     """Get the currently configured default queue class.
 
     Returns:
-        The default queue class, or None if not configured.
+        The default queue class, or ``None`` if not configured.
     """
-    return _default_queue_class
+    return _DEFAULT_QUEUE_CLASS

--- a/src/spdl/pipeline/config.py
+++ b/src/spdl/pipeline/config.py
@@ -18,17 +18,17 @@ from spdl.pipeline._components import (
 )
 
 from ._profile import (
-    _diagnostic_mode_num_sources,
-    _is_diagnostic_mode_enabled,
+    diagnostic_mode_num_sources,
     get_default_profile_callback,
     get_default_profile_hook,
+    is_diagnostic_mode_enabled,
     set_default_profile_callback,
     set_default_profile_hook,
 )
 
 __all__ = [
-    "_is_diagnostic_mode_enabled",
-    "_diagnostic_mode_num_sources",
+    "is_diagnostic_mode_enabled",
+    "diagnostic_mode_num_sources",
     "set_default_hook_class",
     "get_default_hook_class",
     "set_default_queue_class",

--- a/tests/spdl_unittest/dataloader/pipeline_profiling_test.py
+++ b/tests/spdl_unittest/dataloader/pipeline_profiling_test.py
@@ -10,7 +10,7 @@ from contextlib import contextmanager
 from unittest.mock import MagicMock, patch
 
 from spdl.pipeline import (
-    _config,
+    config,
     profile_pipeline,
     ProfileHook,
     ProfileResult,
@@ -18,7 +18,6 @@ from spdl.pipeline import (
 from spdl.pipeline._profile import (
     _build_pipeline_config,
     _fetch_inputs,
-    _NoOpHook,
 )
 from spdl.pipeline.defs import (
     Aggregate,
@@ -35,16 +34,15 @@ from spdl.pipeline.defs import (
 @contextmanager
 def _use_default_hook():
     """Context manager to use NoOp hook for testing purposes."""
-    default_hook = _NoOpHook()
-    original_hook = _config.get_default_profile_hook()
-    original_callback = _config.get_default_profile_callback()
+    original_hook = config.get_default_profile_hook()
+    original_callback = config.get_default_profile_callback()
     try:
-        _config.set_default_profile_hook(default_hook)
-        _config.set_default_profile_callback(lambda _: None)
+        config.set_default_profile_hook()
+        config.set_default_profile_callback()
         yield
     finally:
-        _config.set_default_profile_hook(original_hook)
-        _config.set_default_profile_callback(original_callback)
+        config.set_default_profile_hook(original_hook)
+        config.set_default_profile_callback(original_callback)
 
 
 def test_fetch_inputs():
@@ -212,11 +210,11 @@ class TestProfileHookTest(unittest.TestCase):
 
         custom_hook = MockProfileHook()
 
-        original_hook = _config.get_default_profile_hook()
-        original_callback = _config.get_default_profile_callback()
+        original_hook = config.get_default_profile_hook()
+        original_callback = config.get_default_profile_callback()
         try:
-            _config.set_default_profile_hook(None)
-            _config.set_default_profile_callback(None)
+            config.set_default_profile_hook(None)
+            config.set_default_profile_callback(None)
 
             results = profile_pipeline(cfg, num_inputs=3, hook=custom_hook)
 
@@ -224,8 +222,8 @@ class TestProfileHookTest(unittest.TestCase):
             self.assertEqual(pipeline_hook_mock.call_count, 2)
             self.assertEqual(stage_hook_mock.call_count, 10)
         finally:
-            _config.set_default_profile_hook(original_hook)
-            _config.set_default_profile_callback(original_callback)
+            config.set_default_profile_hook(original_hook)
+            config.set_default_profile_callback(original_callback)
 
     def test_profile_pipeline_skips_when_local_rank_not_zero(self):
         """Test that profiling is skipped if LOCAL_RANK is not '0'."""

--- a/tests/spdl_unittest/pipeline/config_test.py
+++ b/tests/spdl_unittest/pipeline/config_test.py
@@ -18,7 +18,7 @@ from spdl.pipeline import (
     TaskHook,
     TaskStatsHook,
 )
-from spdl.pipeline._config import (
+from spdl.pipeline.config import (
     get_default_hook_class,
     get_default_profile_callback,
     get_default_profile_hook,


### PR DESCRIPTION
This commit introduces `spdl.pipeline.config` module, which allows to inject (mainly infra-related) custom logics.

- `set_default_profile_hook` and `set_default_profile_callback` allow to set default callback and hook when profiling. This allows to inject infra-related code (like logging) when running Pipeline in self-diagnostic mode. (`SPDL_PIPELINE_DIAGNOSTIC_MODE=1`)
- `set_default_hook_class` and `set_default_queue_class` allows to set Pipeline hook and Queue globally. This allows teams/projects to use the same custom logic without requiring the individual project to pass the custom hook/queue class. The usage of custom hook/queue classes are explained in https://facebookresearch.github.io/spdl/main/generated/performance_analysis.html#module-performance_analysis.

Pull Request resolved: https://github.com/facebookresearch/spdl/pull/1042

Differential Revision: D84970937
