### PR TITLE
[libspdl] Move streaming_load_video_nvdec to C++

### DIFF
--- a/src/spdl/io/lib/_libspdl_cuda.pyi
+++ b/src/spdl/io/lib/_libspdl_cuda.pyi
@@ -207,6 +207,11 @@ class NvDecDecoder:
             the number of packets.
         """
 
+class FrameBatchIterator:
+    def __iter__(self) -> FrameBatchIterator: ...
+
+    def __next__(self) -> list[CUDABuffer]: ...
+
 @overload
 def decode_image_nvjpeg(data: bytes, *, device_config: CUDAConfig, scale_width: int = -1, scale_height: int = -1, pix_fmt: str = 'rgb', sync: bool = True, _zero_clear: bool = False) -> CUDABuffer: ...
 


### PR DESCRIPTION
Migrates the streaming_load_video_nvdec implementation from Python to C++, so that we can later simplify the NVDEC decoder architecture and improve performance.

The Python/C++ boundary complexity made it difficult to maintain and optimize the streaming decode pipeline, so consolidating the logic in C++.

It provides better control over resource management.