### PR TITLE
[libspdl] Standardize C++ class member variable naming with _ suffix

### DIFF
--- a/src/libspdl/cuda/buffer.cpp
+++ b/src/libspdl/cuda/buffer.cpp
@@ -22,7 +22,7 @@ void* CUDABuffer::data() const {
 }
 
 uintptr_t CUDABuffer::get_cuda_stream() const {
-  return (uintptr_t)(((CUDAStorage*)(storage.get()))->stream);
+  return (uintptr_t)(((CUDAStorage*)(storage.get()))->stream_);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/src/libspdl/cuda/nvdec/decoder.cpp
+++ b/src/libspdl/cuda/nvdec/decoder.cpp
@@ -56,16 +56,16 @@ void validate_nvdec_params(
 }
 } // namespace
 
-NvDecDecoder::NvDecDecoder() : core(new detail::NvDecDecoderCore()) {}
+NvDecDecoder::NvDecDecoder() : core_(new detail::NvDecDecoderCore()) {}
 
 NvDecDecoder::~NvDecDecoder() {
-  if (core) {
-    delete core;
+  if (core_) {
+    delete core_;
   }
 }
 
 void NvDecDecoder::reset() {
-  core->reset();
+  core_->reset();
 }
 
 void NvDecDecoder::init(
@@ -78,19 +78,19 @@ void NvDecDecoder::init(
     int width,
     int height) {
   validate_nvdec_params(cuda_config.device_index, crop, width, height);
-  core->init(cuda_config, codec, crop, width, height);
+  core_->init(cuda_config, codec, crop, width, height);
 }
 
 std::vector<CUDABuffer> NvDecDecoder::decode(
     spdl::core::VideoPacketsPtr packets) {
   std::vector<CUDABuffer> ret;
-  core->decode_packets(packets.get(), &ret);
+  core_->decode_packets(packets.get(), &ret);
   return ret;
 }
 
 std::vector<CUDABuffer> NvDecDecoder::flush() {
   std::vector<CUDABuffer> ret;
-  core->flush(&ret);
+  core_->flush(&ret);
   return ret;
 }
 } // namespace spdl::cuda

--- a/src/libspdl/cuda/nvdec/decoder.h
+++ b/src/libspdl/cuda/nvdec/decoder.h
@@ -43,7 +43,7 @@ class NvDecDecoderCore;
 // decoder.init();
 class NvDecDecoder {
 #ifdef SPDL_USE_NVCODEC
-  detail::NvDecDecoderCore* core;
+  detail::NvDecDecoderCore* core_;
 #endif
 
  public:

--- a/src/libspdl/cuda/nvdec/detail/decoder.h
+++ b/src/libspdl/cuda/nvdec/detail/decoder.h
@@ -39,7 +39,7 @@ class NvDecDecoderCore {
   //---------------------------------------------------------------------------
   // used to check if decoder configuration needs to be updated.
   // or allocating new memory
-  CUDAConfig device_config{
+  CUDAConfig device_config_{
       .device_index = -1
       // Initialize with invalid index, otherwise when `init` is called, it
       // cannot tell whether it's genuinely initialized.
@@ -50,45 +50,45 @@ class NvDecDecoderCore {
   // Codec config
   //---------------------------------------------------------------------------
   // Codec associated with the parser
-  cudaVideoCodec codec{};
+  cudaVideoCodec codec_{};
   // Params from previous decoder creation.
-  CUVIDDECODECREATEINFO decoder_param{};
+  CUVIDDECODECREATEINFO decoder_param_{};
   //---------------------------------------------------------------------------
 
   //---------------------------------------------------------------------------
   // Global objects (handle to device)
   //---------------------------------------------------------------------------
-  CUcontext cu_ctx;
-  CUvideoctxlock lock;
+  CUcontext cu_ctx_;
+  CUvideoctxlock lock_;
   //---------------------------------------------------------------------------
 
   // Cache the result of `cuvidGetDecoderCaps` as
   // `cuvidGetDecoderCaps` is expensive.
-  std::vector<CUVIDDECODECAPS> cap_cache{};
+  std::vector<CUVIDDECODECAPS> cap_cache_{};
 
   // Core decoder objects
-  CUvideoparserPtr parser{nullptr};
-  CUvideodecoderPtr decoder{nullptr};
+  CUvideoparserPtr parser_{nullptr};
+  CUvideodecoderPtr decoder_{nullptr};
 
  private:
   // Source packet information. Initialized in init
-  int src_width = 0;
-  int src_height = 0;
-  spdl::core::CodecID codec_id;
-  spdl::core::Rational timebase{}; // Time base of the PTS
+  int src_width_ = 0;
+  int src_height_ = 0;
+  spdl::core::CodecID codec_id_;
+  spdl::core::Rational timebase_{}; // Time base of the PTS
 
   //---------------------------------------------------------------------------
   // Post processing params
   //---------------------------------------------------------------------------
   // Resize option Negative values mean not resizing.
-  int target_width = -1;
-  int target_height = -1;
+  int target_width_ = -1;
+  int target_height_ = -1;
   // Cropping options
-  CropArea crop;
+  CropArea crop_;
   //---------------------------------------------------------------------------
 
   // Used to disable all the callbacks during reset.
-  bool cb_disabled = false;
+  bool cb_disabled_ = false;
 
   //---------------------------------------------------------------------------
   // Attributes used for decoding, only during the decoding.
@@ -97,9 +97,9 @@ class NvDecDecoderCore {
   //---------------------------------------------------------------------------
   // Storage for the output frames
   // Used as a reference point for the callback during the decoding.
-  std::vector<CUDABuffer>* frame_buffer;
+  std::vector<CUDABuffer>* frame_buffer_;
   // The user-specified timestamp. Frames outside of this will be discarded.
-  double start_time, end_time;
+  double start_time_, end_time_;
   //---------------------------------------------------------------------------
 
  public:

--- a/src/libspdl/cuda/storage.h
+++ b/src/libspdl/cuda/storage.h
@@ -23,9 +23,9 @@ class CUDAStorage : public core::Storage {
   void* data_ = nullptr;
 
  public:
-  uintptr_t stream = 0;
+  uintptr_t stream_ = 0;
 
-  cuda_deleter_fn deleter;
+  cuda_deleter_fn deleter_;
 
   void* data() const override;
 


### PR DESCRIPTION
Standardize naming convention for class member variables in libspdl/cuda by adding the `_` suffix to distinguish them from local variables and function parameters.
This improves code clarity and follows common C++ conventions.

The naming convention is applied only to class member variables (CUDAStorage, NvDecDecoder, NvDecDecoderCore), while struct members (CUDABuffer, CUDAConfig, CropArea, MapGuard) retain their existing names without the suffix, as structs are passive data structures meant to be accessed externally.