### PR TITLE
[BC-breaking] Remove compat args and methods

### DIFF
--- a/src/spdl/io/_composite.py
+++ b/src/spdl/io/_composite.py
@@ -57,14 +57,7 @@ def _load_packets(
     decode_config: "DecodeConfig | None" = None,
     filter_desc: str | None = _FILTER_DESC_DEFAULT,
     device_config: "CUDAConfig | None" = None,
-    **kwargs,
 ):
-    if device_config is None and "cuda_config" in kwargs:
-        warnings.warn(
-            "`cuda_config` argument has been renamed to `device_config`.", stacklevel=3
-        )
-        device_config = kwargs["cuda_config"]
-
     frames = _core.decode_packets(
         packets, decode_config=decode_config, filter_desc=filter_desc
     )
@@ -418,20 +411,6 @@ def load_image_batch(
 
     if not srcs:
         raise ValueError("`srcs` must not be empty.")
-
-    if "pin_memory" in kwargs:
-        warnings.warn(
-            "`pin_memory` argument has been removed. Use `storage` instead.",
-            stacklevel=2,
-        )
-        kwargs.pop("pin_memory")
-
-    if device_config is None and "cuda_config" in kwargs:
-        warnings.warn(
-            "The `cuda_config` argument has ben renamed to `device_config`.",
-            stacklevel=2,
-        )
-        device_config = kwargs["cuda_config"]
 
     if filter_desc == _FILTER_DESC_DEFAULT:
         filter_desc = _preprocessing.get_video_filter_desc(

--- a/tests/cuda/nvdec_video_decoding_test.py
+++ b/tests/cuda/nvdec_video_decoding_test.py
@@ -189,8 +189,8 @@ class TestNvdecH264(unittest.TestCase):
         array = _decode_video(
             h264.path,
             timestamp=(0, 1.0),
-            width=width,
-            height=height,
+            scale_width=width,
+            scale_height=height,
         )
 
         # _save(array, "./resize")
@@ -241,8 +241,8 @@ class TestNvdecH264(unittest.TestCase):
             crop_bottom=bottom,
             crop_left=left,
             crop_right=right,
-            width=w,
-            height=h,
+            scale_width=w,
+            scale_height=h,
         )
 
         self.assertEqual(array.dtype, torch.uint8)


### PR DESCRIPTION
These are deprecated a while ago.

- Remove compat layer for obsolete arguments like `width`, `height`, `pin_memory` and `cuda_config`.
- Remove `_streaming_demux_video` method.