### PR TITLE
Ensure upstreams are cleaned up when Merge stage finishes

### DIFF
--- a/src/spdl/pipeline/_components/_common.py
+++ b/src/spdl/pipeline/_components/_common.py
@@ -7,6 +7,7 @@
 __all__ = [
     "_periodic_dispatch",
     "_StatsCounter",
+    "_StageCompleted",
     "_time_str",
 ]
 
@@ -105,3 +106,9 @@ async def _periodic_dispatch(
 
     if pending:
         await asyncio.wait(pending)
+
+
+class _StageCompleted(Exception):
+    """Notify the pipeline execution system this stage is completed."""
+
+    pass

--- a/src/spdl/pipeline/_components/_node.py
+++ b/src/spdl/pipeline/_components/_node.py
@@ -25,6 +25,7 @@ from spdl.pipeline.defs import (
     SourceConfig,
 )
 
+from ._common import _StageCompleted
 from ._hook import get_default_hook_class, TaskHook
 from ._pipe import (
     _Aggregate,
@@ -404,7 +405,9 @@ async def _run_pipeline_coroutines(node: _Node[T]) -> None:
         if canceled := _cancel_upstreams_of_errors(node):
             await asyncio.wait(canceled)
 
-    if errs := _gather_error(node):
+    errs = _gather_error(node)
+    errs = [(n, e) for n, e in errs if not isinstance(e, _StageCompleted)]
+    if errs:
         raise PipelineFailure(errs)
 
 

--- a/src/spdl/pipeline/_components/_pipe.py
+++ b/src/spdl/pipeline/_components/_pipe.py
@@ -25,7 +25,7 @@ from spdl.pipeline._common._misc import create_task
 from spdl.pipeline._common._types import _TMergeOp
 from spdl.pipeline.defs import _PipeArgs
 
-from ._common import _EOF, is_eof
+from ._common import _EOF, _StageCompleted, is_eof
 from ._hook import _stage_hooks, _task_hooks, TaskHook
 from ._queue import _queue_stage_hook, AsyncQueue
 
@@ -405,5 +405,10 @@ def _merge(
     @_stage_hooks(hooks)
     async def merge() -> None:
         await op(name, input_queues, output_queue)
+
+        # This notifies the Pipeline execution system that this stage is
+        # completed regardless of the state of the upstream stages.
+        # The Pipeline execution system should clean up the upstream stages.
+        raise _StageCompleted()
 
     return merge()


### PR DESCRIPTION
Introduces a mechanism to ensure that the stages upstream to merge operations are 
cleaned up when a merge operation is completed.

This enables custom merge operations to exit early based on their own logic 
while ensuring proper resource cleanup.

**Implementation detail**

We introduce a `_StageCompleted` exception type, which is sort of analogous to Python's
built-in `StopIteration` exception, and the merge stage to throw it at the end.
This signals the Pipeline execution mechanism to clean up the upstream stages.
Then we filter out the instances of `_StageCompleted` from the list of errors that
should be propagated to the front end, so as not to treat it as a real error.

Note: In a subsequent PR, we get rid of `_StageCompleted` and simplify the logic.

