### PR TITLE
Deprecate the use of Builder in run_in_subprocess

### DIFF
--- a/src/spdl/pipeline/__init__.py
+++ b/src/spdl/pipeline/__init__.py
@@ -8,8 +8,8 @@
 
 # pyre-strict
 
-from ._build import build_pipeline
-from ._builder import PipelineBuilder, run_pipeline_in_subprocess
+from ._build import build_pipeline, run_pipeline_in_subprocess
+from ._builder import PipelineBuilder
 from ._common._misc import create_task
 from ._components import (
     AsyncQueue,


### PR DESCRIPTION
With the introduction of sub-pipelines, the implementation of `Pipeline` is now centered around the pipeline definitions (`PipelineConfig` classes and such), and `PipelineBuilder` only covers the straight chain pipeline.

We updated `run_pipeline_in_subprocess` to support `PipeineConfig`, but with the introduction of `run_pipeilne_in_subinterpreter`, the implementation becomes simpler if we only support `PipelineConfig` in these helper function.

This commit changes the type annotation of
`run_pipeline_in_subprocess` so that `PipelineBuilder` is removed though it's still supported at runtime.

We encourage users to explicitly convert to the config object.