### PR TITLE
[BC-Breaking] Default to per-thread default stream

### DIFF
--- a/src/libspdl/cuda/transfer.cpp
+++ b/src/libspdl/cuda/transfer.cpp
@@ -26,10 +26,10 @@ size_t prod(const std::vector<size_t>& shape) {
   return ret;
 }
 
-std::once_flag WARN_DEFAULT_STREAM_FLAG;
-void warn_default_stream() noexcept {
+std::once_flag WARN_LEGACY_DEFAULT_STREAM_FLAG;
+void warn_legacy_default_stream() noexcept {
   LOG(WARNING)
-      << "The CPUStorage is page-locked (pinned), but the default CUDA stream is used. "
+      << "The CPUStorage is page-locked (pinned), but the legacy default CUDA stream (0) is used. "
          "This is likely not what you intend. "
          "Please use a non-default CUDA stream to overlap the data transfer with kernel execution.";
 }
@@ -46,8 +46,9 @@ CUDABufferPtr transfer_buffer_impl(
   size_t size = depth * prod(shape);
 
   if (pinned_memory) {
-    if (!cfg.stream) {
-      std::call_once(WARN_DEFAULT_STREAM_FLAG, warn_default_stream);
+    if (cfg.stream == 0) {
+      std::call_once(
+          WARN_LEGACY_DEFAULT_STREAM_FLAG, warn_legacy_default_stream);
     }
     auto s = (cudaStream_t)cfg.stream;
     CHECK_CUDA(

--- a/src/spdl/io/lib/_libspdl_cuda.pyi
+++ b/src/spdl/io/lib/_libspdl_cuda.pyi
@@ -27,7 +27,7 @@ class CUDAConfig:
     See the factory function :py:func:`~spdl.io.cuda_config`.
     """
 
-def cuda_config(device_index: int, stream: int = 0, allocator: tuple[Callable[[int, int, int], int], Callable[[int], None]] | None = None) -> CUDAConfig: ...
+def cuda_config(device_index: int, stream: int = 2, allocator: tuple[Callable[[int, int, int], int], Callable[[int], None]] | None = None) -> CUDAConfig: ...
 
 class CUDABuffer:
     """

--- a/src/spdl/io/lib/cuda/types.cpp
+++ b/src/spdl/io/lib/cuda/types.cpp
@@ -46,7 +46,7 @@ void register_types(nb::module_& m) {
       },
       nb::call_guard<nb::gil_scoped_release>(),
       nb::arg("device_index"),
-      nb::arg("stream") = 0,
+      nb::arg("stream") = 0x2,
       nb::arg("allocator") = nb::none());
 }
 } // namespace spdl::cuda


### PR DESCRIPTION
The intended usage of SPDL IO is they perform preprocessing in background process. Therefore, `libspdl/cuda` defaults to use per-thread default CUDA stream.

However, some functions do not comply this pattern, and the Python binding defaults to the legacy default stream, which can interfere with the NN computation.

This commits ensures that the default stream is used, and all the functions use the stream specified in the CUDAConfig.