### PR TITLE
Do not specify cmake and ninja in pyproject.toml

### DIFF
--- a/packaging/spdl_io/pyproject.toml
+++ b/packaging/spdl_io/pyproject.toml
@@ -19,8 +19,12 @@ Documentation = "https://facebookresearch.github.io/spdl/main/index.html"
 [build-system]
 requires = [
     "setuptools>=77.0.0",
-    "ninja",
-    "cmake>=3.24",
     "typing_extensions",
+    # Note: We used to specify these and let the build backend fetch the
+    # tools, however with uv they goes to a temporary directory which is
+    # not available in the subsequent build attempts, which gives pretty
+    # bad UX for local development, so we decided to exclude them.
+    # "ninja",
+    # "cmake>=3.24",
 ]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
For a while we had `cmake` and `ninja` specified in `pyproject.toml` of spdl-io package.

Sometimes with `uv`, the build process cannot find `ninja` for a reason I don't know, and the issue parsists.

It's pretty annoying when local dev, so we do not specify these within build, and rely on the host to have these installed somewhere.