### PR TITLE
Add build callback

### DIFF
--- a/src/spdl/pipeline/config.py
+++ b/src/spdl/pipeline/config.py
@@ -17,6 +17,10 @@ from spdl.pipeline._components import (
     set_default_queue_class,
 )
 
+from ._build import (
+    get_default_build_callback,
+    set_default_build_callback,
+)
 from ._profile import (
     diagnostic_mode_num_sources,
     get_default_profile_callback,
@@ -37,4 +41,6 @@ __all__ = [
     "get_default_profile_hook",
     "set_default_profile_callback",
     "get_default_profile_callback",
+    "get_default_build_callback",
+    "set_default_build_callback",
 ]


### PR DESCRIPTION
This commit adds a callback function to `build_pipeline`.

The purpose of the callback is so that we can log the detail of pipeline without changing the way SPDL is integrated.

This allows to inject logging mechanism across code base without changing the individual projects that use SPDL.

This functionality is intended for adding logging to the code that does not have access to the part that calls `build_pipeline` function. So we do not add equivalent `callback` argument to `build_pipeline` function. (If you are calling `build_pipeline`, you can achieve the same effect by calling your function directly by providing PipelineConfig object.)