### PR TITLE
[IO] Fix the binding of batch NV12 conversion

### DIFF
--- a/src/spdl/io/lib/_libspdl_cuda.pyi
+++ b/src/spdl/io/lib/_libspdl_cuda.pyi
@@ -233,16 +233,16 @@ def built_with_nvjpeg() -> bool: ...
 
 def synchronize_stream(arg: CUDAConfig, /) -> None: ...
 
+@overload
 def nv12_to_planar_rgb(buffers: Sequence[CUDABuffer], *, device_config: CUDAConfig, matrix_coeff: int = 1, sync: bool = True) -> CUDABuffer: ...
 
-def nv12_to_planar_bgr(buffers: Sequence[CUDABuffer], *, device_config: CUDAConfig, matrix_coeff: int = 1, sync: bool = True) -> CUDABuffer: ...
-
-def nv12_to_planar_rgb_batched(nv12_batch: CUDABuffer, *, device_config: CUDAConfig, matrix_coeff: int = 1, sync: bool = True) -> CUDABuffer:
+@overload
+def nv12_to_planar_rgb(buffer: CUDABuffer, *, device_config: CUDAConfig, matrix_coeff: int = 1, sync: bool = True) -> CUDABuffer:
     """
     Convert batched NV12 frames to planar RGB.
 
     Args:
-        nv12_batch: 3D buffer with shape ``[num_frames, height*1.5, width]``.
+        buffer: 3D buffer with shape ``[num_frames, height*1.5, width]``.
         device_config: The CUDA device configuration.
         matrix_coeff: Color matrix coefficients for conversion (default: ``BT.709``).
         sync: If ``True``, synchronizes the stream before returning.
@@ -251,12 +251,16 @@ def nv12_to_planar_rgb_batched(nv12_batch: CUDABuffer, *, device_config: CUDACon
         CUDA buffer containing planar RGB data with shape ``[num_frames, 3, height, width]``.
     """
 
-def nv12_to_planar_bgr_batched(nv12_batch: CUDABuffer, *, device_config: CUDAConfig, matrix_coeff: int = 1, sync: bool = True) -> CUDABuffer:
+@overload
+def nv12_to_planar_bgr(buffers: Sequence[CUDABuffer], *, device_config: CUDAConfig, matrix_coeff: int = 1, sync: bool = True) -> CUDABuffer: ...
+
+@overload
+def nv12_to_planar_bgr(buffer: CUDABuffer, *, device_config: CUDAConfig, matrix_coeff: int = 1, sync: bool = True) -> CUDABuffer:
     """
     Convert batched NV12 frames to planar BGR.
 
     Args:
-        nv12_batch: 3D buffer with shape ``[num_frames, height*1.5, width]``.
+        buffer: 3D buffer with shape ``[num_frames, height*1.5, width]``.
         device_config: The CUDA device configuration.
         matrix_coeff: Color matrix coefficients for conversion (default: ``BT.709``).
         sync: If ``True``, synchronizes the stream before returning.

--- a/src/spdl/io/lib/cuda/color_conversion.cpp
+++ b/src/spdl/io/lib/cuda/color_conversion.cpp
@@ -55,7 +55,7 @@ void register_color_conversion(nb::module_& m) {
       nb::arg("matrix_coeff") = 1,
       nb::arg("sync") = true);
   m.def(
-      "nv12_to_planar_rgb_batched",
+      "nv12_to_planar_rgb",
 #ifndef SPDL_USE_CUDA
       [](const CUDABuffer&, const CUDAConfig&, int, bool) -> CUDABufferPtr {
         throw std::runtime_error("SPDL is not built with CUDA support.");
@@ -66,7 +66,7 @@ void register_color_conversion(nb::module_& m) {
       R"(Convert batched NV12 frames to planar RGB.
 
 Args:
-    nv12_batch: 3D buffer with shape ``[num_frames, height*1.5, width]``.
+    buffer: 3D buffer with shape ``[num_frames, height*1.5, width]``.
     device_config: The CUDA device configuration.
     matrix_coeff: Color matrix coefficients for conversion (default: ``BT.709``).
     sync: If ``True``, synchronizes the stream before returning.
@@ -75,13 +75,13 @@ Returns:
     CUDA buffer containing planar RGB data with shape ``[num_frames, 3, height, width]``.
 )",
       nb::call_guard<nb::gil_scoped_release>(),
-      nb::arg("nv12_batch"),
+      nb::arg("buffer"),
       nb::kw_only(),
       nb::arg("device_config"),
       nb::arg("matrix_coeff") = 1,
       nb::arg("sync") = true);
   m.def(
-      "nv12_to_planar_bgr_batched",
+      "nv12_to_planar_bgr",
 #ifndef SPDL_USE_CUDA
       [](const CUDABuffer&, const CUDAConfig&, int, bool) -> CUDABufferPtr {
         throw std::runtime_error("SPDL is not built with CUDA support.");
@@ -92,7 +92,7 @@ Returns:
       R"(Convert batched NV12 frames to planar BGR.
 
 Args:
-    nv12_batch: 3D buffer with shape ``[num_frames, height*1.5, width]``.
+    buffer: 3D buffer with shape ``[num_frames, height*1.5, width]``.
     device_config: The CUDA device configuration.
     matrix_coeff: Color matrix coefficients for conversion (default: ``BT.709``).
     sync: If ``True``, synchronizes the stream before returning.
@@ -101,7 +101,7 @@ Returns:
     CUDA buffer containing planar BGR data with shape ``[num_frames, 3, height, width]``.
 )",
       nb::call_guard<nb::gil_scoped_release>(),
-      nb::arg("nv12_batch"),
+      nb::arg("buffer"),
       nb::kw_only(),
       nb::arg("device_config"),
       nb::arg("matrix_coeff") = 1,

--- a/tests/cuda/nvdec_video_decoding_test.py
+++ b/tests/cuda/nvdec_video_decoding_test.py
@@ -530,10 +530,10 @@ class TestDecodeAll(unittest.TestCase):
 
         # Execute: Use nvdec_decoder with decode_all
         decoder = spdl.io.nvdec_decoder(cuda_config, packets.codec)
-        nv12_buffer = decoder.decode_all(packets)
+        buffers = decoder.decode_all(packets)
 
         # Convert to torch tensor to verify shape and dtype
-        tensor = spdl.io.to_torch(nv12_buffer)
+        tensor = spdl.io.to_torch(buffers)
 
         # Assert: Verify expected data format
         # decode_all returns NV12 buffer with shape [num_frames, h*1.5, width]
@@ -565,20 +565,15 @@ class TestDecodeAll(unittest.TestCase):
 
         # Convert regular output to comparable format
         # nv12_to_planar_rgb expects list of 2D NV12 buffers
-        regular_rgb = spdl.io.lib._libspdl_cuda.nv12_to_planar_rgb(
-            regular_buffers, device_config=cuda_config
-        )
+        regular_rgb = spdl.io.nv12_to_rgb(regular_buffers, device_config=cuda_config)
         regular_tensor = spdl.io.to_torch(regular_rgb)
 
         # Execute: Decode using decode_all
         decoder2 = spdl.io.nvdec_decoder(cuda_config, packets2.codec, use_cache=False)
         batch_buffer = decoder2.decode_all(packets2)
-        num_frames = batch_buffer.__cuda_array_interface__["shape"][0]
 
         # Convert batch output to RGB using batched conversion
-        batch_rgb = spdl.io.lib._libspdl_cuda.nv12_to_planar_rgb_batched(
-            batch_buffer, device_config=cuda_config
-        )
+        batch_rgb = spdl.io.nv12_to_rgb(batch_buffer, device_config=cuda_config)
         batch_tensor = spdl.io.to_torch(batch_rgb)
 
         # Assert: Both methods should produce the same output


### PR DESCRIPTION
The newly added batched conversion of NV12 CUDABuffer was not properly registered to Python.

This commit fixes it.