### PR TITLE
[libspdl] Remove the original NV12 color conversion function 

### DIFF
--- a/src/libspdl/cuda/color_conversion.cpp
+++ b/src/libspdl/cuda/color_conversion.cpp
@@ -20,113 +20,13 @@
 #include <vector>
 
 namespace spdl::cuda {
-namespace {
-void validate_shape_consistency(const std::vector<CUDABuffer>& frames) {
-  if (!frames.size()) {
-    SPDL_FAIL("The input must have at least one frame.");
-  }
-  const auto& f0 = frames.at(0);
-  for (size_t i = 0; i < frames.size(); ++i) {
-    const auto& f = frames.at(i);
-    if (f.shape.size() != 2) {
-      SPDL_FAIL(
-          fmt::format("The input frame must be 2D. Found: {}", f.shape.size()));
-    }
-    if (f.depth != sizeof(uint8_t) ||
-        f.elem_class != spdl::core::ElemClass::UInt) {
-      SPDL_FAIL(fmt::format("The input must be uint8 type."));
-    }
-
-    if (f.shape != f0.shape) {
-      SPDL_FAIL(
-          fmt::format(
-              "The shape of the buffer does not match. Found [{}] at 0, and [{}] at {}",
-              fmt::join(f0.shape, ", "),
-              fmt::join(f.shape, ", "),
-              i));
-    }
-
-    if (f.device_index != f0.device_index) {
-      SPDL_WARN(
-          fmt::format(
-              "The frames are in different devices. Frame 0 is on device {} and Frame {} is oon device {}",
-              f0.device_index,
-              i,
-              f.device_index));
-    }
-  }
-}
 
 using Nv2Converter =
-    void (*)(CUstream, uint8_t*, int, uint8_t*, int, int, int, int);
-
-using Nv2ConverterBatched =
     void (*)(CUstream, uint8_t*, int, uint8_t*, int, int, int, int, int);
 
+namespace {
 template <Nv2Converter Fn>
 CUDABufferPtr nv12_to_rgb(
-    const std::vector<CUDABuffer>& frames,
-    const CUDAConfig& cfg,
-    int matrix_coefficients,
-    bool sync) {
-  validate_shape_consistency(frames);
-  const auto& f0 = frames[0];
-  auto height = f0.shape[0], width = f0.shape[1];
-  if (height % 3) {
-    SPDL_FAIL(
-        fmt::format(
-            "The height of NV12 image must be divisble by 3. Found: {}",
-            height));
-  }
-  auto h0 = height / 3 * 2;
-
-  auto ret = cuda_buffer({frames.size(), 3, h0, width}, cfg);
-
-  auto* dst = (uint8_t*)ret->data();
-  for (auto& frame : frames) {
-    Fn((CUstream)cfg.stream,
-       (uint8_t*)frame.data(),
-       (int)width,
-       dst,
-       (int)width, // pitch
-       (int)width,
-       (int)h0,
-       matrix_coefficients);
-    dst += 3 * h0 * width;
-  }
-
-  if (sync) {
-    CHECK_CUDA(
-        cudaStreamSynchronize((cudaStream_t)cfg.stream),
-        "Failed to synchronize stream after color conversion.");
-  }
-
-  return ret;
-}
-
-} // namespace
-
-CUDABufferPtr nv12_to_planar_rgb(
-    const std::vector<CUDABuffer>& frames,
-    const CUDAConfig& cfg,
-    int matrix_coefficients,
-    bool sync) {
-  return nv12_to_rgb<detail::nv12_to_planar_rgb>(
-      frames, cfg, matrix_coefficients, sync);
-}
-
-CUDABufferPtr nv12_to_planar_bgr(
-    const std::vector<CUDABuffer>& frames,
-    const CUDAConfig& cfg,
-    int matrix_coefficients,
-    bool sync) {
-  return nv12_to_rgb<detail::nv12_to_planar_bgr>(
-      frames, cfg, matrix_coefficients, sync);
-}
-
-namespace {
-template <Nv2ConverterBatched Fn>
-CUDABufferPtr nv12_to_rgb_batched(
     const CUDABuffer& nv12_batch,
     const CUDAConfig& cfg,
     int matrix_coefficients,
@@ -176,21 +76,21 @@ CUDABufferPtr nv12_to_rgb_batched(
 }
 } // namespace
 
-CUDABufferPtr nv12_to_planar_rgb_batched(
+CUDABufferPtr nv12_to_planar_rgb(
     const CUDABuffer& nv12_batch,
     const CUDAConfig& cfg,
     int matrix_coefficients,
     bool sync) {
-  return nv12_to_rgb_batched<detail::nv12_to_planar_rgb_batched>(
+  return nv12_to_rgb<detail::nv12_to_planar_rgb>(
       nv12_batch, cfg, matrix_coefficients, sync);
 }
 
-CUDABufferPtr nv12_to_planar_bgr_batched(
+CUDABufferPtr nv12_to_planar_bgr(
     const CUDABuffer& nv12_batch,
     const CUDAConfig& cfg,
     int matrix_coefficients,
     bool sync) {
-  return nv12_to_rgb_batched<detail::nv12_to_planar_bgr_batched>(
+  return nv12_to_rgb<detail::nv12_to_planar_bgr>(
       nv12_batch, cfg, matrix_coefficients, sync);
 }
 } // namespace spdl::cuda

--- a/src/libspdl/cuda/color_conversion.h
+++ b/src/libspdl/cuda/color_conversion.h
@@ -15,42 +15,6 @@
 
 namespace spdl::cuda {
 
-/// Convert NV12 frames to planar RGB format on GPU.
-///
-/// Performs color space conversion from NV12 (YUV 4:2:0 with interleaved UV)
-/// to planar RGB format using CUDA.
-///
-/// @param frames Vector of NV12 frame buffers to convert.
-/// @param cfg CUDA configuration including device and stream.
-/// @param matrix_coefficients Color matrix coefficients for conversion
-/// (default: BT.709).
-/// @param sync If true, synchronizes the stream before returning (default:
-/// true).
-/// @return CUDA buffer containing planar RGB data.
-CUDABufferPtr nv12_to_planar_rgb(
-    const std::vector<CUDABuffer>& frames,
-    const CUDAConfig& cfg,
-    int matrix_coefficients = 1,
-    bool sync = true);
-
-/// Convert NV12 frames to planar BGR format on GPU.
-///
-/// Performs color space conversion from NV12 (YUV 4:2:0 with interleaved UV)
-/// to planar BGR format using CUDA.
-///
-/// @param frames Vector of NV12 frame buffers to convert.
-/// @param cfg CUDA configuration including device and stream.
-/// @param matrix_coefficients Color matrix coefficients for conversion
-/// (default: BT.709).
-/// @param sync If true, synchronizes the stream before returning (default:
-/// true).
-/// @return CUDA buffer containing planar BGR data.
-CUDABufferPtr nv12_to_planar_bgr(
-    const std::vector<CUDABuffer>& frames,
-    const CUDAConfig& cfg,
-    int matrix_coefficients = 1,
-    bool sync = true);
-
 /// Convert batched NV12 frames (3D buffer) to planar RGB format on GPU.
 ///
 /// This is an optimized version that takes a pre-allocated 3D buffer containing
@@ -64,7 +28,7 @@ CUDABufferPtr nv12_to_planar_bgr(
 /// true).
 /// @return CUDA buffer containing planar RGB data with shape [num_frames, 3,
 /// height, width].
-CUDABufferPtr nv12_to_planar_rgb_batched(
+CUDABufferPtr nv12_to_planar_rgb(
     const CUDABuffer& nv12_batch,
     const CUDAConfig& cfg,
     int matrix_coefficients = 1,
@@ -83,7 +47,7 @@ CUDABufferPtr nv12_to_planar_rgb_batched(
 /// true).
 /// @return CUDA buffer containing planar BGR data with shape [num_frames, 3,
 /// height, width].
-CUDABufferPtr nv12_to_planar_bgr_batched(
+CUDABufferPtr nv12_to_planar_bgr(
     const CUDABuffer& nv12_batch,
     const CUDAConfig& cfg,
     int matrix_coefficients = 1,

--- a/src/libspdl/cuda/detail/color_conversion.h
+++ b/src/libspdl/cuda/detail/color_conversion.h
@@ -15,29 +15,8 @@ using CUstream = CUstream_st*;
 
 namespace spdl::cuda::detail {
 
-// Non-batched version (single frame)
-void nv12_to_planar_rgb(
-    CUstream stream,
-    uint8_t* src,
-    int src_pitch,
-    uint8_t* dst,
-    int dst_pitch,
-    int width,
-    int height,
-    int matrix_coefficients);
-
-void nv12_to_planar_bgr(
-    CUstream stream,
-    uint8_t* src,
-    int src_pitch,
-    uint8_t* dst,
-    int dst_pitch,
-    int width,
-    int height,
-    int matrix_coefficients);
-
 // Batched version (multiple frames in single kernel launch)
-void nv12_to_planar_rgb_batched(
+void nv12_to_planar_rgb(
     CUstream stream,
     uint8_t* src,
     int src_pitch,
@@ -48,7 +27,7 @@ void nv12_to_planar_rgb_batched(
     int num_frames,
     int matrix_coefficients);
 
-void nv12_to_planar_bgr_batched(
+void nv12_to_planar_bgr(
     CUstream stream,
     uint8_t* src,
     int src_pitch,

--- a/src/spdl/io/lib/_libspdl_cuda.pyi
+++ b/src/spdl/io/lib/_libspdl_cuda.pyi
@@ -219,10 +219,6 @@ def built_with_nvjpeg() -> bool: ...
 
 def synchronize_stream(arg: CUDAConfig, /) -> None: ...
 
-@overload
-def nv12_to_planar_rgb(buffers: Sequence[CUDABuffer], *, device_config: CUDAConfig, matrix_coeff: int = 1, sync: bool = True) -> CUDABuffer: ...
-
-@overload
 def nv12_to_planar_rgb(buffer: CUDABuffer, *, device_config: CUDAConfig, matrix_coeff: int = 1, sync: bool = True) -> CUDABuffer:
     """
     Convert batched NV12 frames to planar RGB.
@@ -237,10 +233,6 @@ def nv12_to_planar_rgb(buffer: CUDABuffer, *, device_config: CUDAConfig, matrix_
         CUDA buffer containing planar RGB data with shape ``[num_frames, 3, height, width]``.
     """
 
-@overload
-def nv12_to_planar_bgr(buffers: Sequence[CUDABuffer], *, device_config: CUDAConfig, matrix_coeff: int = 1, sync: bool = True) -> CUDABuffer: ...
-
-@overload
 def nv12_to_planar_bgr(buffer: CUDABuffer, *, device_config: CUDAConfig, matrix_coeff: int = 1, sync: bool = True) -> CUDABuffer:
     """
     Convert batched NV12 frames to planar BGR.

--- a/src/spdl/io/lib/cuda/color_conversion.cpp
+++ b/src/spdl/io/lib/cuda/color_conversion.cpp
@@ -16,7 +16,6 @@
 
 #include <nanobind/nanobind.h>
 #include <nanobind/stl/unique_ptr.h>
-#include <nanobind/stl/vector.h>
 
 namespace nb = nanobind;
 
@@ -25,43 +24,11 @@ void register_color_conversion(nb::module_& m) {
   m.def(
       "nv12_to_planar_rgb",
 #ifndef SPDL_USE_CUDA
-      [](const std::vector<CUDABuffer>&, const CUDAConfig&, int, bool)
-          -> CUDABufferPtr {
-        throw std::runtime_error("SPDL is not built with CUDA support.");
-      },
-#else
-      &nv12_to_planar_rgb,
-#endif
-      nb::call_guard<nb::gil_scoped_release>(),
-      nb::arg("buffers"),
-      nb::kw_only(),
-      nb::arg("device_config"),
-      nb::arg("matrix_coeff") = 1,
-      nb::arg("sync") = true);
-  m.def(
-      "nv12_to_planar_bgr",
-#ifndef SPDL_USE_CUDA
-      [](const std::vector<CUDABuffer>&, const CUDAConfig&, int, bool)
-          -> CUDABufferPtr {
-        throw std::runtime_error("SPDL is not built with CUDA support.");
-      },
-#else
-      &nv12_to_planar_bgr,
-#endif
-      nb::call_guard<nb::gil_scoped_release>(),
-      nb::arg("buffers"),
-      nb::kw_only(),
-      nb::arg("device_config"),
-      nb::arg("matrix_coeff") = 1,
-      nb::arg("sync") = true);
-  m.def(
-      "nv12_to_planar_rgb",
-#ifndef SPDL_USE_CUDA
       [](const CUDABuffer&, const CUDAConfig&, int, bool) -> CUDABufferPtr {
         throw std::runtime_error("SPDL is not built with CUDA support.");
       },
 #else
-      &nv12_to_planar_rgb_batched,
+      &nv12_to_planar_rgb,
 #endif
       R"(Convert batched NV12 frames to planar RGB.
 
@@ -87,7 +54,7 @@ Returns:
         throw std::runtime_error("SPDL is not built with CUDA support.");
       },
 #else
-      &nv12_to_planar_bgr_batched,
+      &nv12_to_planar_bgr,
 #endif
       R"(Convert batched NV12 frames to planar BGR.
 

--- a/tests/cuda/nvdec_video_decoding_test.py
+++ b/tests/cuda/nvdec_video_decoding_test.py
@@ -547,7 +547,7 @@ class TestDecodePackets(unittest.TestCase):
         self.assertEqual(tensor.shape[2], 320)  # testsrc default width
 
     def test_decode_packets_matches_streaming_decode(self) -> None:
-        """Verify decode_packets produces the same result as streaming decode."""
+        """Verify decode_packets produces the same result as streaming_load_video_nvdec."""
         # Setup: Create test video sample
         h264 = _get_h264_sample()
         cuda_config = spdl.io.cuda_config(device_index=DEFAULT_CUDA)

--- a/tests/cuda/streaming_load_video_nvdec_test.py
+++ b/tests/cuda/streaming_load_video_nvdec_test.py
@@ -182,7 +182,7 @@ class TestStreamingLoadVideoNvdec(unittest.TestCase):
         num_frames = first_batch.__cuda_array_interface__["shape"][0]
         self.assertEqual(num_frames, 32)  # 32 frames in batch
 
-        # Convert batched NV12 to RGB using the batched conversion function
+        # Convert batched NV12 to RGB
         rgb_buffer = spdl.io.nv12_to_rgb(first_batch, device_config=device_config)
         rgb_tensor = spdl.io.to_torch(rgb_buffer)
 


### PR DESCRIPTION
With the changes introduced in
https://github.com/facebookresearch/spdl/pull/1271 ,
NVDEC decoder only returns batched frames, and corresponding
NV12 conversion function was added in
https://github.com/facebookresearch/spdl/pull/1269 .

These changes make the original NV12 color conversion function
(the one takes a list of single frames) obsolete and disconnected
from the rest of the APIs.

So this commit removes the function.