### PR TITLE
Merge `nvdec_decoder` helper function and `init` method

### DIFF
--- a/docs/source/io/gpu_decoding.rst
+++ b/docs/source/io/gpu_decoding.rst
@@ -277,8 +277,7 @@ For hardware-accelerated streaming video decoding with manual control, use :py:c
 
    # Initialize NVDEC decoder
    cuda_config = spdl.io.cuda_config(device_index=0)
-   decoder = spdl.io.nvdec_decoder()
-   decoder.init(cuda_config, codec)
+   decoder = spdl.io.nvdec_decoder(cuda_config, codec)
 
    # IMPORTANT: Bitstream filtering is REQUIRED when using NvDecDecoder
    # Apply bitstream filtering for H.264/HEVC

--- a/src/spdl/io/_composite.py
+++ b/src/spdl/io/_composite.py
@@ -557,8 +557,9 @@ def streaming_load_video_nvdec(
         case _:
             bsf = None
 
-    decoder = _core.nvdec_decoder()
-    decoder.init(device_config, codec, **(post_processing_params or {}))
+    decoder = _core.nvdec_decoder(
+        device_config, codec, **(post_processing_params or {})
+    )
     buffers = []
     for packets in demuxer.streaming_demux_video(num_frames):
         if bsf is not None:


### PR DESCRIPTION
Deprecate the pattern where `init` is called separately.