### PR TITLE
[libspdl] Optimize batched NV12 color conversion

### DIFF
--- a/src/libspdl/cuda/color_conversion.h
+++ b/src/libspdl/cuda/color_conversion.h
@@ -56,8 +56,7 @@ CUDABufferPtr nv12_to_planar_bgr(
 /// This is an optimized version that takes a pre-allocated 3D buffer containing
 /// multiple NV12 frames, reducing memory allocation overhead.
 ///
-/// @param nv12_batch 3D buffer with shape [max_frames, height*1.5, width].
-/// @param num_frames Actual number of frames to convert (may be <= max_frames).
+/// @param nv12_batch 3D buffer with shape [num_frames, height*1.5, width].
 /// @param cfg CUDA configuration including device and stream.
 /// @param matrix_coefficients Color matrix coefficients for conversion
 /// (default: BT.709).
@@ -67,7 +66,6 @@ CUDABufferPtr nv12_to_planar_bgr(
 /// height, width].
 CUDABufferPtr nv12_to_planar_rgb_batched(
     const CUDABuffer& nv12_batch,
-    size_t num_frames,
     const CUDAConfig& cfg,
     int matrix_coefficients = 1,
     bool sync = true);
@@ -77,8 +75,7 @@ CUDABufferPtr nv12_to_planar_rgb_batched(
 /// This is an optimized version that takes a pre-allocated 3D buffer containing
 /// multiple NV12 frames, reducing memory allocation overhead.
 ///
-/// @param nv12_batch 3D buffer with shape [max_frames, height*1.5, width].
-/// @param num_frames Actual number of frames to convert (may be <= max_frames).
+/// @param nv12_batch 3D buffer with shape [num_frames, height*1.5, width].
 /// @param cfg CUDA configuration including device and stream.
 /// @param matrix_coefficients Color matrix coefficients for conversion
 /// (default: BT.709).
@@ -88,7 +85,6 @@ CUDABufferPtr nv12_to_planar_rgb_batched(
 /// height, width].
 CUDABufferPtr nv12_to_planar_bgr_batched(
     const CUDABuffer& nv12_batch,
-    size_t num_frames,
     const CUDAConfig& cfg,
     int matrix_coefficients = 1,
     bool sync = true);

--- a/src/libspdl/cuda/detail/color_conversion.cu
+++ b/src/libspdl/cuda/detail/color_conversion.cu
@@ -85,6 +85,7 @@ yuv_to_rgb_pixel(uint8_t y, uint8_t u, uint8_t v, float mat[3][3]) {
   return rgb;
 }
 
+// Original non-batched kernel
 template <class COLOR24>
 __global__ static void nv12_to_planar_rgb24(
     uint8_t* yuv_ptr,
@@ -125,6 +126,58 @@ __global__ static void nv12_to_planar_rgb24(
     *(rgb_ptr + rgb_pitch) = rgb10.v[i];
     *(rgb_ptr + rgb_pitch + 1) = rgb11.v[i];
     rgb_ptr += height * rgb_pitch;
+  }
+}
+
+// New batched kernel for processing multiple frames in a single launch
+template <class COLOR24>
+__global__ static void nv12_to_planar_rgb24_batched(
+    uint8_t* yuv_ptr,
+    int yuv_pitch,
+    uint8_t* rgb_ptr,
+    int rgb_pitch,
+    int width,
+    int height,
+    int matrix_coefficients) {
+  int x = (threadIdx.x + blockIdx.x * blockDim.x) * 2;
+  int y = (threadIdx.y + blockIdx.y * blockDim.y) * 2;
+  auto frame_idx = blockIdx.z;
+
+  if (x + 1 >= width || y + 1 >= height) {
+    return;
+  }
+
+  size_t nv12_frame_size = (height + height / 2) * width;
+  size_t rgb_frame_size = 3 * height * width;
+
+  uint8_t* frame_yuv = yuv_ptr + frame_idx * nv12_frame_size;
+  uint8_t* frame_rgb = rgb_ptr + frame_idx * rgb_frame_size;
+
+  uint8_t* y00 = frame_yuv + y * yuv_pitch + x;
+  uint8_t* y01 = y00 + 1;
+  uint8_t* y10 = y00 + yuv_pitch;
+  uint8_t* y11 = y10 + 1;
+
+  uint8_t* u = frame_yuv + ((height + y / 2) * yuv_pitch) + x;
+  uint8_t* v = u + 1;
+
+  if (matrix_coefficients <= 0 || 10 < matrix_coefficients) {
+    matrix_coefficients = 1;
+  }
+  auto mat = yuv2rgb[matrix_coefficients - 1];
+
+  auto rgb00 = yuv_to_rgb_pixel<COLOR24>(*y00, *u, *v, mat),
+       rgb01 = yuv_to_rgb_pixel<COLOR24>(*y01, *u, *v, mat),
+       rgb10 = yuv_to_rgb_pixel<COLOR24>(*y10, *u, *v, mat),
+       rgb11 = yuv_to_rgb_pixel<COLOR24>(*y11, *u, *v, mat);
+
+  frame_rgb += x + y * rgb_pitch;
+  for (int i = 0; i < 3; ++i) {
+    *frame_rgb = rgb00.v[i];
+    *(frame_rgb + 1) = rgb01.v[i];
+    *(frame_rgb + rgb_pitch) = rgb10.v[i];
+    *(frame_rgb + rgb_pitch + 1) = rgb11.v[i];
+    frame_rgb += height * rgb_pitch;
   }
 }
 
@@ -173,11 +226,51 @@ void nv12_to_planar_bgr(
     int matrix_coefficients) {
   auto dimGrid = dim3((width + 63) / 64, (height + 3) / 4);
   auto dimBlock = dim3(32, 2);
-  TRACE_EVENT("nvdec", "nv12_to_planar_bgra");
+  TRACE_EVENT("nvdec", "nv12_to_planar_bgr");
   nv12_to_planar_rgb24<BGR24><<<dimGrid, dimBlock, 0, stream>>>(
       src, src_pitch, dst, dst_pitch, width, height, matrix_coefficients);
   CHECK_CUDA(
       cudaPeekAtLastError(),
       "Failed to launch kernel nv12_to_planar_bgr<BGR24>");
+}
+
+void nv12_to_planar_rgb_batched(
+    CUstream stream,
+    uint8_t* src,
+    int src_pitch,
+    uint8_t* dst,
+    int dst_pitch,
+    int width,
+    int height,
+    int num_frames,
+    int matrix_coefficients) {
+  auto dimGrid = dim3((width + 63) / 64, (height + 3) / 4, num_frames);
+  auto dimBlock = dim3(32, 2);
+  TRACE_EVENT("nvdec", "nv12_to_planar_rgb_batched");
+  nv12_to_planar_rgb24_batched<RGB24><<<dimGrid, dimBlock, 0, stream>>>(
+      src, src_pitch, dst, dst_pitch, width, height, matrix_coefficients);
+  CHECK_CUDA(
+      cudaPeekAtLastError(),
+      "Failed to launch kernel nv12_to_planar_rgb_batched<RGB24>");
+}
+
+void nv12_to_planar_bgr_batched(
+    CUstream stream,
+    uint8_t* src,
+    int src_pitch,
+    uint8_t* dst,
+    int dst_pitch,
+    int width,
+    int height,
+    int num_frames,
+    int matrix_coefficients) {
+  auto dimGrid = dim3((width + 63) / 64, (height + 3) / 4, num_frames);
+  auto dimBlock = dim3(32, 2);
+  TRACE_EVENT("nvdec", "nv12_to_planar_bgr_batched");
+  nv12_to_planar_rgb24_batched<BGR24><<<dimGrid, dimBlock, 0, stream>>>(
+      src, src_pitch, dst, dst_pitch, width, height, matrix_coefficients);
+  CHECK_CUDA(
+      cudaPeekAtLastError(),
+      "Failed to launch kernel nv12_to_planar_bgr_batched<BGR24>");
 }
 } // namespace spdl::cuda::detail

--- a/src/libspdl/cuda/detail/color_conversion.h
+++ b/src/libspdl/cuda/detail/color_conversion.h
@@ -15,6 +15,7 @@ using CUstream = CUstream_st*;
 
 namespace spdl::cuda::detail {
 
+// Non-batched version (single frame)
 void nv12_to_planar_rgb(
     CUstream stream,
     uint8_t* src,
@@ -33,6 +34,29 @@ void nv12_to_planar_bgr(
     int dst_pitch,
     int width,
     int height,
+    int matrix_coefficients);
+
+// Batched version (multiple frames in single kernel launch)
+void nv12_to_planar_rgb_batched(
+    CUstream stream,
+    uint8_t* src,
+    int src_pitch,
+    uint8_t* dst,
+    int dst_pitch,
+    int width,
+    int height,
+    int num_frames,
+    int matrix_coefficients);
+
+void nv12_to_planar_bgr_batched(
+    CUstream stream,
+    uint8_t* src,
+    int src_pitch,
+    uint8_t* dst,
+    int dst_pitch,
+    int width,
+    int height,
+    int num_frames,
     int matrix_coefficients);
 
 } // namespace spdl::cuda::detail

--- a/src/spdl/io/_core.py
+++ b/src/spdl/io/_core.py
@@ -827,17 +827,16 @@ def decode_packets_nvdec(
     )
 
     nv12_buffer = decoder.decode_all(packets)
-    num_frames = nv12_buffer.__cuda_array_interface__["shape"][0]
 
     # Convert NV12 to RGB/BGR using batched function
     match pix_fmt:
         case "rgb":
             return _libspdl_cuda.nv12_to_planar_rgb_batched(
-                nv12_buffer, num_frames, device_config=device_config
+                nv12_buffer, device_config=device_config
             )
         case "bgr":
             return _libspdl_cuda.nv12_to_planar_bgr_batched(
-                nv12_buffer, num_frames, device_config=device_config
+                nv12_buffer, device_config=device_config
             )
 
     # Should not reach here

--- a/src/spdl/io/lib/_libspdl_cuda.pyi
+++ b/src/spdl/io/lib/_libspdl_cuda.pyi
@@ -237,13 +237,12 @@ def nv12_to_planar_rgb(buffers: Sequence[CUDABuffer], *, device_config: CUDAConf
 
 def nv12_to_planar_bgr(buffers: Sequence[CUDABuffer], *, device_config: CUDAConfig, matrix_coeff: int = 1, sync: bool = True) -> CUDABuffer: ...
 
-def nv12_to_planar_rgb_batched(nv12_batch: CUDABuffer, num_frames: int, *, device_config: CUDAConfig, matrix_coeff: int = 1, sync: bool = True) -> CUDABuffer:
+def nv12_to_planar_rgb_batched(nv12_batch: CUDABuffer, *, device_config: CUDAConfig, matrix_coeff: int = 1, sync: bool = True) -> CUDABuffer:
     """
     Convert batched NV12 frames to planar RGB.
 
     Args:
         nv12_batch: 3D buffer with shape ``[num_frames, height*1.5, width]``.
-        num_frames: Actual number of frames to convert (may be ``<= max_frames``).
         device_config: The CUDA device configuration.
         matrix_coeff: Color matrix coefficients for conversion (default: ``BT.709``).
         sync: If ``True``, synchronizes the stream before returning.
@@ -252,13 +251,12 @@ def nv12_to_planar_rgb_batched(nv12_batch: CUDABuffer, num_frames: int, *, devic
         CUDA buffer containing planar RGB data with shape ``[num_frames, 3, height, width]``.
     """
 
-def nv12_to_planar_bgr_batched(nv12_batch: CUDABuffer, num_frames: int, *, device_config: CUDAConfig, matrix_coeff: int = 1, sync: bool = True) -> CUDABuffer:
+def nv12_to_planar_bgr_batched(nv12_batch: CUDABuffer, *, device_config: CUDAConfig, matrix_coeff: int = 1, sync: bool = True) -> CUDABuffer:
     """
     Convert batched NV12 frames to planar BGR.
 
     Args:
         nv12_batch: 3D buffer with shape ``[num_frames, height*1.5, width]``.
-        num_frames: Actual number of frames to convert (may be ``<= max_frames``).
         device_config: The CUDA device configuration.
         matrix_coeff: Color matrix coefficients for conversion (default: ``BT.709``).
         sync: If ``True``, synchronizes the stream before returning.

--- a/src/spdl/io/lib/cuda/color_conversion.cpp
+++ b/src/spdl/io/lib/cuda/color_conversion.cpp
@@ -57,8 +57,7 @@ void register_color_conversion(nb::module_& m) {
   m.def(
       "nv12_to_planar_rgb_batched",
 #ifndef SPDL_USE_CUDA
-      [](const CUDABuffer&, size_t, const CUDAConfig&, int, bool)
-          -> CUDABufferPtr {
+      [](const CUDABuffer&, const CUDAConfig&, int, bool) -> CUDABufferPtr {
         throw std::runtime_error("SPDL is not built with CUDA support.");
       },
 #else
@@ -68,7 +67,6 @@ void register_color_conversion(nb::module_& m) {
 
 Args:
     nv12_batch: 3D buffer with shape ``[num_frames, height*1.5, width]``.
-    num_frames: Actual number of frames to convert (may be ``<= max_frames``).
     device_config: The CUDA device configuration.
     matrix_coeff: Color matrix coefficients for conversion (default: ``BT.709``).
     sync: If ``True``, synchronizes the stream before returning.
@@ -78,7 +76,6 @@ Returns:
 )",
       nb::call_guard<nb::gil_scoped_release>(),
       nb::arg("nv12_batch"),
-      nb::arg("num_frames"),
       nb::kw_only(),
       nb::arg("device_config"),
       nb::arg("matrix_coeff") = 1,
@@ -86,8 +83,7 @@ Returns:
   m.def(
       "nv12_to_planar_bgr_batched",
 #ifndef SPDL_USE_CUDA
-      [](const CUDABuffer&, size_t, const CUDAConfig&, int, bool)
-          -> CUDABufferPtr {
+      [](const CUDABuffer&, const CUDAConfig&, int, bool) -> CUDABufferPtr {
         throw std::runtime_error("SPDL is not built with CUDA support.");
       },
 #else
@@ -97,7 +93,6 @@ Returns:
 
 Args:
     nv12_batch: 3D buffer with shape ``[num_frames, height*1.5, width]``.
-    num_frames: Actual number of frames to convert (may be ``<= max_frames``).
     device_config: The CUDA device configuration.
     matrix_coeff: Color matrix coefficients for conversion (default: ``BT.709``).
     sync: If ``True``, synchronizes the stream before returning.
@@ -107,7 +102,6 @@ Returns:
 )",
       nb::call_guard<nb::gil_scoped_release>(),
       nb::arg("nv12_batch"),
-      nb::arg("num_frames"),
       nb::kw_only(),
       nb::arg("device_config"),
       nb::arg("matrix_coeff") = 1,

--- a/tests/cuda/nvdec_video_decoding_test.py
+++ b/tests/cuda/nvdec_video_decoding_test.py
@@ -577,7 +577,7 @@ class TestDecodeAll(unittest.TestCase):
 
         # Convert batch output to RGB using batched conversion
         batch_rgb = spdl.io.lib._libspdl_cuda.nv12_to_planar_rgb_batched(
-            batch_buffer, num_frames, device_config=cuda_config
+            batch_buffer, device_config=cuda_config
         )
         batch_tensor = spdl.io.to_torch(batch_rgb)
 


### PR DESCRIPTION
This refactoring improves the performance of batched NV12-to-RGB/BGR color conversion by eliminating redundant kernel launch overhead.
The previous implementation launched N separate CUDA kernels (one per frame), which introduced significant overhead for video decoding workloads processing multiple frames.

The new implementation uses a single kernel launch with the batch dimension mapped to the grid Z-axis, allowing all frames to be processed concurrently. This change also simplifies the API by removing the redundant `num_frames` parameter - functions now always process all frames in the input buffer, which was the primary use case anyway.