### PR TITLE
[libspdl] Encapsulate frame buffer in NVDEC

### DIFF
--- a/src/libspdl/cuda/CMakeLists.txt
+++ b/src/libspdl/cuda/CMakeLists.txt
@@ -36,6 +36,7 @@ set(srcs
 if (SPDL_USE_NVCODEC)
   list(APPEND srcs
     nvdec/decoder.cpp
+    nvdec/detail/buffer.cpp
     nvdec/detail/decoder.cpp
     nvdec/detail/utils.cpp
     nvdec/detail/wrapper.cpp

--- a/src/libspdl/cuda/nvdec/detail/buffer.cpp
+++ b/src/libspdl/cuda/nvdec/detail/buffer.cpp
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "libspdl/cuda/nvdec/detail/buffer.h"
+
+#include "libspdl/core/detail/tracing.h"
+#include "libspdl/cuda/detail/utils.h"
+
+#include <cuda.h>
+#include <cuda_runtime.h>
+
+#include <fmt/core.h>
+
+namespace spdl::cuda::detail {
+
+FrameBuffer::FrameBuffer(
+    size_t num_frames,
+    size_t width,
+    size_t height,
+    const CUDAConfig& cfg)
+    : shape_({num_frames, height + height / 2, width}), cfg_(cfg) {}
+
+bool FrameBuffer::empty() const {
+  return queue_.empty();
+}
+
+void FrameBuffer::push(void* src_ptr, size_t pitch) {
+  if (!current_) {
+    current_ = cuda_buffer(shape_, cfg_);
+    idx_ = 0;
+  }
+
+  // get the next buffer point
+  auto h2 = shape_[1], width = shape_[2];
+  size_t offset = idx_ * h2 * width;
+  auto* dst_ptr = (uint8_t*)current_->data() + offset;
+
+  // Perform copy
+  CUDA_MEMCPY2D cfg{
+      .srcXInBytes = 0,
+      .srcY = 0,
+      .srcMemoryType = CU_MEMORYTYPE_DEVICE,
+      .srcHost = nullptr,
+      .srcDevice = (CUdeviceptr)src_ptr,
+      .srcArray = nullptr,
+      .srcPitch = pitch,
+
+      .dstXInBytes = 0,
+      .dstY = 0,
+      .dstMemoryType = CU_MEMORYTYPE_DEVICE,
+      .dstHost = nullptr,
+      .dstDevice = (CUdeviceptr)dst_ptr,
+      .dstArray = nullptr,
+      .dstPitch = width,
+
+      .WidthInBytes = width,
+      .Height = h2,
+  };
+
+  TRACE_EVENT("nvdec", "cuMemcpy2DAsync");
+  auto stream = (CUstream)cfg_.stream;
+  CHECK_CU(cuMemcpy2DAsync(&cfg, stream), "Failed to copy a frame.");
+  CHECK_CU(cuStreamSynchronize(stream), "Failed to synchronize stream.");
+
+  // Move the buffer if full
+  ++idx_;
+  if (idx_ == shape_[0]) {
+    queue_.emplace_back(current_.release());
+  }
+}
+
+CUDABufferPtr FrameBuffer::pop() {
+  if (queue_.empty()) {
+    SPDL_FAIL_INTERNAL(fmt::format("There is no buffer available."));
+  }
+  CUDABufferPtr ret = std::move(queue_.front());
+  queue_.pop_front();
+  return ret;
+}
+
+void FrameBuffer::flush() {
+  if (current_ && idx_ > 0) {
+    // Adjust shape to reflect actual number of frames
+    current_->shape[0] = idx_;
+    queue_.emplace_back(current_.release());
+    idx_ = 0;
+  }
+}
+
+}; // namespace spdl::cuda::detail

--- a/src/libspdl/cuda/nvdec/detail/buffer.h
+++ b/src/libspdl/cuda/nvdec/detail/buffer.h
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <libspdl/cuda/buffer.h>
+#include <libspdl/cuda/types.h>
+
+#include <deque>
+
+namespace spdl::cuda::detail {
+
+/// Batches decoded video frames into contiguous CUDA buffers.
+///
+/// FrameBuffer accumulates individual decoded frames from NVDEC into
+/// fixed-size batched buffers. Each buffer holds a configurable number
+/// of frames arranged contiguously in device memory. When a buffer fills,
+/// it moves to an internal queue for retrieval.
+///
+/// The frame data is stored in NV12 format with layout:
+/// [num_frames, height + height/2, width]
+///
+/// This class is non-copyable and non-movable to ensure safe buffer
+/// management.
+class FrameBuffer {
+  std::deque<CUDABufferPtr> queue_{};
+  CUDABufferPtr current_{};
+  size_t idx_ = 0;
+
+  std::vector<size_t> shape_;
+  CUDAConfig cfg_;
+
+ public:
+  FrameBuffer(
+      size_t num_frames,
+      size_t width,
+      size_t height,
+      const CUDAConfig& cfg);
+
+  // Disable copy semantics
+  FrameBuffer(const FrameBuffer&) = delete;
+  FrameBuffer& operator=(const FrameBuffer&) = delete;
+
+  // Disable move semantics
+  FrameBuffer(FrameBuffer&&) = delete;
+  FrameBuffer& operator=(FrameBuffer&&) = delete;
+
+  /// Returns whether the buffer queue is empty.
+  ///
+  /// @return true if no completed buffers are available, false otherwise
+  bool empty() const;
+
+  /// Copies a decoded frame from device memory into the current batch buffer.
+  ///
+  /// Frames are accumulated until the batch is full (num_frames reached).
+  /// When full, the buffer is moved to the queue for retrieval via pop().
+  ///
+  /// @param ptr Device pointer to the source frame data in NV12 format
+  /// @param pitch Source memory pitch (stride) in bytes
+  void push(void* ptr, size_t pitch);
+
+  /// Retrieves and removes a completed buffer from the queue.
+  ///
+  /// @return A CUDABufferPtr containing a batch of frames
+  /// @throws std::runtime_error if the queue is empty
+  CUDABufferPtr pop();
+
+  /// Flushes the current buffer to the queue, adjusting its shape to reflect
+  /// the actual number of frames pushed.
+  ///
+  /// If the current buffer is empty (no frames pushed), does nothing.
+  /// After flushing, the current buffer is reset.
+  void flush();
+};
+
+} // namespace spdl::cuda::detail


### PR DESCRIPTION
Replaces manual batch mode buffer management in ``NvDecDecoderCore`` with the ``FrameBuffer`` class to improve code maintainability and safety.

The previous implementation used raw pointers and manual index tracking across three member variables (``batch_buffer_``, ``batch_frame_index_`` and ``batch_max_frames_``), which required careful state management and was error-prone.

The FrameBuffer class encapsulates all buffer allocation, frame batching, and queue management logic, reducing complexity and eliminating potential bugs.

This refactoring simplifies the decoder implementation by delegating buffer management to a dedicated class, making the code easier to understand and maintain while maintaining full backward compatibility.

In the subsequent commit, the ``FrameBuffer`` will be fully integrated to ``NvDecDecoderCore``.