### PR TITLE
Add `iterate_in_subinterpter` function

### DIFF
--- a/docs/source/notes/remote_iterable_protocol.rst
+++ b/docs/source/notes/remote_iterable_protocol.rst
@@ -66,7 +66,7 @@ Helper functions and data structures
 -------------------------------------
 
 The follosing functions and data structures are used to implement
-the :py:func:`~spdl.pipeline.iterate_in_subprocess` function.
+the :py:func:`~spdl.pipeline.iterate_in_subprocess` and :py:func:`iterate_in_subinterpreter` functions.
 They are not public interface, but the logic is sufficiently elaborated,
 and it is helpful to have them in the documentation, so they are listed here.
 

--- a/src/spdl/pipeline/__init__.py
+++ b/src/spdl/pipeline/__init__.py
@@ -21,7 +21,11 @@ from ._components import (
     TaskPerfStats,
     TaskStatsHook,
 )
-from ._iter_utils import cache_iterator, iterate_in_subprocess
+from ._iter_utils import (
+    cache_iterator,
+    iterate_in_subinterpreter,
+    iterate_in_subprocess,
+)
 from ._pipeline import Pipeline
 from ._profile import profile_pipeline, ProfileHook, ProfileResult
 
@@ -42,6 +46,7 @@ __all__ = [
     "AsyncQueue",
     "StatsQueue",
     "QueuePerfStats",
+    "iterate_in_subinterpreter",
     "iterate_in_subprocess",
     "run_pipeline_in_subprocess",
 ]

--- a/src/spdl/pipeline/_iter_utils/__init__.py
+++ b/src/spdl/pipeline/_iter_utils/__init__.py
@@ -13,10 +13,12 @@ subinterpreters, as well as caching iterators for performance testing.
 """
 
 from ._cache_iterator import cache_iterator
+from ._subinterpreter import iterate_in_subinterpreter
 from ._subprocess import iterate_in_subprocess
 
 __all__ = [
     "iterate_in_subprocess",
+    "iterate_in_subinterpreter",
     "cache_iterator",
 ]
 

--- a/src/spdl/pipeline/_iter_utils/_subinterpreter.py
+++ b/src/spdl/pipeline/_iter_utils/_subinterpreter.py
@@ -1,0 +1,170 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""Subinterpreter-based iteration support.
+
+This module provides functionality to run iterables in Python subinterpreters
+using Python 3.14's concurrent.interpreters module.
+"""
+
+import logging
+import sys
+import threading
+import weakref
+from collections.abc import Callable, Iterable, Iterator, Sequence
+from dataclasses import dataclass
+from typing import Generic, TypeVar
+
+from spdl.pipeline._iter_utils._common import (
+    _Cmd,
+    _drain,
+    _enter_iteration_mode,
+    _execute_iterable,
+    _iterate_results,
+    _wait_for_init,
+)
+
+__all__ = [
+    "iterate_in_subinterpreter",
+]
+
+_LG: logging.Logger = logging.getLogger(__name__)
+
+T = TypeVar("T")
+
+
+if sys.version_info < (3, 14):
+
+    def _impl(
+        fn: Callable[[], Iterable[T]],  # noqa: ARG001
+        *,
+        buffer_size: int = 3,  # noqa: ARG001
+        initializer: Callable[[], None] | Sequence[Callable[[], None]] | None = None,  # noqa: ARG001
+        timeout: float | None = None,  # noqa: ARG001
+    ) -> Iterable[T]:
+        raise RuntimeError(
+            f"iterate_in_subinterpreter requires Python 3.14 or later. "
+            f"Current version: {sys.version_info.major}.{sys.version_info.minor}"
+        )
+else:
+    import concurrent.interpreters
+
+    # short for inter-interpreter communication.
+    # (analogous to inter-process communication)
+    @dataclass
+    class _iic(Generic[T]):
+        thread: threading.Thread
+        interpreter: "concurrent.interpreters.Interpreter"
+        cmd_q: "concurrent.interpreters.Queue"
+        data_q: "concurrent.interpreters.Queue"
+        timeout: float
+
+        def terminate(self) -> None:
+            self.cmd_q.put(_Cmd.ABORT)
+            _drain(self.data_q)
+            self.thread.join(timeout=3)
+            if self.thread.is_alive():
+                _LG.warning("Thread did not terminate gracefully")
+
+    class _SubinterpreterIterable(Iterable[T]):
+        """An Iterable interface that manipulates the iterable in a subinterpreter
+        and fetches the results."""
+
+        def __init__(self, interface: _iic[T]) -> None:
+            self._if: _iic[T] | None = interface
+            self._finalizer = weakref.finalize(self, interface.terminate)
+
+        def __iter__(self) -> Iterator[T]:
+            """Instruct the subinterpreter to enter iteration mode and iterate on the results."""
+            if (if_ := self._if) is None:
+                raise RuntimeError(
+                    "The subinterpreter is shutdown. Cannot iterate again."
+                )
+
+            try:
+                _enter_iteration_mode(
+                    if_.cmd_q, if_.data_q, if_.timeout, "subinterpreter"
+                )
+                yield from _iterate_results(if_.data_q, if_.timeout, "subinterpreter")
+            except (Exception, KeyboardInterrupt):
+                self._terminate()
+                raise
+
+        def _terminate(self) -> None:
+            if (if_ := self._if) is not None:
+                if_.terminate()
+                self._finalizer.detach()
+                self._if = None
+
+    def _impl(
+        fn: Callable[[], Iterable[T]],
+        *,
+        buffer_size: int = 3,
+        initializer: Callable[[], None] | Sequence[Callable[[], None]] | None = None,
+        timeout: float | None = None,
+    ) -> Iterable[T]:
+        initializers = (
+            None
+            if initializer is None
+            else (
+                [initializer] if not isinstance(initializer, Sequence) else initializer
+            )
+        )
+
+        cmd_q = concurrent.interpreters.create_queue()
+        data_q = concurrent.interpreters.create_queue(maxsize=buffer_size)
+        interp = concurrent.interpreters.create()
+
+        thread = interp.call_in_thread(
+            _execute_iterable, cmd_q, data_q, fn, initializers
+        )
+
+        timeout_ = float("inf") if timeout is None else timeout
+        interface = _iic(thread, interp, cmd_q, data_q, timeout_)
+
+        _wait_for_init(interface.data_q, interface.timeout, "subinterpreter")
+
+        return _SubinterpreterIterable(interface)
+
+
+def iterate_in_subinterpreter(
+    fn: Callable[[], Iterable[T]],
+    *,
+    buffer_size: int = 3,
+    initializer: Callable[[], None] | Sequence[Callable[[], None]] | None = None,
+    timeout: float | None = None,
+) -> Iterable[T]:
+    """**[Experimental]** Run the given ``iterable`` in a subinterpreter.
+
+    This function behaves similarly to :py:func:`iterate_in_subprocess`, but uses
+    Python 3.14's ``concurrent.interpreters`` module instead of multiprocessing.
+    Subinterpreters provide isolation while sharing the same process, which can be
+    more lightweight than spawning a separate process.
+
+    Args:
+        fn: Function that returns an iterator. Use :py:func:`functools.partial` to
+            pass arguments to the function.
+        buffer_size: Maximum number of items to buffer in the queue.
+        initializer: Functions executed in the subinterpreter before iteration starts.
+        timeout: Timeout for inactivity. If the generator function does not yield
+            any item for this amount of time, the subinterpreter is terminated.
+
+    Returns:
+        Iterator over the results of the generator function.
+
+    Note:
+        This function requires Python 3.14 or later. The function and the values
+        yielded by the iterator must be shareable between interpreters.
+
+    See Also:
+        :py:func:`iterate_in_subprocess` for running in a subprocess instead.
+
+    Raises:
+        RuntimeError: If Python version is less than 3.14.
+    """
+    return _impl(fn, buffer_size=buffer_size, initializer=initializer, timeout=timeout)

--- a/tests/spdl_unittest/pipeline/subinterpreter_test.py
+++ b/tests/spdl_unittest/pipeline/subinterpreter_test.py
@@ -1,0 +1,123 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import sys
+import unittest
+from collections.abc import Callable, Iterable, Sequence
+from typing import Generic, TypeVar
+
+from parameterized import parameterized
+from spdl.pipeline._iter_utils._subinterpreter import (
+    iterate_in_subinterpreter as _iterate_in_subinterpreter,
+)
+
+T = TypeVar("T")
+
+
+def iterate_in_subinterpreter(
+    fn: Callable[[], Iterable[T]],
+    *,
+    buffer_size: int = 3,
+    initializer: Callable[[], None] | Sequence[Callable[[], None]] | None = None,
+    timeout: float = 5,
+) -> Iterable[T]:
+    """Set timeout for unittest"""
+    return _iterate_in_subinterpreter(
+        fn, buffer_size=buffer_size, initializer=initializer, timeout=timeout
+    )
+
+
+class _Wrap(Generic[T]):
+    """Helper class to wrap an iterable as a callable.
+
+    This class wraps an iterable object and makes it callable, which is useful
+    for testing iterate_in_subinterpreter. It can optionally execute a pre-flight
+    function before returning the iterable, allowing for assertions to verify
+    that initializers have run correctly in the subinterpreter.
+
+    Args:
+        obj: The iterable object to wrap.
+        pre: Optional callable to execute before returning the iterable.
+            Typically used for assertions in tests.
+    """
+
+    def __init__(self, obj: Iterable[T], pre: Callable[[], None] | None = None) -> None:
+        self.obj = obj
+        self.pre = pre
+
+    def __call__(self) -> Iterable[T]:
+        if self.pre is not None:
+            self.pre()
+        return self.obj
+
+
+_FLAGS: list[int] = []
+
+
+def _init_flag0() -> None:
+    _FLAGS.append(0)
+
+
+def _init_flag1() -> None:
+    _FLAGS.append(1)
+
+
+def _check_flag0and1() -> None:
+    ref = [0, 1]
+    assert _FLAGS == ref, f"{_FLAGS=} != {ref=}"
+
+
+if sys.version_info >= (3, 14):
+
+    class TestIterateInSubinterpreter(unittest.TestCase):
+        """Test cases for iterate_in_subinterpreter function."""
+
+        @parameterized.expand(
+            [
+                ("basic_iteration", list(range(5))),
+                ("string_iteration", ["hello", "world", "test"]),
+                ("empty_iterator", []),
+            ],
+        )
+        def test_iteration(self, name: str, ref: list[object]) -> None:  # noqa: ARG002
+            """Test iteration with various input types."""
+            iterable = iterate_in_subinterpreter(_Wrap(ref))
+            result = list(iterable)
+            self.assertEqual(result, ref)
+            result2 = list(iterable)
+            self.assertEqual(result2, ref)
+
+        def test_buffer_size(self) -> None:
+            """Test with custom buffer size."""
+            ref = list(range(10))
+            result = list(iterate_in_subinterpreter(_Wrap(ref), buffer_size=5))
+            self.assertEqual(result, ref)
+
+        def test_with_initializers(self) -> None:
+            """Test with multiple initializer functions."""
+            ref = list(range(10))
+            result = list(
+                iterate_in_subinterpreter(
+                    _Wrap(ref, pre=_check_flag0and1),
+                    initializer=[_init_flag0, _init_flag1],
+                    timeout=5.0,
+                )
+            )
+            self.assertEqual(result, ref)
+            # The flag should not be set in the main interpreter
+            self.assertEqual(_FLAGS, [])
+
+        def test_partial_iteration(self) -> None:
+            """Test partial iteration by breaking early."""
+            iterable = iterate_in_subinterpreter(_Wrap(range(10)))
+            result = []
+            for i, item in enumerate(iterable):
+                result.append(item)
+                if i >= 4:
+                    break
+            self.assertEqual(result, [0, 1, 2, 3, 4])


### PR DESCRIPTION
This commit adds `iterate_in_subinterpreter` function, which has the same functionality as `iterate_in_subprocess`, but uses subinterpreter instead of subprocess.