### PR TITLE
Pre-allocate output buffer when decoding with NVDEC

### DIFF
--- a/src/libspdl/cuda/color_conversion.h
+++ b/src/libspdl/cuda/color_conversion.h
@@ -51,4 +51,46 @@ CUDABufferPtr nv12_to_planar_bgr(
     int matrix_coefficients = 1,
     bool sync = true);
 
+/// Convert batched NV12 frames (3D buffer) to planar RGB format on GPU.
+///
+/// This is an optimized version that takes a pre-allocated 3D buffer containing
+/// multiple NV12 frames, reducing memory allocation overhead.
+///
+/// @param nv12_batch 3D buffer with shape [max_frames, height*1.5, width].
+/// @param num_frames Actual number of frames to convert (may be <= max_frames).
+/// @param cfg CUDA configuration including device and stream.
+/// @param matrix_coefficients Color matrix coefficients for conversion
+/// (default: BT.709).
+/// @param sync If true, synchronizes the stream before returning (default:
+/// true).
+/// @return CUDA buffer containing planar RGB data with shape [num_frames, 3,
+/// height, width].
+CUDABufferPtr nv12_to_planar_rgb_batched(
+    const CUDABuffer& nv12_batch,
+    size_t num_frames,
+    const CUDAConfig& cfg,
+    int matrix_coefficients = 1,
+    bool sync = true);
+
+/// Convert batched NV12 frames (3D buffer) to planar BGR format on GPU.
+///
+/// This is an optimized version that takes a pre-allocated 3D buffer containing
+/// multiple NV12 frames, reducing memory allocation overhead.
+///
+/// @param nv12_batch 3D buffer with shape [max_frames, height*1.5, width].
+/// @param num_frames Actual number of frames to convert (may be <= max_frames).
+/// @param cfg CUDA configuration including device and stream.
+/// @param matrix_coefficients Color matrix coefficients for conversion
+/// (default: BT.709).
+/// @param sync If true, synchronizes the stream before returning (default:
+/// true).
+/// @return CUDA buffer containing planar BGR data with shape [num_frames, 3,
+/// height, width].
+CUDABufferPtr nv12_to_planar_bgr_batched(
+    const CUDABuffer& nv12_batch,
+    size_t num_frames,
+    const CUDAConfig& cfg,
+    int matrix_coefficients = 1,
+    bool sync = true);
+
 } // namespace spdl::cuda

--- a/src/libspdl/cuda/nvdec/decoder.cpp
+++ b/src/libspdl/cuda/nvdec/decoder.cpp
@@ -93,4 +93,8 @@ std::vector<CUDABuffer> NvDecDecoder::flush() {
   core_->flush(&ret);
   return ret;
 }
+
+CUDABuffer NvDecDecoder::decode_all(spdl::core::VideoPacketsPtr packets) {
+  return core_->decode_all(packets.get());
+}
 } // namespace spdl::cuda

--- a/src/libspdl/cuda/nvdec/decoder.h
+++ b/src/libspdl/cuda/nvdec/decoder.h
@@ -75,6 +75,11 @@ class NvDecDecoder {
 
   // Call this method at the end of video stream.
   _RET_ATTR std::vector<CUDABuffer> flush();
+
+  // Decode all packets and return NV12 buffer.
+  // Allocates the buffer internally based on packet count.
+  // The buffer shape's first dimension reflects the actual frame count.
+  _RET_ATTR CUDABuffer decode_all(spdl::core::VideoPacketsPtr packets);
 };
 
 } // namespace spdl::cuda

--- a/src/spdl/io/lib/_libspdl_cuda.pyi
+++ b/src/spdl/io/lib/_libspdl_cuda.pyi
@@ -190,6 +190,23 @@ class NvDecDecoder:
             The decoded frames. (can be empty)
         """
 
+    def decode_all(self, packets: spdl.io.lib._libspdl.VideoPackets) -> CUDABuffer:
+        """
+        Decode all packets and return NV12 buffer.
+
+        This method decodes all packets and flushes the decoder in one operation,
+        and returns the resulting frames as one contiguous memory buffer.
+
+        Args:
+            packets: Video packets to decode.
+
+        Returns:
+            A :py:class:`~spdl.io.CUDABuffer` containing NV12 frames with shape
+            ``[num_frames, h*1.5, width]``, where ``num_frames`` reflects
+            the actual number of decoded frames, which should match
+            the number of packets.
+        """
+
 @overload
 def decode_image_nvjpeg(data: bytes, *, device_config: CUDAConfig, scale_width: int = -1, scale_height: int = -1, pix_fmt: str = 'rgb', sync: bool = True, _zero_clear: bool = False) -> CUDABuffer: ...
 
@@ -219,3 +236,33 @@ def synchronize_stream(arg: CUDAConfig, /) -> None: ...
 def nv12_to_planar_rgb(buffers: Sequence[CUDABuffer], *, device_config: CUDAConfig, matrix_coeff: int = 1, sync: bool = True) -> CUDABuffer: ...
 
 def nv12_to_planar_bgr(buffers: Sequence[CUDABuffer], *, device_config: CUDAConfig, matrix_coeff: int = 1, sync: bool = True) -> CUDABuffer: ...
+
+def nv12_to_planar_rgb_batched(nv12_batch: CUDABuffer, num_frames: int, *, device_config: CUDAConfig, matrix_coeff: int = 1, sync: bool = True) -> CUDABuffer:
+    """
+    Convert batched NV12 frames to planar RGB.
+
+    Args:
+        nv12_batch: 3D buffer with shape ``[num_frames, height*1.5, width]``.
+        num_frames: Actual number of frames to convert (may be ``<= max_frames``).
+        device_config: The CUDA device configuration.
+        matrix_coeff: Color matrix coefficients for conversion (default: ``BT.709``).
+        sync: If ``True``, synchronizes the stream before returning.
+
+    Returns:
+        CUDA buffer containing planar RGB data with shape ``[num_frames, 3, height, width]``.
+    """
+
+def nv12_to_planar_bgr_batched(nv12_batch: CUDABuffer, num_frames: int, *, device_config: CUDAConfig, matrix_coeff: int = 1, sync: bool = True) -> CUDABuffer:
+    """
+    Convert batched NV12 frames to planar BGR.
+
+    Args:
+        nv12_batch: 3D buffer with shape ``[num_frames, height*1.5, width]``.
+        num_frames: Actual number of frames to convert (may be ``<= max_frames``).
+        device_config: The CUDA device configuration.
+        matrix_coeff: Color matrix coefficients for conversion (default: ``BT.709``).
+        sync: If ``True``, synchronizes the stream before returning.
+
+    Returns:
+        CUDA buffer containing planar BGR data with shape ``[num_frames, 3, height, width]``.
+    """

--- a/src/spdl/io/lib/cuda/color_conversion.cpp
+++ b/src/spdl/io/lib/cuda/color_conversion.cpp
@@ -54,5 +54,63 @@ void register_color_conversion(nb::module_& m) {
       nb::arg("device_config"),
       nb::arg("matrix_coeff") = 1,
       nb::arg("sync") = true);
+  m.def(
+      "nv12_to_planar_rgb_batched",
+#ifndef SPDL_USE_CUDA
+      [](const CUDABuffer&, size_t, const CUDAConfig&, int, bool)
+          -> CUDABufferPtr {
+        throw std::runtime_error("SPDL is not built with CUDA support.");
+      },
+#else
+      &nv12_to_planar_rgb_batched,
+#endif
+      R"(Convert batched NV12 frames to planar RGB.
+
+Args:
+    nv12_batch: 3D buffer with shape ``[num_frames, height*1.5, width]``.
+    num_frames: Actual number of frames to convert (may be ``<= max_frames``).
+    device_config: The CUDA device configuration.
+    matrix_coeff: Color matrix coefficients for conversion (default: ``BT.709``).
+    sync: If ``True``, synchronizes the stream before returning.
+
+Returns:
+    CUDA buffer containing planar RGB data with shape ``[num_frames, 3, height, width]``.
+)",
+      nb::call_guard<nb::gil_scoped_release>(),
+      nb::arg("nv12_batch"),
+      nb::arg("num_frames"),
+      nb::kw_only(),
+      nb::arg("device_config"),
+      nb::arg("matrix_coeff") = 1,
+      nb::arg("sync") = true);
+  m.def(
+      "nv12_to_planar_bgr_batched",
+#ifndef SPDL_USE_CUDA
+      [](const CUDABuffer&, size_t, const CUDAConfig&, int, bool)
+          -> CUDABufferPtr {
+        throw std::runtime_error("SPDL is not built with CUDA support.");
+      },
+#else
+      &nv12_to_planar_bgr_batched,
+#endif
+      R"(Convert batched NV12 frames to planar BGR.
+
+Args:
+    nv12_batch: 3D buffer with shape ``[num_frames, height*1.5, width]``.
+    num_frames: Actual number of frames to convert (may be ``<= max_frames``).
+    device_config: The CUDA device configuration.
+    matrix_coeff: Color matrix coefficients for conversion (default: ``BT.709``).
+    sync: If ``True``, synchronizes the stream before returning.
+
+Returns:
+    CUDA buffer containing planar BGR data with shape ``[num_frames, 3, height, width]``.
+)",
+      nb::call_guard<nb::gil_scoped_release>(),
+      nb::arg("nv12_batch"),
+      nb::arg("num_frames"),
+      nb::kw_only(),
+      nb::arg("device_config"),
+      nb::arg("matrix_coeff") = 1,
+      nb::arg("sync") = true);
 }
 } // namespace spdl::cuda

--- a/src/spdl/io/lib/cuda/decoding_nvdec.cpp
+++ b/src/spdl/io/lib/cuda/decoding_nvdec.cpp
@@ -27,7 +27,7 @@ namespace spdl::cuda {
 #ifndef SPDL_USE_NVCODEC
 NvDecDecoder::NvDecDecoder() {}
 NvDecDecoder::~NvDecDecoder() {}
-void NvDecDecoder::reset() {
+CUDABuffer NvDecDecoder::decode_all(spdl::core::VideoPacketsPtr) {
   NOT_SUPPORTED_NVCODEC;
 }
 void NvDecDecoder::init(
@@ -42,6 +42,9 @@ std::vector<CUDABuffer> NvDecDecoder::decode(spdl::core::VideoPacketsPtr) {
   NOT_SUPPORTED_NVCODEC;
 }
 std::vector<CUDABuffer> NvDecDecoder::flush() {
+  NOT_SUPPORTED_NVCODEC;
+}
+void NvDecDecoder::reset() {
   NOT_SUPPORTED_NVCODEC;
 }
 #endif
@@ -227,7 +230,26 @@ Returns:
 Returns:
     The decoded frames. (can be empty)
 )",
-          nb::call_guard<nb::gil_scoped_release>());
+          nb::call_guard<nb::gil_scoped_release>())
+      .def(
+          "decode_all",
+          &NvDecDecoder::decode_all,
+          R"(Decode all packets and return NV12 buffer.
+
+This method decodes all packets and flushes the decoder in one operation,
+and returns the resulting frames as one contiguous memory buffer.
+
+Args:
+    packets: Video packets to decode.
+
+Returns:
+    A :py:class:`~spdl.io.CUDABuffer` containing NV12 frames with shape
+    ``[num_frames, h*1.5, width]``, where ``num_frames`` reflects
+    the actual number of decoded frames, which should match
+    the number of packets.
+)",
+          nb::call_guard<nb::gil_scoped_release>(),
+          nb::arg("packets"));
 
   m.def(
       "_nvdec_decoder",


### PR DESCRIPTION
When decoding video packets with NVDEC, allocating output buffer for each output frame separately is inefficient.

The following figures from PyTorch profiler shows that calling PyTorch CUDA caching allocator (the pink stripes) 
from multiple threads at high frequency cause some sort of resource contention, and it takes extremely
long (~11ms at worst) to complete.

<img width="1204" height="697" alt="Screenshot 2025-12-22 at 4 57 37 PM" src="https://github.com/user-attachments/assets/bfb4162e-b9ed-4558-8093-2d887d17b7cd" />

<img width="1221" height="573" alt="Screenshot 2025-12-22 at 4 59 45 PM" src="https://github.com/user-attachments/assets/7a0ae930-be0a-4fa6-a328-3f5109f51698" />

To avoid this, we can allocate the output buffer beforehand and copy decoded frames there.

<img width="1221" height="726" alt="Screenshot 2025-12-22 at 5 06 52 PM" src="https://github.com/user-attachments/assets/8f363fd5-ee03-4240-bc21-233ca86d7809" />

We occasionally see 5ms allocation, but most of them are in the order of 100 us.

<img width="1211" height="486" alt="Screenshot 2025-12-22 at 5 11 59 PM" src="https://github.com/user-attachments/assets/b3617764-383a-4530-866b-406d62a447cb" />




