### PR TITLE
Use torch.assert for better error message

### DIFF
--- a/tests/spdl_unittest/cuda/nvdec_video_decoding_test.py
+++ b/tests/spdl_unittest/cuda/nvdec_video_decoding_test.py
@@ -223,8 +223,8 @@ class TestNvdecH264(unittest.TestCase):
         )
 
         for i in range(3):
-            self.assertTrue(
-                torch.equal(rgb[:, i], rgba0[:, i, top : top + h, left : left + w])
+            torch.testing.assert_close(
+                rgb[:, i], rgba0[:, i, top : top + h, left : left + w]
             )
 
     def test_nvdec_decode_crop_resize(self) -> None:


### PR DESCRIPTION
When using PyTest runner and Python's `unittest`,
`assertTrue` does not show meaningfull error message.