### PR TITLE
Generalize the clean up mechanism

### DIFF
--- a/src/spdl/pipeline/_components/_common.py
+++ b/src/spdl/pipeline/_components/_common.py
@@ -7,7 +7,6 @@
 __all__ = [
     "_periodic_dispatch",
     "_StatsCounter",
-    "_StageCompleted",
     "_time_str",
 ]
 
@@ -106,9 +105,3 @@ async def _periodic_dispatch(
 
     if pending:
         await asyncio.wait(pending)
-
-
-class _StageCompleted(Exception):
-    """Notify the pipeline execution system this stage is completed."""
-
-    pass

--- a/src/spdl/pipeline/_components/_pipe.py
+++ b/src/spdl/pipeline/_components/_pipe.py
@@ -25,7 +25,7 @@ from spdl.pipeline._common._misc import create_task
 from spdl.pipeline._common._types import _TMergeOp
 from spdl.pipeline.defs import _PipeArgs
 
-from ._common import _EOF, _StageCompleted, is_eof
+from ._common import _EOF, is_eof
 from ._hook import _stage_hooks, _task_hooks, TaskHook
 from ._queue import _queue_stage_hook, AsyncQueue
 
@@ -405,10 +405,5 @@ def _merge(
     @_stage_hooks(hooks)
     async def merge() -> None:
         await op(name, input_queues, output_queue)
-
-        # This notifies the Pipeline execution system that this stage is
-        # completed regardless of the state of the upstream stages.
-        # The Pipeline execution system should clean up the upstream stages.
-        raise _StageCompleted()
 
     return merge()

--- a/src/spdl/pipeline/defs/_defs.py
+++ b/src/spdl/pipeline/defs/_defs.py
@@ -386,6 +386,11 @@ def Merge(
             If not provided, the default merge operation will be used, which passes items
             from all input queues to the output queue in the order they become available.
 
+            .. versionchanged:: 0.1.7
+               Custom merge operations can now exit early without hanging the pipeline.
+               The upstream stages are automatically cleaned up when the merge operation
+               returns.
+
     Returns:
         The config object.
 


### PR DESCRIPTION
Instead of requiring individual stage implementation to throw specific error, we can always ensure that when a stage task is done, its upstream stages are all canceled regardless of the task succeeded, failed or cancelled.

Follow-up of https://github.com/facebookresearch/spdl/pull/1207