### PR TITLE
[libspdl] Add C++ iterator support to Generator

### DIFF
--- a/src/libspdl/core/detail/ffmpeg/bsf.cpp
+++ b/src/libspdl/core/detail/ffmpeg/bsf.cpp
@@ -90,19 +90,16 @@ void BSFImpl::filter(
     const std::vector<AVPacket*>& packets,
     PacketSeries& out,
     bool flush) {
-  auto packet_stream = stream_packets(packets, flush);
-  while (packet_stream) {
-    auto filtering = this->filter(packet_stream());
-    while (filtering) {
-      out.push(filtering().release());
+  for (auto* packet : stream_packets(packets, flush)) {
+    for (auto&& filtered : this->filter(packet)) {
+      out.push(filtered.release());
     }
   }
 }
 
 void BSFImpl::flush(PacketSeries& out) {
-  auto filtering = this->filter(nullptr);
-  while (filtering) {
-    out.push(filtering().release());
+  for (auto&& filtered : this->filter(nullptr)) {
+    out.push(filtered.release());
   }
 }
 

--- a/src/libspdl/cuda/nvdec/detail/decoder.cpp
+++ b/src/libspdl/cuda/nvdec/detail/decoder.cpp
@@ -633,7 +633,6 @@ void NvDecDecoderCore::decode_packets(
   this->frame_buffer_ = buffer;
   time_window_ = packets->timestamp;
 
-  auto ite = packets->pkts.iter_data();
   unsigned long flags = CUVID_PKT_TIMESTAMP;
   switch (codec_id_) {
     case spdl::core::CodecID::MPEG4: {
@@ -651,8 +650,7 @@ void NvDecDecoderCore::decode_packets(
   }
 
   flags |= CUVID_PKT_ENDOFPICTURE;
-  while (ite) {
-    auto pkt = ite();
+  for (auto pkt : packets->pkts.iter_data()) {
     VLOG(9) << fmt::format("pkt.pts {}:", pkt.pts);
     decode_packet(pkt.data, pkt.size, pkt.pts, flags);
   }
@@ -712,7 +710,6 @@ CUDABuffer NvDecDecoderCore::decode_all(
   std::vector<CUDABuffer> dummy_buffer;
   frame_buffer_ = &dummy_buffer;
 
-  auto ite = packets->pkts.iter_data();
   unsigned long flags = CUVID_PKT_TIMESTAMP;
   switch (codec_id_) {
     case spdl::core::CodecID::MPEG4: {
@@ -725,8 +722,7 @@ CUDABuffer NvDecDecoderCore::decode_all(
   }
 
   flags |= CUVID_PKT_ENDOFPICTURE;
-  while (ite) {
-    auto pkt = ite();
+  for (auto pkt : packets->pkts.iter_data()) {
     VLOG(9) << fmt::format("pkt.pts {}:", pkt.pts);
     decode_packet(pkt.data, pkt.size, pkt.pts, flags);
   }


### PR DESCRIPTION
Adds C++ iterator support to the Generator class,
enabling range-based for loops and standard algorithm compatibility.
Also updates the codebase to use the new iterator pattern.

Changes:
- Added iterator struct with begin()/end() methods for range-based for loop support
- Refactored decoder.cpp, bsf.cpp, and demuxer.cpp to use range-based for loops

Before:

```
  auto gen = some_generator();
  while (gen) {
    auto val = gen();
    // ...
  }
```

After:

```
  for (auto&& val : some_generator()) {
    // ...
  }
```