### PR TITLE
Include stddef in tar_iterator.cpp

### DIFF
--- a/src/spdl/io/lib/archive/tar_iterator.cpp
+++ b/src/spdl/io/lib/archive/tar_iterator.cpp
@@ -7,6 +7,8 @@
  */
 
 #include "tar_iterator.h"
+
+#include <cstddef>
 #include <cstring>
 
 namespace spdl::archive {


### PR DESCRIPTION
Otherwise the build fails on GCC 11.5