### PR TITLE
[libspdl/IO][BC-Breaking] Use batch allocation in NVDEC decoder

### DIFF
--- a/src/libspdl/cuda/nvdec/decoder.h
+++ b/src/libspdl/cuda/nvdec/decoder.h
@@ -11,6 +11,7 @@
 #include <libspdl/cuda/buffer.h>
 #include <libspdl/cuda/storage.h>
 
+#include <libspdl/core/generator.h>
 #include <libspdl/core/packets.h>
 #include <libspdl/core/types.h>
 
@@ -27,20 +28,45 @@ namespace detail {
 class NvDecDecoderCore;
 }
 
-// Usage:
-// NvDecDecoder decoder{};
-// decoder.init(...)
-// for (auto packets : src) {
-//   frames = decoder.decode(std::move(packets));
-//   ...
-// }
-// frames = decoder.flush();
-//
-// If there was an error, then reset before
-// initializing it again.
-//
-// decoder.reset();
-// decoder.init();
+/// Generator type for yielding decoded frame batches.
+using CUDABufferGenerator = spdl::core::Generator<CUDABuffer>;
+
+/// NVDEC-based video decoder for hardware-accelerated video decoding.
+///
+/// This class provides two decoding modes:
+///
+/// 1. **Batch decoding** - Decode all packets at once:
+/// @code
+///   NvDecDecoder decoder;
+///   decoder.init_decoder(cuda_config, codec, crop, width, height);
+///   auto buffer = decoder.decode_packets(packets);
+/// @endcode
+///
+/// 2. **Streaming decoding** - Process packets incrementally with batched
+/// output:
+/// @code
+///   NvDecDecoder decoder;
+///   decoder.init_decoder(cuda_config, codec, crop, width, height);
+///   decoder.init_buffer(num_frames);  // Initialize frame buffer
+///
+///   for (auto packets : packet_stream) {
+///     for (auto batch : decoder.streaming_decode_packets(packets)) {
+///       // Process batch (CUDABuffer with num_frames)
+///     }
+///   }
+///
+///   // Flush and get remaining frames
+///   for (auto batch : decoder.flush()) {
+///     // Process final batches
+///   }
+/// @endcode
+///
+/// **Error Recovery**:
+/// If an error occurs, call reset() before reinitializing:
+/// @code
+///   decoder.reset();
+///   decoder.init_decoder(cuda_config, codec, ...);
+/// @endcode
 class NvDecDecoder {
 #ifdef SPDL_USE_NVCODEC
   detail::NvDecDecoderCore* core_;
@@ -60,7 +86,7 @@ class NvDecDecoder {
 
   // Initialize the decoder object for a new stream of
   // video packets
-  _RET_ATTR void init(
+  _RET_ATTR void init_decoder(
       // device config
       const CUDAConfig& cuda_config,
       // Source codec information
@@ -70,16 +96,40 @@ class NvDecDecoder {
       int width = -1,
       int height = -1);
 
-  // decode one stream of video packets
-  _RET_ATTR std::vector<CUDABuffer> decode(spdl::core::VideoPacketsPtr packets);
-
-  // Call this method at the end of video stream.
-  _RET_ATTR std::vector<CUDABuffer> flush();
+  ////////////////////////////////////////////////////////////////////////////
+  // One-off decoding
+  ////////////////////////////////////////////////////////////////////////////
 
   // Decode all packets and return NV12 buffer.
   // Allocates the buffer internally based on packet count.
   // The buffer shape's first dimension reflects the actual frame count.
-  _RET_ATTR CUDABuffer decode_all(spdl::core::VideoPacketsPtr packets);
+  _RET_ATTR CUDABuffer decode_packets(spdl::core::VideoPacketsPtr packets);
+
+  ////////////////////////////////////////////////////////////////////////////
+  // Streaming decoding
+  ////////////////////////////////////////////////////////////////////////////
+
+  // Initialize frame buffer for streaming decode
+  _RET_ATTR void init_buffer(size_t num_frames);
+
+  // Streaming decode packets and yield batches.
+  //
+  // This method decodes packets and yields batches of frames as they become
+  // ready. The frame buffer must be initialized with init_buffer() before
+  // calling this.
+  //
+  // @param packets Video packets to decode.
+  // @return Generator that yields CUDABuffer batches in NV12 format.
+  _RET_ATTR CUDABufferGenerator
+  streaming_decode_packets(spdl::core::VideoPacketsPtr packets);
+
+  // Flush the decoder and yield remaining batches.
+  //
+  // Call this method at the end of video stream to flush the decoder
+  // and retrieve any remaining buffered frames as batches.
+  //
+  // @return Generator that yields remaining CUDABuffer batches in NV12 format.
+  _RET_ATTR CUDABufferGenerator flush();
 };
 
 } // namespace spdl::cuda

--- a/src/libspdl/cuda/nvdec/detail/buffer.cpp
+++ b/src/libspdl/cuda/nvdec/detail/buffer.cpp
@@ -12,7 +12,6 @@
 #include "libspdl/cuda/detail/utils.h"
 
 #include <cuda.h>
-#include <cuda_runtime.h>
 
 #include <fmt/core.h>
 

--- a/src/libspdl/cuda/nvdec/detail/buffer.h
+++ b/src/libspdl/cuda/nvdec/detail/buffer.h
@@ -50,6 +50,8 @@ class FrameBuffer {
   FrameBuffer(FrameBuffer&&) = delete;
   FrameBuffer& operator=(FrameBuffer&&) = delete;
 
+  ~FrameBuffer() = default;
+
   /// Returns whether the buffer queue is empty.
   ///
   /// @return true if no completed buffers are available, false otherwise


### PR DESCRIPTION
This commit fully integrates FrameBuffer to NVDEC video decoder so that the decoder always allocate memory for video frames in batch.

Previously, `streaming_load_video_nvdec` accumulated individual decoded frames in vectors then created batches.
This process called memory allocation function many times. When using PyTorch caching allocator, calling the allocator frequently caused contention and made it slow.

The new implementation preallocates fixed number of frames then copy decoded frames there.
It mitigates the contention.

**Core Decoder (NvDecDecoderCore)**:
- Removed `pending_frames_` tracking - FrameBuffer handles frame accumulation automatically
- Removed old `frame_buffer_` vector pointer - replaced with `FrameBuffer`
- Updated `decode_packet`: now accepts optional `flags` parameter (default: `CUVID_PKT_TIMESTAMP | CUVID_PKT_ENDOFPICTURE`)
- Removed `flush_decoder` method - consolidated into `decode_packet` by sending flush packet with `CUVID_PKT_ENDOFSTREAM` flag
- Removed `create_nv12_buffer` method - no longer needed with FrameBuffer
- Simplified `handle_display_picture`: always uses FrameBuffer
- Merged `handle_display_picture_batch` into `handle_display_picture_buffered`
- Added streaming API methods: `init_buffer`, `has_batch_ready`, `pop_batch`, `flush`
- Renamed `decode_all` to `decode_packets` for clarity

**Public Decoder (NvDecDecoder)**:
- Removed `decode()` method - users should use streaming API or `decode_packets` for batch processing
- Removed `flush()` return value - now returns void, batches retrieved separately
- Added streaming API: `init_buffer`, `streaming_decode_packets`, `flush`

**Python Interface**:
- Updated return type annotation from `Iterator[list[CUDABuffer]]` to `Iterator[CUDABuffer]`
- Updated docstring: now yields batches of `num_frames` frames, shape `(num_frames, height + height//2, width)`

This changes the Python API for `streaming_load_video_nvdec`:
- **Old**: `for chunk in streamer:` where `chunk` is `list[CUDABuffer]` with each buffer being a single frame
- **New**: `for batch in streamer:` where `batch` is a single `CUDABuffer` containing multiple frames