### PR TITLE
Add ProcessGroupStatsMonitor background task (#1334)

### DIFF
--- a/src/spdl/pipeline/__init__.py
+++ b/src/spdl/pipeline/__init__.py
@@ -31,12 +31,18 @@ from ._iter_utils import (
     iterate_in_subinterpreter,
     iterate_in_subprocess,
 )
+from ._pgrp_stats import (
+    ProcessGroupResourceUsage,
+    ProcessGroupStatsMonitor,
+)
 from ._pipeline import Pipeline
 from ._profile import profile_pipeline, ProfileHook, ProfileResult
 
 __all__ = [
     "BackgroundTask",
     "BackgroundTaskFactory",
+    "ProcessGroupResourceUsage",
+    "ProcessGroupStatsMonitor",
     "build_pipeline",
     "is_eof",
     "profile_pipeline",

--- a/src/spdl/pipeline/__init__.py
+++ b/src/spdl/pipeline/__init__.py
@@ -8,9 +8,8 @@
 
 # pyre-strict
 
+from ._bg_task import BackgroundTask, BackgroundTaskFactory
 from ._build import (
-    BackgroundTask,
-    BackgroundTaskFactory,
     build_pipeline,
     run_pipeline_in_subinterpreter,
     run_pipeline_in_subprocess,

--- a/src/spdl/pipeline/_bg_task.py
+++ b/src/spdl/pipeline/_bg_task.py
@@ -1,0 +1,81 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""Background task abstractions for the pipeline engine."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+__all__ = [
+    "BackgroundTask",
+    "BackgroundTaskFactory",
+    "get_default_background_tasks",
+    "set_default_background_tasks",
+]
+
+
+class BackgroundTask:
+    """A background task that runs alongside pipeline stages.
+
+    Subclass this and override :py:meth:`run` to implement custom logic.
+    The task is started when the pipeline starts and cancelled when the
+    pipeline completes. Errors are logged but do not cause the pipeline
+    to fail.
+
+    Example::
+
+        class MyMonitor(BackgroundTask):
+            async def run(self) -> None:
+                while True:
+                    collect_metrics()
+                    await asyncio.sleep(60)
+
+        pipeline = build_pipeline(cfg, num_threads=4,
+                                  background_tasks=[MyMonitor])
+    """
+
+    async def run(self) -> None:
+        """Override this to implement the background task logic.
+
+        This coroutine runs in the pipeline's event loop. It will be
+        cancelled when the pipeline completes, so use ``try/except
+        asyncio.CancelledError`` if cleanup is needed.
+        """
+        raise NotImplementedError
+
+
+BackgroundTaskFactory = Callable[[], BackgroundTask]
+
+_DEFAULT_BACKGROUND_TASKS: list[BackgroundTaskFactory] | None = None
+
+
+def get_default_background_tasks() -> list[BackgroundTaskFactory] | None:
+    """Get the default background task factories.
+
+    Returns:
+        The default background task factories or None if not set.
+    """
+    return _DEFAULT_BACKGROUND_TASKS
+
+
+def set_default_background_tasks(
+    tasks: list[BackgroundTaskFactory] | None,
+) -> None:
+    """Set the default background task factories.
+
+    Each factory is called to create a :py:class:`BackgroundTask` instance
+    whose :py:meth:`~BackgroundTask.run` coroutine runs alongside the pipeline
+    stages. Tasks are cancelled when the pipeline completes. Their errors are
+    logged but do not cause the pipeline to fail.
+
+    Args:
+        tasks: A list of background task factories, or None to unset.
+    """
+    global _DEFAULT_BACKGROUND_TASKS
+    _DEFAULT_BACKGROUND_TASKS = tasks

--- a/src/spdl/pipeline/_build.py
+++ b/src/spdl/pipeline/_build.py
@@ -12,10 +12,6 @@ __all__ = [
     "run_pipeline_in_subprocess",
     "get_default_build_callback",
     "set_default_build_callback",
-    "BackgroundTask",
-    "BackgroundTaskFactory",
-    "get_default_background_tasks",
-    "set_default_background_tasks",
 ]
 
 import logging
@@ -26,6 +22,10 @@ from fractions import Fraction
 from functools import partial
 from typing import Any, Generic, TypeVar
 
+from spdl.pipeline._bg_task import (
+    BackgroundTaskFactory,
+    get_default_background_tasks,
+)
 from spdl.pipeline._components import (
     _build_pipeline_coro,
     _get_global_id,
@@ -68,67 +68,6 @@ def set_default_build_callback(
     """
     global _DEFAULT_BUILD_CALLBACK
     _DEFAULT_BUILD_CALLBACK = callback
-
-
-class BackgroundTask:
-    """A background task that runs alongside pipeline stages.
-
-    Subclass this and override :py:meth:`run` to implement custom logic.
-    The task is started when the pipeline starts and cancelled when the
-    pipeline completes. Errors are logged but do not cause the pipeline
-    to fail.
-
-    Example::
-
-        class MyMonitor(BackgroundTask):
-            async def run(self) -> None:
-                while True:
-                    collect_metrics()
-                    await asyncio.sleep(60)
-
-        pipeline = build_pipeline(cfg, num_threads=4,
-                                  background_tasks=[MyMonitor])
-    """
-
-    async def run(self) -> None:
-        """Override this to implement the background task logic.
-
-        This coroutine runs in the pipeline's event loop. It will be
-        cancelled when the pipeline completes, so use ``try/except
-        asyncio.CancelledError`` if cleanup is needed.
-        """
-        raise NotImplementedError
-
-
-BackgroundTaskFactory = Callable[[], BackgroundTask]
-
-_DEFAULT_BACKGROUND_TASKS: list[BackgroundTaskFactory] | None = None
-
-
-def get_default_background_tasks() -> list[BackgroundTaskFactory] | None:
-    """Get the default background task factories.
-
-    Returns:
-        The default background task factories or None if not set.
-    """
-    return _DEFAULT_BACKGROUND_TASKS
-
-
-def set_default_background_tasks(
-    tasks: list[BackgroundTaskFactory] | None,
-) -> None:
-    """Set the default background task factories.
-
-    Each factory is called to create a :py:class:`BackgroundTask` instance
-    whose :py:meth:`~BackgroundTask.run` coroutine runs alongside the pipeline
-    stages. Tasks are cancelled when the pipeline completes. Their errors are
-    logged but do not cause the pipeline to fail.
-
-    Args:
-        tasks: A list of background task factories, or None to unset.
-    """
-    global _DEFAULT_BACKGROUND_TASKS
-    _DEFAULT_BACKGROUND_TASKS = tasks
 
 
 # The following is how we intend pipeline to behave. If the implementation
@@ -201,8 +140,9 @@ def _build_pipeline(
 
     # Merge per-pipeline background tasks with defaults
     all_bg_tasks: list[BackgroundTaskFactory] = []
-    if _DEFAULT_BACKGROUND_TASKS:
-        all_bg_tasks.extend(_DEFAULT_BACKGROUND_TASKS)
+    default_bg = get_default_background_tasks()
+    if default_bg:
+        all_bg_tasks.extend(default_bg)
     if background_tasks:
         all_bg_tasks.extend(background_tasks)
 

--- a/src/spdl/pipeline/_components/_node.py
+++ b/src/spdl/pipeline/_components/_node.py
@@ -14,6 +14,7 @@ from fractions import Fraction
 from functools import partial
 from typing import Any, TypeAlias, TypeVar
 
+from spdl.pipeline._bg_task import BackgroundTaskFactory
 from spdl.pipeline._common._misc import create_task
 from spdl.pipeline.defs import (
     _PipeArgs,
@@ -786,7 +787,7 @@ class PipelineFailure(RuntimeError):
 
 async def _run_pipeline_coroutines(
     node: _TNodes,
-    background_tasks: Sequence[Callable[[], Any]] | None = None,
+    background_tasks: Sequence[BackgroundTaskFactory] | None = None,
 ) -> None:
     """Orchestrate the execution of all pipeline stage coroutines.
 
@@ -881,7 +882,7 @@ def _build_pipeline_coro(
     queue_class: type[AsyncQueue] | None = None,
     task_hook_factory: Callable[[str], list[TaskHook]] | None = None,
     stage_id: int = 0,
-    background_tasks: Sequence[Callable[[], Any]] | None = None,
+    background_tasks: Sequence[BackgroundTaskFactory] | None = None,
 ) -> tuple[Coroutine[None, None, None], asyncio.Queue]:
     try:
         node = _build_pipeline_node(

--- a/src/spdl/pipeline/_pgrp_stats.py
+++ b/src/spdl/pipeline/_pgrp_stats.py
@@ -1,0 +1,606 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""Process-group resource monitoring (Linux-only).
+
+Collects CPU, memory (RSS, PSS, private), disk IO, and network bytes
+across all processes sharing a PGID by reading ``/proc``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import multiprocessing
+import os
+import signal
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+
+from spdl.pipeline._bg_task import BackgroundTask
+
+__all__ = [
+    "ProcessGroupResourceUsage",
+    "ProcessGroupStatsMonitor",
+]
+
+_LG: logging.Logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_warned: set[str] = set()
+
+
+def _warn_once(key: str, msg: str, *args: object) -> None:
+    """Log a warning at most once per key."""
+    if key not in _warned:
+        _warned.add(key)
+        _LG.warning(msg, *args)
+
+
+_PGRP_INTERVAL_SEC: float = 60.0
+
+_SC_CLK_TCK: int | None = None
+_PAGE_SIZE: int | None = None
+
+
+def _get_sc_clk_tck() -> int:
+    global _SC_CLK_TCK
+    if _SC_CLK_TCK is None:
+        _SC_CLK_TCK = os.sysconf("SC_CLK_TCK")
+    return _SC_CLK_TCK
+
+
+def _get_page_size() -> int:
+    global _PAGE_SIZE
+    if _PAGE_SIZE is None:
+        _PAGE_SIZE = os.sysconf("SC_PAGE_SIZE")
+    return _PAGE_SIZE
+
+
+# ---------------------------------------------------------------------------
+# /proc parsers
+# ---------------------------------------------------------------------------
+
+
+def _read_file(path: str) -> str | None:
+    """Read a file, returning None if it doesn't exist or can't be read."""
+    try:
+        with open(path) as f:
+            return f.read().strip()
+    except OSError:
+        return None
+
+
+@dataclass
+class _SmapsRollup:
+    pss: int
+    private_clean: int
+    private_dirty: int
+
+
+def _parse_smaps_rollup(content: str) -> _SmapsRollup:
+    """Parse ``/proc/[pid]/smaps_rollup`` for PSS and private memory.
+
+    Example ``/proc/[pid]/smaps_rollup`` content (partial)::
+
+        00400000-ffffffff ---p 00000000 00:00 0          [rollup]
+        Rss:              123456 kB
+        Pss:               98765 kB
+        Private_Clean:     50000 kB
+        Private_Dirty:     30000 kB
+        ...
+
+    Values are in kB.  We return bytes.
+
+    Raises:
+        RuntimeError: If the content is malformed.
+    """
+    pss = 0
+    private_clean = 0
+    private_dirty = 0
+    try:
+        for line in content.splitlines():
+            parts = line.split()
+            if len(parts) < 3:
+                continue
+            if parts[0] == "Pss:":
+                pss = int(parts[1]) * 1024
+            elif parts[0] == "Private_Clean:":
+                private_clean = int(parts[1]) * 1024
+            elif parts[0] == "Private_Dirty:":
+                private_dirty = int(parts[1]) * 1024
+    except (ValueError, IndexError) as e:
+        raise RuntimeError(
+            f"Failed to parse /proc/[pid]/smaps_rollup: {content[:120]}"
+        ) from e
+    return _SmapsRollup(
+        pss=pss, private_clean=private_clean, private_dirty=private_dirty
+    )
+
+
+@dataclass
+class _ProcStat:
+    pgrp: int
+    utime: int
+    stime: int
+    rss: int
+
+
+def _parse_proc_stat(content: str) -> _ProcStat:
+    """Parse ``/proc/[pid]/stat``.
+
+    Example ``/proc/[pid]/stat`` content::
+
+        12345 (python3) S 100 200 200 0 -1 4194304 0 0 0 0 500 300 0 0 20 0 1 0 12345 0 4096 ...
+
+    Format: ``pid (comm) state ppid pgrp session ...``
+    The comm field can contain spaces and parentheses, so we find the last
+    ``)`` and split everything after it.  Fields after comm (0-indexed):
+      [0] state, [1] ppid, [2] pgrp, [11] utime, [12] stime, [21] rss, ...
+
+    Raises:
+        RuntimeError: If the content is malformed or has too few fields.
+    """
+    close_paren = content.rfind(")")
+    if close_paren < 0:
+        raise RuntimeError(
+            f"Unexpected /proc/[pid]/stat format: missing closing paren: {content[:80]}"
+        )
+    fields = content[close_paren + 2 :].split()
+    if len(fields) < 22:
+        raise RuntimeError(
+            f"Unexpected /proc/[pid]/stat format: "
+            f"expected >=22 fields after comm, got {len(fields)}"
+        )
+    try:
+        return _ProcStat(
+            pgrp=int(fields[2]),
+            utime=int(fields[11]),
+            stime=int(fields[12]),
+            rss=int(fields[21]),
+        )
+    except (ValueError, IndexError) as e:
+        raise RuntimeError(f"Failed to parse /proc/[pid]/stat: {content[:80]}") from e
+
+
+@dataclass
+class _ProcIO:
+    read_bytes: int
+    write_bytes: int
+
+
+def _parse_proc_io(content: str) -> _ProcIO:
+    """Parse ``/proc/[pid]/io``.
+
+    Example ``/proc/[pid]/io`` content::
+
+        rchar: 123456
+        wchar: 654321
+        syscr: 100
+        syscw: 200
+        read_bytes: 4096
+        write_bytes: 8192
+        cancelled_write_bytes: 0
+
+    ``read_bytes`` / ``write_bytes`` are actual storage IO bytes (not
+    page-cache reads/writes like ``rchar`` / ``wchar``).
+
+    Raises:
+        RuntimeError: If the content contains non-numeric values.
+    """
+    read_bytes = 0
+    write_bytes = 0
+    try:
+        for line in content.splitlines():
+            parts = line.split()
+            if len(parts) < 2:
+                continue
+            if parts[0] == "read_bytes:":
+                read_bytes = int(parts[1])
+            elif parts[0] == "write_bytes:":
+                write_bytes = int(parts[1])
+    except (ValueError, IndexError) as e:
+        raise RuntimeError(f"Failed to parse /proc/[pid]/io: {content[:80]}") from e
+    return _ProcIO(read_bytes=read_bytes, write_bytes=write_bytes)
+
+
+@dataclass
+class _NetworkBytes:
+    rx_bytes: int
+    tx_bytes: int
+
+
+def _read_network_bytes() -> _NetworkBytes:
+    """Read network RX/TX bytes from ``/proc/net/dev``.
+
+    Example ``/proc/net/dev`` content::
+
+        Inter-|   Receive                                                |  Transmit
+         face |bytes packets errs drop fifo frame compressed multicast|bytes packets ...
+            lo: 1234    10    0    0    0     0          0         0     5678    20 ...
+          eth0: 9999    50    0    0    0     0          0         0     8888    30 ...
+
+    Each line after the two header lines has the interface name followed by
+    16 counters.  Column 1 (0-indexed) is RX bytes, column 9 is TX bytes.
+    Loopback (``lo``) is excluded.
+
+    Raises:
+        RuntimeError: If the file content is malformed.
+    """
+    rx_bytes = 0
+    tx_bytes = 0
+    content = _read_file("/proc/net/dev")
+    if content:
+        for line in content.splitlines()[2:]:  # skip header lines
+            parts = line.split()
+            if len(parts) < 10:
+                continue
+            iface = parts[0].rstrip(":")
+            if iface == "lo":
+                continue
+            try:
+                rx_bytes += int(parts[1])
+                tx_bytes += int(parts[9])
+            except (ValueError, IndexError) as e:
+                raise RuntimeError(
+                    f"Failed to parse /proc/net/dev line: {line.strip()[:80]}"
+                ) from e
+    return _NetworkBytes(rx_bytes=rx_bytes, tx_bytes=tx_bytes)
+
+
+# ---------------------------------------------------------------------------
+# Aggregation across the process group
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _PgrpStats:
+    cpu_usec: int
+    rss_bytes: int
+    pss_bytes: int | None
+    private_bytes: int | None
+    disk_read_bytes: int
+    disk_write_bytes: int
+    num_procs: int
+
+
+def _read_pgrp_stats() -> _PgrpStats:
+    """Sum CPU, RSS, PSS, private memory, and disk IO across all PIDs in this process group.
+
+    Raises:
+        RuntimeError: If /proc cannot be scanned.
+    """
+    pgid = os.getpgrp()
+    total_utime = 0
+    total_stime = 0
+    total_rss = 0
+    total_pss = 0
+    total_private = 0
+    has_smaps = False
+    total_read_bytes = 0
+    total_write_bytes = 0
+    num_procs = 0
+
+    try:
+        for entry in os.scandir("/proc"):
+            if not entry.name.isdigit():
+                continue
+            content = _read_file(f"/proc/{entry.name}/stat")
+            if content is None:
+                continue
+            try:
+                stat = _parse_proc_stat(content)
+            except RuntimeError as e:
+                _warn_once("proc_stat", "%s", e)
+                continue
+            if stat.pgrp != pgid:
+                continue
+            total_utime += stat.utime
+            total_stime += stat.stime
+            total_rss += stat.rss
+            num_procs += 1
+
+            smaps_content = _read_file(f"/proc/{entry.name}/smaps_rollup")
+            if smaps_content is not None:
+                try:
+                    smaps = _parse_smaps_rollup(smaps_content)
+                except RuntimeError as e:
+                    _warn_once("smaps_rollup", "%s", e)
+                else:
+                    has_smaps = True
+                    total_pss += smaps.pss
+                    total_private += smaps.private_clean + smaps.private_dirty
+
+            io_content = _read_file(f"/proc/{entry.name}/io")
+            if io_content is not None:
+                try:
+                    io = _parse_proc_io(io_content)
+                except RuntimeError as e:
+                    _warn_once("proc_io", "%s", e)
+                else:
+                    total_read_bytes += io.read_bytes
+                    total_write_bytes += io.write_bytes
+    except OSError as e:
+        raise RuntimeError(f"Failed to scan /proc: {e}") from e
+
+    cpu_usec = (total_utime + total_stime) * 1_000_000 // _get_sc_clk_tck()
+
+    return _PgrpStats(
+        cpu_usec=cpu_usec,
+        rss_bytes=total_rss * _get_page_size(),
+        pss_bytes=total_pss if has_smaps else None,
+        private_bytes=total_private if has_smaps else None,
+        disk_read_bytes=total_read_bytes,
+        disk_write_bytes=total_write_bytes,
+        num_procs=num_procs,
+    )
+
+
+@dataclass
+class ProcessGroupResourceUsage:
+    """Snapshot of resource usage across all processes in the process group.
+
+    Collected periodically by :class:`ProcessGroupStatsMonitor` and passed
+    to the user-provided callback.
+
+    **Memory metrics** — three complementary views are provided:
+
+    * **RSS** (Resident Set Size, from ``/proc/[pid]/stat``):
+      Total physical pages mapped by each process. Shared pages (shared
+      libraries, CUDA context, etc.) are counted once *per process* that
+      maps them, so summing RSS across a process group **overcounts**
+      actual physical memory when pages are shared.
+
+    * **PSS** (Proportional Set Size, from ``/proc/[pid]/smaps_rollup``):
+      Each shared page is divided equally among all processes that map it.
+      Summing PSS across a process group gives the most accurate estimate
+      of actual physical memory consumption without double-counting.
+
+    * **Private bytes** (``Private_Clean + Private_Dirty`` from
+      ``/proc/[pid]/smaps_rollup``):
+      Only pages exclusive to each process — memory that would be freed
+      if the process exited. This **undercounts** total usage because it
+      excludes shared memory entirely, but isolates per-process
+      allocations (model weights, activations, buffers).
+
+    The difference ``RSS − Private`` approximates each process's shared
+    memory contribution.  Reading ``smaps_rollup`` is more expensive than
+    ``stat`` (the kernel walks page tables), but it is a single-file read
+    per process so the overhead is modest.
+
+    **Which metric to use:**
+
+    * Use **PSS** as the primary metric for comparing memory across
+      configuration changes — it reflects the true physical memory cost
+      of the process group without double-counting.
+    * Use **Private** to isolate per-process allocations (model weights,
+      activations, buffers) from shared overhead.
+    * Use **RSS** as an upper-bound sanity check.  When ``num_procs == 1``,
+      RSS equals PSS.
+    * ``PSS − Private`` can be derived in queries to see how much shared
+      memory is attributed to this group.
+    """
+
+    pid: int
+    """PID of the monitoring process."""
+
+    pgid: int
+    """Process group ID being monitored."""
+
+    cpu_percent: float | None = None
+    """CPU utilization as a percentage of a single core over the last interval.
+
+    Computed as ``delta_cpu_usec / delta_wall_usec * 100``.  A value of
+    200.0 means two cores were fully utilized.  ``None`` on the first
+    snapshot (no previous value to diff against).
+    """
+
+    rss_bytes: int | None = None
+    """Total resident set size in bytes across the process group.
+
+    Overcounts physical memory when pages are shared across processes.
+    See class docstring for details.
+    """
+
+    pss_bytes: int | None = None
+    """Total proportional set size in bytes across the process group.
+
+    Shared pages are divided by the number of sharers, giving the most
+    accurate view of actual physical memory cost.  ``None`` when
+    ``smaps_rollup`` is unavailable.
+    """
+
+    private_bytes: int | None = None
+    """Total private memory (Private_Clean + Private_Dirty) in bytes.
+
+    Only pages exclusive to each process.  ``None`` when
+    ``smaps_rollup`` is unavailable.
+    """
+
+    disk_read_bytes: int | None = None
+    """Total bytes read from storage across the process group."""
+
+    disk_write_bytes: int | None = None
+    """Total bytes written to storage across the process group."""
+
+    num_procs: int | None = None
+    """Number of processes in the process group."""
+
+    net_rx_bytes: int | None = None
+    """Total network bytes received (excluding loopback)."""
+
+    net_tx_bytes: int | None = None
+    """Total network bytes transmitted (excluding loopback)."""
+
+
+def _collect_pgrp_stats(
+    prev_cpu_usec: int | None = None,
+    prev_time_usec: int | None = None,
+) -> tuple[ProcessGroupResourceUsage, int | None, int]:
+    """Collect all process-group stats.
+
+    Reads CPU, memory (RSS, PSS, private), disk IO from
+    ``/proc/[pid]/stat``, ``/proc/[pid]/smaps_rollup``, and
+    ``/proc/[pid]/io``, and network bytes from ``/proc/net/dev``
+    for all processes in the current process group.
+
+    Args:
+        prev_cpu_usec: Cumulative CPU µs from the previous snapshot
+            (used to compute ``cpu_percent``).  ``None`` on the first call.
+        prev_time_usec: Wall-clock µs (``time.monotonic()`` × 1e6) of the
+            previous snapshot.
+
+    Returns:
+        A tuple of ``(usage, current_cpu_usec, current_time_usec)``.
+        ``current_cpu_usec`` is ``None`` when /proc could not be read.
+    """
+    import time as _time
+
+    now_usec = int(_time.monotonic() * 1_000_000)
+    result = ProcessGroupResourceUsage(pid=os.getpid(), pgid=os.getpgrp())
+    current_cpu_usec: int | None = None
+
+    try:
+        pgrp = _read_pgrp_stats()
+        current_cpu_usec = pgrp.cpu_usec
+        if (
+            prev_cpu_usec is not None
+            and prev_time_usec is not None
+            and now_usec > prev_time_usec
+        ):
+            delta_cpu = pgrp.cpu_usec - prev_cpu_usec
+            delta_wall = now_usec - prev_time_usec
+            result.cpu_percent = delta_cpu / delta_wall * 100.0
+        result.rss_bytes = pgrp.rss_bytes
+        result.pss_bytes = pgrp.pss_bytes
+        result.private_bytes = pgrp.private_bytes
+        result.disk_read_bytes = pgrp.disk_read_bytes
+        result.disk_write_bytes = pgrp.disk_write_bytes
+        result.num_procs = pgrp.num_procs
+    except RuntimeError as e:
+        _warn_once("pgrp_stats", "%s", e)
+
+    try:
+        net = _read_network_bytes()
+        result.net_rx_bytes = net.rx_bytes
+        result.net_tx_bytes = net.tx_bytes
+    except RuntimeError as e:
+        _warn_once("net_dev", "%s", e)
+
+    return result, current_cpu_usec, now_usec
+
+
+# ---------------------------------------------------------------------------
+# Subprocess entry point and BackgroundTask wrapper
+# ---------------------------------------------------------------------------
+
+
+def _pgrp_monitor_subprocess(
+    interval: float,
+    callback: Callable[[ProcessGroupResourceUsage], Awaitable[None]],
+) -> None:
+    """Entry point for the monitoring subprocess.
+
+    Runs a standalone asyncio loop that collects process-group stats and
+    dispatches them to *callback*. Both SIGINT (Ctrl-C) and SIGTERM
+    (terminate) set a flag to exit the loop gracefully.
+    """
+    running: bool = True
+
+    def _handle_term(signum: int, frame: object) -> None:
+        nonlocal running
+        running = False
+
+    signal.signal(signal.SIGINT, _handle_term)
+    signal.signal(signal.SIGTERM, _handle_term)
+
+    async def _loop() -> None:
+        loop = asyncio.get_running_loop()
+        prev_cpu_usec: int | None = None
+        prev_time_usec: int | None = None
+        while running:
+            try:
+                usage, prev_cpu_usec, prev_time_usec = await loop.run_in_executor(
+                    None, _collect_pgrp_stats, prev_cpu_usec, prev_time_usec
+                )
+                await callback(usage)
+            except Exception:
+                pass  # best-effort, avoid crashing the subprocess
+            await asyncio.sleep(interval)
+
+    asyncio.run(_loop())
+
+
+class ProcessGroupStatsMonitor(BackgroundTask):
+    """Background task that spawns a subprocess to collect per-process-group stats.
+
+    In multi-rank training, multiple ranks on the same host often share a
+    single cgroup.  External monitoring systems (e.g., dynolog) report
+    metrics per cgroup, so they cannot attribute resource usage to
+    individual ranks.  This monitor solves that by collecting stats per
+    process group — each rank typically runs as its own PGID, giving
+    per-rank granularity even when ranks share a cgroup.
+
+    Sums CPU, memory (RSS, PSS, private), disk IO, and network bytes
+    across all processes sharing this rank's PGID.
+
+    Runs in a separate subprocess so the main Python runtime is not
+    affected by GC pauses or CPU overhead from /proc scanning.
+
+    Args:
+        callback: An async callable that receives a
+            :class:`ProcessGroupResourceUsage` snapshot each interval.
+        interval: Collection interval in seconds (default 60).
+    """
+
+    def __init__(
+        self,
+        callback: Callable[[ProcessGroupResourceUsage], Awaitable[None]],
+        interval: float = _PGRP_INTERVAL_SEC,
+    ) -> None:
+        super().__init__()
+        self._callback = callback
+        self._interval = interval
+
+    async def run(self) -> None:
+        proc = multiprocessing.Process(
+            target=_pgrp_monitor_subprocess,
+            args=(self._interval, self._callback),
+            daemon=True,
+        )
+        proc.start()
+        _LG.info(
+            "Process-group stats monitor subprocess started "
+            "(main_pid=%d, monitor_pid=%d, pgid=%d)",
+            os.getpid(),
+            proc.pid,
+            os.getpgrp(),
+        )
+        try:
+            while proc.is_alive():
+                await asyncio.sleep(5)
+            _LG.warning(
+                "Process-group stats monitor subprocess exited unexpectedly "
+                "(exit code %s)",
+                proc.exitcode,
+            )
+        except asyncio.CancelledError:
+            proc.terminate()
+            proc.join(timeout=5)
+            if proc.is_alive():
+                proc.kill()
+                proc.join(timeout=1)
+            _LG.info(
+                "Process-group stats monitor subprocess stopped (pid=%d)",
+                proc.pid,
+            )
+            raise

--- a/src/spdl/pipeline/config.py
+++ b/src/spdl/pipeline/config.py
@@ -19,10 +19,12 @@ from spdl.pipeline._components import (
     set_default_queue_class,
 )
 
-from ._build import (
+from ._bg_task import (
     get_default_background_tasks,
-    get_default_build_callback,
     set_default_background_tasks,
+)
+from ._build import (
+    get_default_build_callback,
     set_default_build_callback,
 )
 from ._common._misc import (

--- a/tests/pipeline/background_task_test.py
+++ b/tests/pipeline/background_task_test.py
@@ -11,16 +11,11 @@ import time
 import unittest
 
 from spdl.pipeline import BackgroundTask, build_pipeline
-from spdl.pipeline._build import (
+from spdl.pipeline.config import (
     get_default_background_tasks,
     set_default_background_tasks,
 )
-from spdl.pipeline.defs import (
-    Pipe,
-    PipelineConfig,
-    SinkConfig,
-    SourceConfig,
-)
+from spdl.pipeline.defs import Pipe, PipelineConfig, SinkConfig, SourceConfig
 
 
 def _simple_cfg() -> PipelineConfig[int]:

--- a/tests/pipeline/pgrp_stats_test.py
+++ b/tests/pipeline/pgrp_stats_test.py
@@ -1,0 +1,483 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import asyncio
+import multiprocessing
+import os
+import sys
+import tempfile
+import unittest
+from collections.abc import Awaitable, Callable
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from spdl.pipeline._bg_task import BackgroundTask
+from spdl.pipeline._pgrp_stats import (
+    _collect_pgrp_stats,
+    _parse_proc_io,
+    _parse_proc_stat,
+    _parse_smaps_rollup,
+    _pgrp_monitor_subprocess,
+    _read_file,
+    _read_network_bytes,
+    _read_pgrp_stats,
+    _warned,
+    ProcessGroupResourceUsage,
+    ProcessGroupStatsMonitor,
+)
+
+_MODULE = "spdl.pipeline._pgrp_stats"
+
+
+@unittest.skipUnless(sys.platform == "linux", "Requires Linux /proc filesystem")
+class LiveProcMonitorTest(unittest.TestCase):
+    """Integration test that reads real /proc data without mocking."""
+
+    def test_read_pgrp_stats_returns_valid_data(self) -> None:
+        """_read_pgrp_stats should find at least this process."""
+        _warned.discard("proc_stat")
+        _warned.discard("proc_io")
+        _warned.discard("smaps_rollup")
+
+        result = _read_pgrp_stats()
+        self.assertGreaterEqual(result.num_procs, 1)
+        self.assertGreaterEqual(result.cpu_usec, 0)
+        self.assertGreaterEqual(result.rss_bytes, 0)
+        self.assertGreaterEqual(result.disk_read_bytes, 0)
+        self.assertGreaterEqual(result.disk_write_bytes, 0)
+        # smaps_rollup should be available on modern Linux
+        if result.pss_bytes is not None:
+            self.assertGreater(result.pss_bytes, 0)
+            self.assertIsNotNone(result.private_bytes)
+            self.assertGreater(result.private_bytes, 0)
+
+    def test_collect_pgrp_stats_returns_complete_snapshot(self) -> None:
+        """_collect_pgrp_stats should return a fully populated snapshot."""
+        result, cpu_usec, time_usec = _collect_pgrp_stats()
+        self.assertIsInstance(result, ProcessGroupResourceUsage)
+        self.assertEqual(result.pid, os.getpid())
+        self.assertEqual(result.pgid, os.getpgrp())
+
+        # First call: cpu_percent should be None (no previous value).
+        self.assertIsNone(result.cpu_percent)
+        self.assertIsNotNone(cpu_usec)
+        self.assertIsNotNone(result.rss_bytes)
+        self.assertIsNotNone(result.num_procs)
+        self.assertIsNotNone(result.net_rx_bytes)
+        self.assertIsNotNone(result.net_tx_bytes)
+
+        # Second call with prev values: cpu_percent should be set.
+        result2, _, _ = _collect_pgrp_stats(cpu_usec, time_usec)
+        self.assertIsNotNone(result2.cpu_percent)
+        self.assertGreaterEqual(result2.cpu_percent, 0.0)
+
+        # Sanity: at least one process (this one) should be counted.
+        assert result.num_procs is not None
+        self.assertGreaterEqual(result.num_procs, 1)
+        # RSS must be positive for a running process.
+        assert result.rss_bytes is not None
+        self.assertGreater(result.rss_bytes, 0)
+
+
+class ReadFileTest(unittest.TestCase):
+    def test_read_existing_file(self) -> None:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
+            f.write("hello\n")
+            f.flush()
+            result = _read_file(f.name)
+        self.assertEqual(result, "hello")
+        os.unlink(f.name)
+
+    def test_read_nonexistent_file(self) -> None:
+        result = _read_file("/nonexistent/path/file.txt")
+        self.assertIsNone(result)
+
+
+class ReadNetworkTest(unittest.TestCase):
+    @patch(f"{_MODULE}._read_file")
+    def test_network_bytes(self, mock_read: MagicMock) -> None:
+        mock_read.return_value = (
+            "Inter-|   Receive                                                |  Transmit\n"  # noqa: B950
+            " face |bytes    packets errs drop fifo frame compressed multicast|bytes    packets errs drop fifo colls carrier compressed\n"  # noqa: B950
+            "    lo: 1000       10    0    0    0     0          0         0     2000      20    0    0    0     0       0          0\n"  # noqa: B950
+            "  eth0: 5000       50    0    0    0     0          0         0     3000      30    0    0    0     0       0          0\n"  # noqa: B950
+            "  eth1: 7000       70    0    0    0     0          0         0     4000      40    0    0    0     0       0          0"  # noqa: B950
+        )
+        result = _read_network_bytes()
+        # lo is excluded; eth0 + eth1
+        self.assertEqual(result.rx_bytes, 12000)
+        self.assertEqual(result.tx_bytes, 7000)
+
+    @patch(f"{_MODULE}._read_file")
+    def test_network_file_missing(self, mock_read: MagicMock) -> None:
+        mock_read.return_value = None
+        result = _read_network_bytes()
+        self.assertEqual(result.rx_bytes, 0)
+        self.assertEqual(result.tx_bytes, 0)
+
+    @patch(f"{_MODULE}._read_file")
+    def test_network_malformed_line_raises(self, mock_read: MagicMock) -> None:
+        mock_read.return_value = (
+            "Inter-|   Receive\n"
+            " face |bytes\n"
+            "  eth0: bad 0 0 0 0 0 0 0 also_bad 0 0 0 0 0 0 0\n"
+        )
+        with self.assertRaises(RuntimeError, msg="Failed to parse /proc/net/dev"):
+            _read_network_bytes()
+
+
+class ParseProcStatTest(unittest.TestCase):
+    def test_normal_comm(self) -> None:
+        content = (
+            "12345 (python3) S 100 200 200 0 -1 0 0 0 0 0 500 300 0 0 20 0 1 0 0 0 4096"
+        )
+        stat = _parse_proc_stat(content)
+        self.assertEqual(stat.pgrp, 200)
+        self.assertEqual(stat.utime, 500)
+        self.assertEqual(stat.stime, 300)
+        self.assertEqual(stat.rss, 4096)
+
+    def test_comm_with_spaces_and_parens(self) -> None:
+        content = "12345 (my (weird) app) S 100 200 200 0 -1 0 0 0 0 0 500 300 0 0 20 0 1 0 0 0 4096"  # noqa: B950
+        stat = _parse_proc_stat(content)
+        self.assertEqual(stat.pgrp, 200)
+
+    def test_malformed_no_parens_raises(self) -> None:
+        with self.assertRaises(RuntimeError, msg="missing closing paren"):
+            _parse_proc_stat("no parens here")
+
+    def test_too_few_fields_raises(self) -> None:
+        with self.assertRaises(RuntimeError, msg="expected >=22 fields"):
+            _parse_proc_stat("12345 (python3) S 100 200")
+
+    def test_non_numeric_field_raises(self) -> None:
+        content = (
+            "12345 (python3) S 100 abc 200 0 -1 0 0 0 0 0 500 300 0 0 20 0 1 0 0 0 4096"  # noqa: B950
+        )
+        with self.assertRaises(RuntimeError, msg="Failed to parse"):
+            _parse_proc_stat(content)
+
+
+class ParseProcIoTest(unittest.TestCase):
+    def test_normal_io(self) -> None:
+        content = (
+            "rchar: 123456\n"
+            "wchar: 654321\n"
+            "syscr: 100\n"
+            "syscw: 200\n"
+            "read_bytes: 4096\n"
+            "write_bytes: 8192\n"
+            "cancelled_write_bytes: 0"
+        )
+        io = _parse_proc_io(content)
+        self.assertEqual(io.read_bytes, 4096)
+        self.assertEqual(io.write_bytes, 8192)
+
+    def test_empty_content(self) -> None:
+        io = _parse_proc_io("")
+        self.assertEqual(io.read_bytes, 0)
+        self.assertEqual(io.write_bytes, 0)
+
+    def test_malformed_value_raises(self) -> None:
+        content = "read_bytes: not_a_number\n"
+        with self.assertRaises(RuntimeError, msg="Failed to parse /proc/[pid]/io"):
+            _parse_proc_io(content)
+
+
+class ParseSmapsRollupTest(unittest.TestCase):
+    def test_normal_smaps_rollup(self) -> None:
+        content = (
+            "00400000-ffffffff ---p 00000000 00:00 0          [rollup]\n"
+            "Rss:              123456 kB\n"
+            "Pss:               98765 kB\n"
+            "Pss_Dirty:         40000 kB\n"
+            "Private_Clean:     50000 kB\n"
+            "Private_Dirty:     30000 kB\n"
+            "Shared_Clean:      20000 kB\n"
+            "Shared_Dirty:      10000 kB\n"
+        )
+        result = _parse_smaps_rollup(content)
+        self.assertEqual(result.pss, 98765 * 1024)
+        self.assertEqual(result.private_clean, 50000 * 1024)
+        self.assertEqual(result.private_dirty, 30000 * 1024)
+
+    def test_empty_content(self) -> None:
+        result = _parse_smaps_rollup("")
+        self.assertEqual(result.pss, 0)
+        self.assertEqual(result.private_clean, 0)
+        self.assertEqual(result.private_dirty, 0)
+
+    def test_malformed_value_raises(self) -> None:
+        content = "Pss: not_a_number kB\n"
+        with self.assertRaises(RuntimeError, msg="Failed to parse"):
+            _parse_smaps_rollup(content)
+
+
+@unittest.skipUnless(sys.platform == "linux", "Requires Linux /proc filesystem")
+class ReadPgrpStatsTest(unittest.TestCase):
+    def setUp(self) -> None:
+        _warned.discard("proc_stat")
+        _warned.discard("proc_io")
+
+    @patch(f"{_MODULE}.os.scandir")
+    @patch(f"{_MODULE}._read_file")
+    @patch(f"{_MODULE}.os.getpgrp")
+    def test_sums_processes_in_same_pgrp(
+        self,
+        mock_getpgrp: MagicMock,
+        mock_read: MagicMock,
+        mock_scandir: MagicMock,
+    ) -> None:
+        mock_getpgrp.return_value = 1000
+
+        # Two processes in pgrp 1000, one in pgrp 9999
+        entries = []
+        for name in ["101", "102", "103", "not_a_pid"]:
+            entry = MagicMock()
+            entry.name = name
+            entry.is_dir.return_value = True
+            entries.append(entry)
+        mock_scandir.return_value = entries
+
+        def read_side_effect(path: str) -> str | None:
+            if path == "/proc/101/stat":
+                return "101 (python3) S 1 1000 1000 0 -1 0 0 0 0 0 100 50 0 0 20 0 1 0 0 0 2000"  # noqa: B950
+            if path == "/proc/101/smaps_rollup":
+                return "00400000-ffffffff ---p 00000000 00:00 0          [rollup]\nRss: 8000 kB\nPss: 6000 kB\nPrivate_Clean: 3000 kB\nPrivate_Dirty: 2000 kB\n"  # noqa: B950
+            if path == "/proc/101/io":
+                return "rchar: 1000\nwchar: 2000\nsyscr: 10\nsyscw: 20\nread_bytes: 4096\nwrite_bytes: 8192\ncancelled_write_bytes: 0"  # noqa: B950
+            if path == "/proc/102/stat":
+                return "102 (worker) S 1 1000 1000 0 -1 0 0 0 0 0 200 75 0 0 20 0 1 0 0 0 3000"  # noqa: B950
+            if path == "/proc/102/smaps_rollup":
+                return "00400000-ffffffff ---p 00000000 00:00 0          [rollup]\nRss: 12000 kB\nPss: 9000 kB\nPrivate_Clean: 5000 kB\nPrivate_Dirty: 3000 kB\n"  # noqa: B950
+            if path == "/proc/102/io":
+                return "rchar: 3000\nwchar: 4000\nsyscr: 30\nsyscw: 40\nread_bytes: 1024\nwrite_bytes: 2048\ncancelled_write_bytes: 0"  # noqa: B950
+            if path == "/proc/103/stat":
+                # Different pgrp
+                return "103 (other) S 1 9999 9999 0 -1 0 0 0 0 0 999 999 0 0 20 0 1 0 0 0 9999"  # noqa: B950
+            return None
+
+        mock_read.side_effect = read_side_effect
+
+        result = _read_pgrp_stats()
+
+        # utime: 100+200=300, stime: 50+75=125, total_ticks=425
+        from spdl.pipeline._pgrp_stats import _get_sc_clk_tck
+
+        expected_cpu_usec = 425 * 1_000_000 // _get_sc_clk_tck()
+        self.assertEqual(result.cpu_usec, expected_cpu_usec)
+
+        # rss: 2000+3000=5000 pages
+        from spdl.pipeline._pgrp_stats import _get_page_size
+
+        expected_rss = 5000 * _get_page_size()
+        self.assertEqual(result.rss_bytes, expected_rss)
+
+        # pss: 6000+9000=15000 kB
+        self.assertEqual(result.pss_bytes, 15000 * 1024)
+
+        # private: (3000+2000)+(5000+3000)=13000 kB
+        self.assertEqual(result.private_bytes, 13000 * 1024)
+
+        # disk IO: 4096+1024=5120 read, 8192+2048=10240 write
+        self.assertEqual(result.disk_read_bytes, 5120)
+        self.assertEqual(result.disk_write_bytes, 10240)
+
+        self.assertEqual(result.num_procs, 2)
+
+    @patch(f"{_MODULE}.os.scandir")
+    @patch(f"{_MODULE}.os.getpgrp")
+    def test_scandir_failure_raises(
+        self,
+        mock_getpgrp: MagicMock,
+        mock_scandir: MagicMock,
+    ) -> None:
+        mock_getpgrp.return_value = 1000
+        mock_scandir.side_effect = OSError("permission denied")
+
+        with self.assertRaises(RuntimeError, msg="Failed to scan /proc"):
+            _read_pgrp_stats()
+
+    @patch(f"{_MODULE}.os.scandir")
+    @patch(f"{_MODULE}._read_file")
+    @patch(f"{_MODULE}.os.getpgrp")
+    def test_missing_io_and_smaps_file(
+        self,
+        mock_getpgrp: MagicMock,
+        mock_read: MagicMock,
+        mock_scandir: MagicMock,
+    ) -> None:
+        """Disk IO is 0 and PSS/private are None when files are unreadable."""
+        mock_getpgrp.return_value = 1000
+
+        entry = MagicMock()
+        entry.name = "101"
+        mock_scandir.return_value = [entry]
+
+        def read_side_effect(path: str) -> str | None:
+            if path == "/proc/101/stat":
+                return "101 (python3) S 1 1000 1000 0 -1 0 0 0 0 0 100 50 0 0 20 0 1 0 0 0 2000"  # noqa: B950
+            # /proc/101/io and /proc/101/smaps_rollup return None
+            return None
+
+        mock_read.side_effect = read_side_effect
+
+        result = _read_pgrp_stats()
+        self.assertEqual(result.disk_read_bytes, 0)
+        self.assertEqual(result.disk_write_bytes, 0)
+        self.assertIsNone(result.pss_bytes)
+        self.assertIsNone(result.private_bytes)
+        self.assertEqual(result.num_procs, 1)
+
+    @patch(f"{_MODULE}.os.scandir")
+    @patch(f"{_MODULE}._read_file")
+    @patch(f"{_MODULE}.os.getpgrp")
+    def test_malformed_stat_skips_with_warning(
+        self,
+        mock_getpgrp: MagicMock,
+        mock_read: MagicMock,
+        mock_scandir: MagicMock,
+    ) -> None:
+        """A process with malformed stat is skipped and warns once."""
+        mock_getpgrp.return_value = 1000
+
+        entries = []
+        for name in ["101", "102"]:
+            entry = MagicMock()
+            entry.name = name
+            entries.append(entry)
+        mock_scandir.return_value = entries
+
+        def read_side_effect(path: str) -> str | None:
+            if path == "/proc/101/stat":
+                return "malformed content"  # no parens
+            if path == "/proc/102/stat":
+                return "102 (python3) S 1 1000 1000 0 -1 0 0 0 0 0 200 75 0 0 20 0 1 0 0 0 3000"  # noqa: B950
+            return None
+
+        mock_read.side_effect = read_side_effect
+
+        with self.assertLogs(_MODULE, level="WARNING") as cm:
+            result = _read_pgrp_stats()
+
+        # Only pid 102 was counted
+        self.assertEqual(result.num_procs, 1)
+        self.assertTrue(any("missing closing paren" in m for m in cm.output))
+
+
+class ProcessGroupStatsMonitorClassTest(unittest.TestCase):
+    def test_is_background_task(self) -> None:
+        monitor = ProcessGroupStatsMonitor(callback=AsyncMock())
+        self.assertIsInstance(monitor, BackgroundTask)
+
+
+@unittest.skipUnless(sys.platform == "linux", "Requires Linux /proc filesystem")
+class ProcessGroupStatsMonitorSubprocessTest(unittest.TestCase):
+    def test_monitor_spawns_and_cancels_subprocess(self) -> None:
+        """Verify the monitor spawns a subprocess and terminates it on cancel."""
+        mock_proc = MagicMock(spec=multiprocessing.Process)
+        mock_proc.pid = 12345
+        mock_proc.is_alive.side_effect = [True, True, False]
+
+        with patch(f"{_MODULE}.multiprocessing.Process") as mock_cls:
+            mock_cls.return_value = mock_proc
+
+            async def run_monitor() -> None:
+                monitor = ProcessGroupStatsMonitor(callback=AsyncMock())
+                task = asyncio.create_task(monitor.run())
+                await asyncio.sleep(0.01)
+                task.cancel()
+                try:
+                    await task
+                except asyncio.CancelledError:
+                    pass
+
+            asyncio.run(run_monitor())
+
+        mock_proc.start.assert_called_once()
+        mock_proc.terminate.assert_called_once()
+        mock_proc.join.assert_called()
+
+    def test_monitor_warns_on_unexpected_exit(self) -> None:
+        """Verify warning is logged when the subprocess exits unexpectedly."""
+        mock_proc = MagicMock(spec=multiprocessing.Process)
+        mock_proc.pid = 12345
+        mock_proc.exitcode = 1
+        mock_proc.is_alive.return_value = False
+
+        with patch(f"{_MODULE}.multiprocessing.Process") as mock_cls:
+            mock_cls.return_value = mock_proc
+
+            async def run_monitor() -> None:
+                monitor = ProcessGroupStatsMonitor(callback=AsyncMock())
+                await monitor.run()
+
+            with self.assertLogs(_MODULE, level="WARNING") as cm:
+                asyncio.run(run_monitor())
+
+        exit_warnings = [m for m in cm.output if "exited unexpectedly" in m]
+        self.assertEqual(len(exit_warnings), 1)
+        self.assertIn("exit code 1", exit_warnings[0])
+
+
+@unittest.skipUnless(sys.platform == "linux", "Requires Linux /proc filesystem")
+class PgrpMonitorSubprocessFunctionTest(unittest.TestCase):
+    @patch(f"{_MODULE}._collect_pgrp_stats")
+    def test_subprocess_function_collects_and_calls_callback(
+        self,
+        mock_collect: MagicMock,
+    ) -> None:
+        """Test the subprocess entry point invokes the callback."""
+        usage = ProcessGroupResourceUsage(
+            pid=os.getpid(),
+            pgid=os.getpgrp(),
+            cpu_percent=50.0,
+            rss_bytes=1048576,
+            pss_bytes=800000,
+            private_bytes=600000,
+            disk_read_bytes=4096,
+            disk_write_bytes=8192,
+            num_procs=3,
+            net_rx_bytes=100,
+            net_tx_bytes=200,
+        )
+        mock_collect.return_value = (usage, 500000, 1000000)
+
+        mock_callback = AsyncMock()
+
+        call_count = 0
+        original_sleep: Callable[[float], Awaitable[None]] = asyncio.sleep
+
+        async def counting_sleep(delay: float) -> None:
+            nonlocal call_count
+            call_count += 1
+            if call_count >= 2:
+                raise KeyboardInterrupt
+            await original_sleep(0)
+
+        with (
+            patch("asyncio.sleep", counting_sleep),
+            patch(f"{_MODULE}.signal.signal"),
+        ):
+            try:
+                _pgrp_monitor_subprocess(0.01, mock_callback)
+            except KeyboardInterrupt:
+                pass
+
+        mock_collect.assert_called()
+        mock_callback.assert_called()
+        received = mock_callback.call_args[0][0]
+        self.assertIsInstance(received, ProcessGroupResourceUsage)
+        self.assertEqual(received.cpu_percent, 50.0)
+        self.assertEqual(received.rss_bytes, 1048576)
+        self.assertEqual(received.pss_bytes, 800000)
+        self.assertEqual(received.private_bytes, 600000)
+        self.assertEqual(received.disk_read_bytes, 4096)
+        self.assertEqual(received.disk_write_bytes, 8192)
+        self.assertEqual(received.num_procs, 3)
+        self.assertEqual(received.net_rx_bytes, 100)
+        self.assertEqual(received.net_tx_bytes, 200)


### PR DESCRIPTION
Summary:

Add `ProcessGroupStatsMonitor`, a `BackgroundTask` that sums CPU and RSS
across all PIDs in the same process group (PGID) via /proc/[pid]/stat.
Gives per-rank granularity when torchrun launches each rank as a separate
process group.

Also collects network RX/TX bytes from /proc/net/dev (excluding loopback)
and logs all stats via async_log (Scuba/Hive) every 60 seconds.

Reviewed By: huangruizhe

Differential Revision: D100346030
