### PR TITLE
Fix CQS signal facebook-unused-include-check in fbcode/libspdl/core

### DIFF
--- a/src/libspdl/core/packets.cpp
+++ b/src/libspdl/core/packets.cpp
@@ -9,7 +9,6 @@
 #include <libspdl/core/packets.h>
 
 #include <libspdl/core/rational_utils.h>
-#include <libspdl/core/utils.h>
 
 #include "libspdl/core/detail/ffmpeg/logging.h"
 #include "libspdl/core/detail/tracing.h"


### PR DESCRIPTION
Differential Revision: D88130440


