### PR TITLE
[libspdl] Fix conditional operator argument copy in decoder

### DIFF
--- a/src/libspdl/core/detail/ffmpeg/decoder.cpp
+++ b/src/libspdl/core/detail/ffmpeg/decoder.cpp
@@ -122,11 +122,15 @@ DecoderImpl<media>::DecoderImpl(
     const Codec<media>& codec,
     const std::optional<DecodeConfig>& cfg,
     const std::optional<std::string>& filter_desc)
-    : codec_ctx_(get_decode_codec_ctx_ptr(
-          codec.get_parameters(),
-          codec.get_time_base(),
-          cfg ? cfg->decoder : std::nullopt,
-          cfg ? cfg->decoder_options : std::nullopt)),
+    : codec_ctx_([&codec, &cfg]() {
+        static const std::optional<std::string> default_decoder = std::nullopt;
+        static const std::optional<OptionDict> empty_option = std::nullopt;
+        return get_decode_codec_ctx_ptr(
+            codec.get_parameters(),
+            codec.get_time_base(),
+            cfg ? cfg->decoder : default_decoder,
+            cfg ? cfg->decoder_options : empty_option);
+      }()),
       filter_graph_(filter_desc) {}
 
 template <MediaType media>


### PR DESCRIPTION
Resolved a lint warning in the DecoderImpl constructor by avoiding unnecessary copies when passing decoder options to `get_decode_codec_ctx_ptr`.

The issue occurred because the ternary operator compared a reference (`cfg->decoder_options`) against a temporary (`std::nullopt`), forcing the compiler to create an unnecessary copy to unify the types. This was inefficient and triggered the lint warning.

Fixed by wrapping the initialization in a lambda that uses static const variables for empty values, ensuring both branches of the ternary operators return references of the same type, eliminating the copy overhead.