### PR TITLE
Add custom merge op support

### DIFF
--- a/src/spdl/pipeline/_common/_types.py
+++ b/src/spdl/pipeline/_common/_types.py
@@ -8,16 +8,15 @@
 
 """Module to stash things common to all the modules internal to SPDL"""
 
-import logging
-from collections.abc import AsyncIterable, Awaitable, Callable, Iterable
+from asyncio import Queue
+from collections.abc import AsyncIterable, Awaitable, Callable, Iterable, Sequence
 from typing import TypeAlias, TypeVar
 
 __all__ = [
     "_TAsyncCallables",
     "_TCallables",
+    "_TMergeOp",
 ]
-
-_LG: logging.Logger = logging.getLogger(__name__)
 
 
 T = TypeVar("T")
@@ -35,3 +34,6 @@ _TCallables: TypeAlias = (
 _TAsyncCallables: TypeAlias = (
     Callable[[T], Awaitable[U]] | Callable[[T], AsyncIterable[U]]
 )
+
+
+_TMergeOp: TypeAlias = Callable[[str, Sequence[Queue], Queue], Awaitable[None]]

--- a/src/spdl/pipeline/_components/_node.py
+++ b/src/spdl/pipeline/_components/_node.py
@@ -200,7 +200,7 @@ def _build_node(
             input_queues = [n.queue for n in node.upstream]
             hooks = task_hook_factory(node.name)
             fc = fc_class(max_failures)
-            node._coro = _merge(node.name, input_queues, node.queue, fc, hooks)
+            node._coro = _merge(node.name, input_queues, node.queue, fc, hooks, cfg.op)
         case SinkConfig():
             cfg: SinkConfig = node.cfg
             assert len(node.upstream) == 1


### PR DESCRIPTION
This commit adds support to customize the Merge node.
Users can now implement their own logic to merge items from sub-pipelines.

Differential Revision: D85095941


