### PR TITLE
Add benchmark for video decoder thread configuration

### DIFF
--- a/examples/benchmark_video.py
+++ b/examples/benchmark_video.py
@@ -1,0 +1,251 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""This example measures the performance of video decoding with different concurrency settings.
+
+It benchmarks :py:func:`spdl.io.load_video` across multiple dimensions:
+
+- Various video resolutions (SD: 640x480, HD: 1920x1080, 4K: 3840x2160)
+- Different worker thread counts (1, 2, 4, 8) for parallel video processing
+- Different decoder thread counts (1, 2, 4) for FFmpeg's internal threading
+
+The benchmark evaluates how throughput changes with:
+
+1. **Worker-level concurrency**: Number of videos processed concurrently (via ``num_workers``)
+2. **Decoder-level concurrency**: FFmpeg's internal threading (via ``decoder_options={"threads": "X"}``)
+
+**Example**
+
+.. code-block:: shell
+
+   $ numactl --membind 0 --cpubind 0 python benchmark_video.py --output video_benchmark_results.csv
+   # Plot results
+   $ python benchmark_video_plot.py --input video_benchmark_results.csv --output video_benchmark_plot.png
+
+**Result**
+
+The benchmark helps identify optimal concurrency settings for video decoding workloads,
+showing how throughput scales with different combinations of worker and decoder threads.
+"""
+
+__all__ = [
+    "BenchmarkConfig",
+    "create_video_data",
+    "load_video_with_config",
+    "main",
+]
+
+import argparse
+import os
+import subprocess
+import tempfile
+from dataclasses import dataclass
+
+import spdl.io
+
+try:
+    from examples.benchmark_utils import (  # pyre-ignore[21]
+        BenchmarkResult,
+        BenchmarkRunner,
+        ExecutorType,
+        get_default_result_path,
+        save_results_to_csv,
+    )
+except ImportError:
+    from spdl.examples.benchmark_utils import (
+        BenchmarkResult,
+        BenchmarkRunner,
+        ExecutorType,
+        get_default_result_path,
+        save_results_to_csv,
+    )
+
+
+DEFAULT_RESULT_PATH: str = get_default_result_path(__file__)
+
+
+@dataclass(frozen=True)
+class BenchmarkConfig:
+    """Configuration for a single video decoding benchmark run.
+
+    Attributes:
+        resolution: Video resolution label (e.g., "SD", "HD", "4K")
+        width: Video width in pixels
+        height: Video height in pixels
+        duration_seconds: Duration of the video in seconds
+        num_workers: Number of concurrent worker threads
+        decoder_threads: Number of FFmpeg decoder threads
+        iterations: Number of iterations per run
+        num_runs: Number of runs for statistical analysis
+    """
+
+    resolution: str
+    width: int
+    height: int
+    duration_seconds: float
+    num_workers: int
+    decoder_threads: int
+    iterations: int
+    num_runs: int
+
+
+def create_video_data(
+    width: int = 1920,
+    height: int = 1080,
+    duration_seconds: float = 5.0,
+    fps: int = 30,
+) -> bytes:
+    """Create a mock H.264 video file in memory for benchmarking.
+
+    Args:
+        width: Video width in pixels
+        height: Video height in pixels
+        duration_seconds: Duration of video in seconds
+        fps: Frames per second
+
+    Returns:
+        Video file as bytes (H.264 encoded in MP4 container)
+    """
+    with tempfile.NamedTemporaryFile(suffix=".mp4") as tmp_file:
+        output_path = tmp_file.name
+
+        cmd = [
+            "ffmpeg",
+            "-f",
+            "lavfi",
+            "-i",
+            f"testsrc=duration={duration_seconds}:size={width}x{height}:rate={fps}",
+            "-c:v",
+            "libx264",
+            "-preset",
+            "ultrafast",
+            "-pix_fmt",
+            "yuv420p",
+            "-y",
+            output_path,
+        ]
+
+        subprocess.run(
+            cmd,
+            check=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+
+        with open(output_path, "rb") as f:
+            video_data = f.read()
+
+        return video_data
+
+
+def load_video_with_config(
+    video_data: bytes, decoder_threads: int
+) -> spdl.io.CPUBuffer:
+    """Load video data using spdl.io.load_video with specified decoder threads.
+
+    Args:
+        video_data: Video file data as bytes
+        decoder_threads: Number of threads for FFmpeg decoder
+
+    Returns:
+        Decoded video frames as CPUBuffer
+    """
+    decode_config = spdl.io.decode_config(
+        decoder_options={"threads": str(decoder_threads)}
+    )
+    return spdl.io.load_video(video_data, decode_config=decode_config)
+
+
+def _parse_args() -> argparse.Namespace:
+    """Parse command line arguments for the benchmark script.
+
+    Returns:
+        Parsed command line arguments
+    """
+    parser = argparse.ArgumentParser(description="Benchmark video decoding performance")
+    parser.add_argument(
+        "--output",
+        type=lambda p: os.path.realpath(p),
+        default=DEFAULT_RESULT_PATH,
+        help="Output file path.",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    """Run comprehensive benchmark suite for video decoding performance.
+
+    Benchmarks video decoding across different resolutions (SD, HD, 4K),
+    worker thread counts (1, 2, 4, 8), and decoder thread counts (1, 2, 4).
+    """
+    args = _parse_args()
+
+    video_configs = [
+        ("SD", 640, 480, 5.0),
+        ("HD", 1920, 1080, 5.0),
+        ("4K", 3840, 2160, 5.0),
+    ]
+
+    worker_counts = [1, 2, 4, 8]
+    decoder_thread_counts = [1, 2, 4]
+
+    results: list[BenchmarkResult[BenchmarkConfig]] = []
+
+    for resolution, width, height, duration in video_configs:
+        print(f"\nCreating {resolution} video ({width}x{height}, {duration}s)...")
+        video_data = create_video_data(
+            width=width, height=height, duration_seconds=duration
+        )
+        print(f"Video size: {len(video_data) / 1024 / 1024:.2f} MB")
+
+        print(f"\n{resolution} ({width}x{height})")
+        print("Workers,Decoder Threads,QPS,CI Lower,CI Upper,CPU %")
+
+        for num_workers in worker_counts:
+            with BenchmarkRunner(
+                executor_type=ExecutorType.THREAD,
+                num_workers=num_workers,
+            ) as runner:
+                for decoder_threads in decoder_thread_counts:
+                    config = BenchmarkConfig(
+                        resolution=resolution,
+                        width=width,
+                        height=height,
+                        duration_seconds=duration,
+                        num_workers=num_workers,
+                        decoder_threads=decoder_threads,
+                        iterations=num_workers * 2,
+                        num_runs=5,
+                    )
+
+                    result, output = runner.run(
+                        config,
+                        lambda data=video_data,
+                        threads=decoder_threads: load_video_with_config(data, threads),
+                        config.iterations,
+                        num_runs=config.num_runs,
+                    )
+
+                    results.append(result)
+
+                    print(
+                        f"{num_workers},{decoder_threads},"
+                        f"{result.qps:.2f},{result.ci_lower:.2f},{result.ci_upper:.2f},"
+                        f"{result.cpu_percent:.1f}"
+                    )
+
+    save_results_to_csv(results, args.output)
+    print(
+        f"\nBenchmark complete. To generate plots, run:\n"
+        f"python benchmark_video_plot.py --input {args.output} "
+        f"--output {args.output.replace('.csv', '.png')}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/benchmark_video_plot.py
+++ b/examples/benchmark_video_plot.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""Plot benchmark results from video decoding benchmarks.
+
+This script reads benchmark results from a CSV file and generates plots
+comparing performance across different video resolutions and concurrency settings.
+
+**Example**
+
+.. code-block:: shell
+
+   $ python benchmark_video_plot.py --input benchmark_results.csv --output plot.png
+"""
+
+import argparse
+import os
+
+import matplotlib
+import matplotlib.pyplot as plt
+
+try:
+    from examples.benchmark_utils import load_results_from_csv  # pyre-ignore[21]
+    from examples.benchmark_video import (  # pyre-ignore[21]
+        BenchmarkConfig,
+        DEFAULT_RESULT_PATH,
+    )
+except ImportError:
+    from spdl.examples.benchmark_utils import load_results_from_csv
+    from spdl.examples.benchmark_video import BenchmarkConfig, DEFAULT_RESULT_PATH
+
+
+def plot_benchmark_results(
+    csv_file: str,
+    output_file: str = "benchmark_results.png",
+) -> None:
+    """Plot benchmark results and save to file.
+
+    Args:
+        csv_file: Path to CSV file containing benchmark data
+        output_file: Output file path for the saved plot
+    """
+    matplotlib.use("Agg")
+
+    results = load_results_from_csv(csv_file, BenchmarkConfig)
+
+    if not results:
+        print("No results to plot")
+        return
+
+    python_version = results[0].python_version
+    free_threaded = results[0].free_threaded
+
+    abi_info = " (free-threaded)" if free_threaded else ""
+
+    resolutions = sorted(set(r.config.resolution for r in results))
+
+    fig, axes = plt.subplots(2, len(resolutions), figsize=(6 * len(resolutions), 10))
+    if len(resolutions) == 1:
+        axes = axes.reshape(2, 1)
+
+    for idx, resolution in enumerate(resolutions):
+        ax_qps = axes[0, idx]
+        ax_cpu = axes[1, idx]
+        resolution_results = [r for r in results if r.config.resolution == resolution]
+
+        decoder_threads_set = sorted(
+            set(r.config.decoder_threads for r in resolution_results)
+        )
+
+        for decoder_threads in decoder_threads_set:
+            thread_results = [
+                r
+                for r in resolution_results
+                if r.config.decoder_threads == decoder_threads
+            ]
+            thread_results.sort(key=lambda x: x.config.num_workers)
+
+            worker_counts = [r.config.num_workers for r in thread_results]
+            qps_values = [r.qps for r in thread_results]
+            ci_lower_values = [r.ci_lower for r in thread_results]
+            ci_upper_values = [r.ci_upper for r in thread_results]
+            cpu_values = [r.cpu_percent for r in thread_results]
+
+            line = ax_qps.plot(
+                worker_counts,
+                qps_values,
+                marker="o",
+                label=f"{decoder_threads} decoder threads",
+                linewidth=2,
+            )
+
+            ax_qps.fill_between(
+                worker_counts,
+                ci_lower_values,
+                ci_upper_values,
+                alpha=0.2,
+                color=line[0].get_color(),
+            )
+
+            ax_cpu.plot(
+                worker_counts,
+                cpu_values,
+                marker="s",
+                label=f"{decoder_threads} decoder threads",
+                linewidth=2,
+                color=line[0].get_color(),
+            )
+
+        ax_qps.set_xlabel("Number of Workers", fontsize=11)
+        ax_qps.set_ylabel("QPS (Videos Per Second)", fontsize=11)
+        ax_qps.set_title(f"{resolution} Resolution", fontsize=12, fontweight="bold")
+        ax_qps.legend(title="Decoder Threads", fontsize=9)
+        ax_qps.grid(True, alpha=0.3)
+
+        ax_cpu.set_xlabel("Number of Workers", fontsize=11)
+        ax_cpu.set_ylabel("CPU Utilization (%)", fontsize=11)
+        ax_cpu.set_title(f"{resolution} CPU Usage", fontsize=12, fontweight="bold")
+        ax_cpu.legend(title="Decoder Threads", fontsize=9)
+        ax_cpu.grid(True, alpha=0.3)
+
+    fig.suptitle(
+        f"Video Decoding Performance Benchmark\nPython {python_version}{abi_info}",
+        fontsize=14,
+        fontweight="bold",
+    )
+
+    plt.tight_layout()
+    plt.savefig(output_file, dpi=300, bbox_inches="tight")
+    print(f"Plot saved to {output_file}")
+
+
+def _parse_args() -> argparse.Namespace:
+    """Parse command line arguments.
+
+    Returns:
+        Parsed arguments.
+    """
+    parser = argparse.ArgumentParser(
+        description="Plot video decoding benchmark results from CSV"
+    )
+    parser.add_argument(
+        "--input",
+        type=lambda p: os.path.realpath(p),
+        default=DEFAULT_RESULT_PATH,
+        help="Input CSV file with benchmark results",
+    )
+    parser.add_argument(
+        "--output",
+        type=lambda p: os.path.realpath(p),
+        help="Output path for the plot",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    """Main entry point for the plotting script."""
+    args = _parse_args()
+
+    output_file = args.output
+    if output_file is None:
+        output_file = args.input.replace(".csv", ".png")
+
+    plot_benchmark_results(args.input, output_file)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/spdl/io/_composite.py
+++ b/src/spdl/io/_composite.py
@@ -191,10 +191,22 @@ def load_video(
     Returns:
         Buffer object.
 
+    Note:
+        The decoder thread configuration can significantly affect video decoding
+        performance. By default, SPDL uses a single thread for decoding. You can
+        customize this via ``decode_config`` using
+        ``decoder_options={"threads": "X"}``, where ``X`` is the number of threads
+        (or ``"0"`` to let FFmpeg choose automatically).
+
+        The optimal configuration depends on your workload's characteristics.
+        For benchmarking different thread configurations, see
+        :doc:`../examples/benchmark_video`.
+
     See Also:
         - :doc:`../io/basic` - High-level loading functions documentation
         - :doc:`../io/decoding_overview` - Understanding the decoding pipeline
         - :doc:`../io/filtering` - Customizing output with filters
+        - :doc:`../examples/benchmark_video` - Benchmark for thread configuration
     """
     _core.log_api_usage_once("spdl.io.load_video")
 

--- a/src/spdl/io/_core.py
+++ b/src/spdl/io/_core.py
@@ -644,6 +644,17 @@ def decode_packets(
 
     Returns:
         Frames object.
+
+    Note:
+        The decoder thread configuration can significantly affect video decoding
+        performance. By default, SPDL uses a single thread for decoding. You can
+        customize this via ``decode_config`` using
+        ``decoder_options={"threads": "X"}``, where ``X`` is the number of threads
+        (or ``"0"`` to let FFmpeg choose automatically).
+
+        The optimal configuration depends on your workload's characteristics.
+        For benchmarking different thread configurations, see
+        :doc:`../examples/benchmark_video`.
     """
 
     if filter_desc is not None:


### PR DESCRIPTION
This changeset introduces a new benchmark example for SPDL, which compares the throughput of video decoding under various concurrency settings and measures CPU utilization.

The benchmark generates mock H.264 videos in different resolutions (SD, HD, 4K) and tests the `spdl.io.load_video` function with different worker-level and decoder-level concurrency settings.

The results are output to a CSV file and can be visualized using a plotting script.
This benchmark provides valuable insights into the performance of SPDL's video decoding capabilities and helps identify potential bottlenecks.

The changes include updates to benchmark_utils.py to track CPU utilization and the creation of new files benchmark_video.py and benchmark_video_plot.py to run and visualize the benchmark.