### PR TITLE
Fix NvDec decoder stale state when cropping

### DIFF
--- a/src/spdl/io/_core.py
+++ b/src/spdl/io/_core.py
@@ -1039,6 +1039,11 @@ def nvdec_decoder(
         The old pattern of calling ``decoder.init()`` after ``nvdec_decoder()``
         will be removed in a future version.
     """
+    # Force recreation if crop is provided, regardless of use_cache
+    crop_params = (crop_left, crop_top, crop_right, crop_bottom)
+    if any(param != 0 for param in crop_params):
+        use_cache = False
+
     if use_cache:
         decoder = _get_decoder()
         decoder.reset()


### PR DESCRIPTION
This commit address an issue where executing `test_nvdec_decode_crop_resize` before `test_nvdec_decode_h264_420p_crop` causes the latter to return wrong results 
due to bad state left behind. 

~The fix involves modifying the `NvDecDecoderCore::reset()` method to properly clean up state, 
including resetting crop, target width and height, and source information to default values. 
This ensures that the thread-local cached decoder does not carry over stale parameters from previous test runs.~

Modifying the `NvDecDecoderCore` is more elaborated, so, for now, we disable cache if crop is provided. 

~This commit also adds the stand alone test that would repro the issue without the patch.~
Moved to https://github.com/facebookresearch/spdl/pull/1186 as the test manifests a different issue.

- w/o fix https://github.com/facebookresearch/spdl/actions/runs/19650268816
- w/ fix https://github.com/facebookresearch/spdl/actions/runs/19641739313

Closes https://github.com/facebookresearch/spdl/issues/1159