### PR TITLE
Refactor the handling of Rationals 

### DIFF
--- a/src/libspdl/core/detail/ffmpeg/decoder.cpp
+++ b/src/libspdl/core/detail/ffmpeg/decoder.cpp
@@ -8,6 +8,7 @@
 
 #include "libspdl/core/detail/ffmpeg/decoder.h"
 
+#include <libspdl/core/rational_utils.h>
 #include <libspdl/core/utils.h>
 
 #include "libspdl/core/detail/ffmpeg/ctx_utils.h"

--- a/src/libspdl/core/detail/ffmpeg/demuxer.h
+++ b/src/libspdl/core/detail/ffmpeg/demuxer.h
@@ -23,8 +23,10 @@ class DemuxerImpl {
   DataInterfacePtr di_;
   AVFormatContext* fmt_ctx_ = nullptr;
 
-  Generator<AVPacketPtr>
-  demux_window(AVStream* stream, const double end, std::optional<BSFImpl>& bsf);
+  Generator<AVPacketPtr> demux_window(
+      AVStream* stream,
+      const AVRational end,
+      std::optional<BSFImpl>& bsf);
 
  public:
   explicit DemuxerImpl(DataInterfacePtr di);

--- a/src/libspdl/core/frames.cpp
+++ b/src/libspdl/core/frames.cpp
@@ -8,6 +8,7 @@
 
 #include <libspdl/core/frames.h>
 
+#include <libspdl/core/rational_utils.h>
 #include <libspdl/core/types.h>
 #include <libspdl/core/utils.h>
 
@@ -96,7 +97,7 @@ int64_t Frames<media>::get_pts(size_t index) const {
 
 template <MediaType media>
 double Frames<media>::get_timestamp(size_t index) const {
-  return av_q2d(detail::to_rational(get_pts(index), time_base_));
+  return av_q2d(to_rational(get_pts(index), time_base_));
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/src/libspdl/core/rational_utils.cpp
+++ b/src/libspdl/core/rational_utils.cpp
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <libspdl/core/rational_utils.h>
+
+#include <glog/logging.h>
+
+extern "C" {
+#include <libavutil/rational.h>
+}
+
+namespace spdl::core {
+
+bool is_within_window(
+    const Rational& val,
+    const Rational& start,
+    const Rational& end) {
+  return (av_cmp_q(start, val) <= 0) && (av_cmp_q(val, end) < 0);
+}
+
+Rational to_rational(int64_t val, const Rational tb) {
+  Rational ret;
+  if (!av_reduce(&ret.num, &ret.den, val * tb.num, tb.den, INT32_MAX)) {
+    // Warn once that reduced PTS may be inexact due to rational reduction
+    // constraints.
+    static bool warned_inexact_pts = false;
+    if (!warned_inexact_pts) {
+      LOG(WARNING) << "PTS conversion was not exact during rational reduction; "
+                      "timestamp might be slightly inaccurate.";
+      warned_inexact_pts = true;
+    }
+  }
+  return ret;
+}
+
+Rational make_rational(const std::tuple<int64_t, int64_t>& val) {
+  auto& [num, den] = val;
+  Rational ret;
+  if (!av_reduce(&ret.num, &ret.den, num, den, INT32_MAX)) {
+    LOG(WARNING)
+        << "Timestamp conversion was not exact during rational reduction; "
+           "timestamp might be slightly inaccurate.";
+  }
+  return ret;
+}
+
+double to_double(const Rational& val) {
+  return av_q2d(val);
+}
+
+} // namespace spdl::core

--- a/src/libspdl/core/rational_utils.h
+++ b/src/libspdl/core/rational_utils.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <libspdl/core/types.h>
+
+#include <cstdint>
+#include <tuple>
+
+namespace spdl::core {
+
+// Check if a given AVRational value falls within a specified window [start,
+// end). Returns true if start <= val < end (half-open interval).
+bool is_within_window(
+    const Rational& val,
+    const Rational& start,
+    const Rational& end);
+
+Rational to_rational(int64_t val, const Rational time_base);
+
+Rational make_rational(const std::tuple<int64_t, int64_t>& val);
+
+double to_double(const Rational& val);
+
+} // namespace spdl::core

--- a/src/libspdl/core/utils.cpp
+++ b/src/libspdl/core/utils.cpp
@@ -204,45 +204,4 @@ void trace_event_end() {
 #endif
 }
 
-////////////////////////////////////////////////////////////////////////////////
-// Utilities moved from rational_utils.h
-////////////////////////////////////////////////////////////////////////////////
-namespace detail {
-
-bool is_within_window(
-    const AVRational& val,
-    const AVRational& start,
-    const AVRational& end) {
-  return (av_cmp_q(start, val) <= 0) && (av_cmp_q(val, end) < 0);
-}
-
-AVRational to_rational(int64_t val, const AVRational time_base) {
-  AVRational ret;
-  if (av_reduce(
-          &ret.num, &ret.den, val * time_base.num, time_base.den, INT32_MAX)) {
-    // Warn once that reduced PTS may be inexact due to rational reduction
-    // constraints.
-    static bool warned_inexact_pts = false;
-    if (!warned_inexact_pts) {
-      LOG(WARNING) << "PTS conversion was not exact during rational reduction; "
-                      "timestamps might be slightly inaccurate.";
-      warned_inexact_pts = true;
-    }
-  }
-  return ret;
-}
-
-Rational make_rational(const std::tuple<int64_t, int64_t>& val) {
-  Rational ret;
-  if (av_reduce(
-          &ret.num, &ret.den, std::get<0>(val), std::get<1>(val), INT32_MAX) !=
-      1) {
-    LOG(WARNING) << "PTS conversion was not exact during rational reduction; "
-                    "timestamps might be slightly inaccurate.";
-  }
-  return ret;
-}
-
-} // namespace detail
-
 } // namespace spdl::core

--- a/src/libspdl/core/utils.h
+++ b/src/libspdl/core/utils.h
@@ -11,7 +11,6 @@
 #include <libspdl/core/types.h>
 
 #include <memory>
-#include <optional>
 #include <string>
 #include <tuple>
 #include <vector>
@@ -64,23 +63,5 @@ template <typename Number>
 void trace_counter(int i, Number counter);
 void trace_event_begin(const std::string& name);
 void trace_event_end();
-
-//////////////////////////////////////////////////////////////////////////////////
-// Non-user facing utilities
-//////////////////////////////////////////////////////////////////////////////////
-namespace detail {
-
-// Check if a given AVRational value falls within a specified window [start,
-// end). Returns true if start <= val < end (half-open interval).
-bool is_within_window(
-    const AVRational& val,
-    const AVRational& start,
-    const AVRational& end);
-
-AVRational to_rational(int64_t val, const AVRational time_base);
-
-Rational make_rational(const std::tuple<int64_t, int64_t>& val);
-
-} // namespace detail
 
 } // namespace spdl::core

--- a/src/libspdl/cuda/nvdec/detail/decoder.h
+++ b/src/libspdl/cuda/nvdec/detail/decoder.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <libspdl/core/packets.h>
+#include <libspdl/core/types.h>
 #include <libspdl/cuda/buffer.h>
 
 #include "libspdl/cuda/nvdec/detail/wrapper.h"
@@ -19,6 +20,7 @@
 #include <vector>
 
 namespace spdl::cuda::detail {
+using spdl::core::Rational;
 
 // NOTE
 // This class is designed to be used as thread local.
@@ -99,7 +101,7 @@ class NvDecDecoderCore {
   // Used as a reference point for the callback during the decoding.
   std::vector<CUDABuffer>* frame_buffer_;
   // The user-specified timestamp. Frames outside of this will be discarded.
-  double start_time_, end_time_;
+  std::optional<std::tuple<Rational, Rational>> time_window_ = std::nullopt;
   //---------------------------------------------------------------------------
 
  public:

--- a/src/libspdl/tests/rational_utils_test.cpp
+++ b/src/libspdl/tests/rational_utils_test.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include <libspdl/core/utils.h>
+#include <libspdl/core/rational_utils.h>
 
 #include <gtest/gtest.h>
 
@@ -14,7 +14,7 @@ extern "C" {
 #include <libavutil/rational.h>
 }
 
-namespace spdl::core::detail {
+namespace spdl::core {
 namespace {
 
 TEST(RationalUtilsTest, IsWithinWindowBasic) {
@@ -141,4 +141,4 @@ TEST(RationalUtilsTest, ToRationalNegativeValue) {
 }
 
 } // namespace
-} // namespace spdl::core::detail
+} // namespace spdl::core

--- a/src/spdl/io/lib/core/demuxing.cpp
+++ b/src/spdl/io/lib/core/demuxing.cpp
@@ -9,7 +9,7 @@
 #include "register_spdl_core_extensions.h"
 
 #include <libspdl/core/demuxing.h>
-#include <libspdl/core/utils.h>
+#include <libspdl/core/rational_utils.h>
 
 #include <fmt/core.h>
 
@@ -75,14 +75,13 @@ struct PyDemuxer {
 
     // Convert from Python format ((num1, den1), (num2, den2)) to C++ AVRational
     // format
-    std::optional<std::tuple<Rational, Rational>> cpp_window = std::nullopt;
+    std::optional<std::tuple<Rational, Rational>> w = std::nullopt;
     if (window) {
-      cpp_window = std::make_tuple(
-          detail::make_rational(std::get<0>(*window)),
-          detail::make_rational(std::get<1>(*window)));
+      w = std::make_tuple(
+          make_rational(std::get<0>(*window)),
+          make_rational(std::get<1>(*window)));
     }
-
-    return demuxer->demux_window<media>(cpp_window, bsf);
+    return demuxer->demux_window<media>(w, bsf);
   }
 
   PacketsPtr<MediaType::Image> demux_image(
@@ -183,7 +182,7 @@ void register_demuxing(nb::module_& m) {
           "time_base",
           [](AudioCodec& self) -> std::tuple<int, int> {
             auto base = self.get_time_base();
-            return {base.num, base.den};
+            return std::tuple<int, int>{base.num, base.den};
           },
           nb::call_guard<nb::gil_scoped_release>(),
           "The internal unit of time used for timestamp.\n\n"
@@ -226,7 +225,7 @@ void register_demuxing(nb::module_& m) {
           "frame_rate",
           [](VideoCodec& self) -> std::tuple<int, int> {
             auto rate = self.get_frame_rate();
-            return {rate.num, rate.den};
+            return std::tuple<int, int>{rate.num, rate.den};
           },
           nb::call_guard<nb::gil_scoped_release>(),
           "The frame rate of the video.\n\n"
@@ -235,7 +234,7 @@ void register_demuxing(nb::module_& m) {
           "time_base",
           [](VideoCodec& self) -> std::tuple<int, int> {
             auto base = self.get_time_base();
-            return {base.num, base.den};
+            return std::tuple<int, int>{base.num, base.den};
           },
           nb::call_guard<nb::gil_scoped_release>(),
           "The internal unit of time used for timestamp.\n\n"
@@ -244,7 +243,7 @@ void register_demuxing(nb::module_& m) {
           "sample_aspect_ratio",
           [](VideoCodec& self) -> std::tuple<int, int> {
             auto r = self.get_sample_aspect_ratio();
-            return {r.num, r.den};
+            return std::tuple<int, int>{r.num, r.den};
           },
           nb::call_guard<nb::gil_scoped_release>(),
           "The aspect ratio of a single pixel.\n\n"
@@ -277,7 +276,7 @@ void register_demuxing(nb::module_& m) {
           "time_base",
           [](ImageCodec& self) -> std::tuple<int, int> {
             auto base = self.get_time_base();
-            return {base.num, base.den};
+            return std::tuple<int, int>{base.num, base.den};
           },
           nb::call_guard<nb::gil_scoped_release>(),
           "The internal unit of time used for timestamp.\n\n"
@@ -288,7 +287,7 @@ void register_demuxing(nb::module_& m) {
           "sample_aspect_ratio",
           [](ImageCodec& self) -> std::tuple<int, int> {
             auto r = self.get_sample_aspect_ratio();
-            return {r.num, r.den};
+            return std::tuple<int, int>{r.num, r.den};
           },
           nb::call_guard<nb::gil_scoped_release>(),
           "The aspect ratio of a single pixel.\n\n"

--- a/src/spdl/io/lib/core/packets.cpp
+++ b/src/spdl/io/lib/core/packets.cpp
@@ -9,6 +9,7 @@
 #include "register_spdl_core_extensions.h"
 
 #include <libspdl/core/packets.h>
+#include <libspdl/core/rational_utils.h>
 #include <libspdl/core/types.h>
 
 #include <nanobind/nanobind.h>
@@ -52,10 +53,7 @@ std::string get_summary(const Codec<media>& c) {
 
 std::string get_ts(const TimeWindow& ts) {
   auto [start, end] = ts;
-  // TODO: Use av_q2d
-  double start_val = static_cast<double>(start.num) / start.den;
-  double end_val = static_cast<double>(end.num) / end.den;
-  return fmt::format("timestamp=({}, {})", start_val, end_val);
+  return fmt::format("timestamp=({}, {})", to_double(start), to_double(end));
 }
 
 template <MediaType media>
@@ -110,11 +108,8 @@ void register_packets(nb::module_& m) {
               -> std::optional<std::tuple<double, double>> {
             nb::gil_scoped_release __g;
             if (self.timestamp) {
-              auto [start, end] = *self.timestamp;
-              // TODO: Use av_q2d
-              return std::make_tuple(
-                  static_cast<double>(start.num) / start.den,
-                  static_cast<double>(end.num) / end.den);
+              auto [s, e] = *self.timestamp;
+              return std::make_tuple(to_double(s), to_double(e));
             }
             return std::nullopt;
           },
@@ -185,11 +180,8 @@ void register_packets(nb::module_& m) {
               -> std::optional<std::tuple<double, double>> {
             nb::gil_scoped_release __g;
             if (self.timestamp) {
-              // TODO: Use av_q2d
-              auto [start, end] = *self.timestamp;
-              return std::make_tuple(
-                  static_cast<double>(start.num) / start.den,
-                  static_cast<double>(end.num) / end.den);
+              auto [s, e] = *self.timestamp;
+              return std::make_tuple(to_double(s), to_double(e));
             }
             return std::nullopt;
           },


### PR DESCRIPTION
Manually multiplying and dividing Rational objects can
introduce issues like integer overflow and zero divisions.

This commit adds `rational_utils` module which delegates
the computation to FFmepg's utilities. Then use the utilities
in the codebase.