### PR TITLE
Update the way timestamp is handled

### DIFF
--- a/src/libspdl/core/packets.cpp
+++ b/src/libspdl/core/packets.cpp
@@ -247,7 +247,8 @@ extract_packets(const VideoPacketsPtr& src, size_t start, size_t end) {
   auto ret = std::make_unique<VideoPackets>();
   ret->src = src->src;
   ret->codec = src->codec;
-  ret->timestamp = src->timestamp;
+  // Do not preserve timestamp as indices are already adjusted
+  ret->timestamp = std::nullopt;
   for (size_t t = start; t < end; ++t) {
     ret->pkts.push(CHECK_AVALLOCATE(av_packet_clone(src_packets[t])));
   }

--- a/src/spdl/io/_preprocessing.py
+++ b/src/spdl/io/_preprocessing.py
@@ -254,9 +254,12 @@ def get_filter_desc(
     """
     match type(packets):
         case _libspdl.AudioPackets:
+            # When audio packets have `timestamp` attribute, we delegate to `atrim` filter.
             return get_audio_filter_desc(timestamp=packets.timestamp, **filter_args)
         case _libspdl.VideoPackets:
-            return get_video_filter_desc(timestamp=packets.timestamp, **filter_args)
+            # When video packets have `timestamp` attribute, we manually filter the frame
+            # in the decoding logic, so we don't use `trim` filter.
+            return get_video_filter_desc(timestamp=None, **filter_args)
         case _libspdl.ImagePackets:
             return get_video_filter_desc(timestamp=None, **filter_args)
         case _:


### PR DESCRIPTION
1. When comparing the timestamp and PTS, convert them into AVRational instead of double, so that the comparison is more accurate.
2. Use the same timestamp filtering mechanism in Packets and decoding.
3. Do not use the `trim` filter for timestamp mechanism. Instead filter manually, using the above mechanism.

The new implementation gives a result closer to Python's slice notation.
For example in one of the test, we used `timestamp=(2.88, 2.89)`. The `trim` filter will discard the frame at 2.88, while the new implementation keeps it.