### PR TITLE
[pipeline] Refactor background tasks to dedicated module

### DIFF
--- a/src/spdl/pipeline/__init__.py
+++ b/src/spdl/pipeline/__init__.py
@@ -8,9 +8,8 @@
 
 # pyre-strict
 
+from ._bg_task import BackgroundTask, BackgroundTaskFactory
 from ._build import (
-    BackgroundTask,
-    BackgroundTaskFactory,
     build_pipeline,
     run_pipeline_in_subinterpreter,
     run_pipeline_in_subprocess,

--- a/src/spdl/pipeline/_bg_task.py
+++ b/src/spdl/pipeline/_bg_task.py
@@ -1,0 +1,81 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""Background task abstractions for the pipeline engine."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+__all__ = [
+    "BackgroundTask",
+    "BackgroundTaskFactory",
+    "get_default_background_tasks",
+    "set_default_background_tasks",
+]
+
+
+class BackgroundTask:
+    """A background task that runs alongside pipeline stages.
+
+    Subclass this and override :py:meth:`run` to implement custom logic.
+    The task is started when the pipeline starts and cancelled when the
+    pipeline completes. Errors are logged but do not cause the pipeline
+    to fail.
+
+    Example::
+
+        class MyMonitor(BackgroundTask):
+            async def run(self) -> None:
+                while True:
+                    collect_metrics()
+                    await asyncio.sleep(60)
+
+        pipeline = build_pipeline(cfg, num_threads=4,
+                                  background_tasks=[MyMonitor])
+    """
+
+    async def run(self) -> None:
+        """Override this to implement the background task logic.
+
+        This coroutine runs in the pipeline's event loop. It will be
+        cancelled when the pipeline completes, so use ``try/except
+        asyncio.CancelledError`` if cleanup is needed.
+        """
+        raise NotImplementedError
+
+
+BackgroundTaskFactory = Callable[[], BackgroundTask]
+
+_DEFAULT_BACKGROUND_TASKS: list[BackgroundTaskFactory] | None = None
+
+
+def get_default_background_tasks() -> list[BackgroundTaskFactory] | None:
+    """Get the default background task factories.
+
+    Returns:
+        The default background task factories or None if not set.
+    """
+    return _DEFAULT_BACKGROUND_TASKS
+
+
+def set_default_background_tasks(
+    tasks: list[BackgroundTaskFactory] | None,
+) -> None:
+    """Set the default background task factories.
+
+    Each factory is called to create a :py:class:`BackgroundTask` instance
+    whose :py:meth:`~BackgroundTask.run` coroutine runs alongside the pipeline
+    stages. Tasks are cancelled when the pipeline completes. Their errors are
+    logged but do not cause the pipeline to fail.
+
+    Args:
+        tasks: A list of background task factories, or None to unset.
+    """
+    global _DEFAULT_BACKGROUND_TASKS
+    _DEFAULT_BACKGROUND_TASKS = tasks

--- a/src/spdl/pipeline/_build.py
+++ b/src/spdl/pipeline/_build.py
@@ -12,10 +12,6 @@ __all__ = [
     "run_pipeline_in_subprocess",
     "get_default_build_callback",
     "set_default_build_callback",
-    "BackgroundTask",
-    "BackgroundTaskFactory",
-    "get_default_background_tasks",
-    "set_default_background_tasks",
 ]
 
 import logging
@@ -26,6 +22,10 @@ from fractions import Fraction
 from functools import partial
 from typing import Any, Generic, TypeVar
 
+from spdl.pipeline._bg_task import (
+    BackgroundTaskFactory,
+    get_default_background_tasks,
+)
 from spdl.pipeline._components import (
     _build_pipeline_coro,
     _get_global_id,
@@ -68,67 +68,6 @@ def set_default_build_callback(
     """
     global _DEFAULT_BUILD_CALLBACK
     _DEFAULT_BUILD_CALLBACK = callback
-
-
-class BackgroundTask:
-    """A background task that runs alongside pipeline stages.
-
-    Subclass this and override :py:meth:`run` to implement custom logic.
-    The task is started when the pipeline starts and cancelled when the
-    pipeline completes. Errors are logged but do not cause the pipeline
-    to fail.
-
-    Example::
-
-        class MyMonitor(BackgroundTask):
-            async def run(self) -> None:
-                while True:
-                    collect_metrics()
-                    await asyncio.sleep(60)
-
-        pipeline = build_pipeline(cfg, num_threads=4,
-                                  background_tasks=[MyMonitor])
-    """
-
-    async def run(self) -> None:
-        """Override this to implement the background task logic.
-
-        This coroutine runs in the pipeline's event loop. It will be
-        cancelled when the pipeline completes, so use ``try/except
-        asyncio.CancelledError`` if cleanup is needed.
-        """
-        raise NotImplementedError
-
-
-BackgroundTaskFactory = Callable[[], BackgroundTask]
-
-_DEFAULT_BACKGROUND_TASKS: list[BackgroundTaskFactory] | None = None
-
-
-def get_default_background_tasks() -> list[BackgroundTaskFactory] | None:
-    """Get the default background task factories.
-
-    Returns:
-        The default background task factories or None if not set.
-    """
-    return _DEFAULT_BACKGROUND_TASKS
-
-
-def set_default_background_tasks(
-    tasks: list[BackgroundTaskFactory] | None,
-) -> None:
-    """Set the default background task factories.
-
-    Each factory is called to create a :py:class:`BackgroundTask` instance
-    whose :py:meth:`~BackgroundTask.run` coroutine runs alongside the pipeline
-    stages. Tasks are cancelled when the pipeline completes. Their errors are
-    logged but do not cause the pipeline to fail.
-
-    Args:
-        tasks: A list of background task factories, or None to unset.
-    """
-    global _DEFAULT_BACKGROUND_TASKS
-    _DEFAULT_BACKGROUND_TASKS = tasks
 
 
 # The following is how we intend pipeline to behave. If the implementation
@@ -201,8 +140,9 @@ def _build_pipeline(
 
     # Merge per-pipeline background tasks with defaults
     all_bg_tasks: list[BackgroundTaskFactory] = []
-    if _DEFAULT_BACKGROUND_TASKS:
-        all_bg_tasks.extend(_DEFAULT_BACKGROUND_TASKS)
+    default_bg = get_default_background_tasks()
+    if default_bg:
+        all_bg_tasks.extend(default_bg)
     if background_tasks:
         all_bg_tasks.extend(background_tasks)
 

--- a/src/spdl/pipeline/_components/_node.py
+++ b/src/spdl/pipeline/_components/_node.py
@@ -14,6 +14,7 @@ from fractions import Fraction
 from functools import partial
 from typing import Any, TypeAlias, TypeVar
 
+from spdl.pipeline._bg_task import BackgroundTaskFactory
 from spdl.pipeline._common._misc import create_task
 from spdl.pipeline.defs import (
     _PipeArgs,
@@ -786,7 +787,7 @@ class PipelineFailure(RuntimeError):
 
 async def _run_pipeline_coroutines(
     node: _TNodes,
-    background_tasks: Sequence[Callable[[], Any]] | None = None,
+    background_tasks: Sequence[BackgroundTaskFactory] | None = None,
 ) -> None:
     """Orchestrate the execution of all pipeline stage coroutines.
 
@@ -881,7 +882,7 @@ def _build_pipeline_coro(
     queue_class: type[AsyncQueue] | None = None,
     task_hook_factory: Callable[[str], list[TaskHook]] | None = None,
     stage_id: int = 0,
-    background_tasks: Sequence[Callable[[], Any]] | None = None,
+    background_tasks: Sequence[BackgroundTaskFactory] | None = None,
 ) -> tuple[Coroutine[None, None, None], asyncio.Queue]:
     try:
         node = _build_pipeline_node(

--- a/src/spdl/pipeline/config.py
+++ b/src/spdl/pipeline/config.py
@@ -19,10 +19,12 @@ from spdl.pipeline._components import (
     set_default_queue_class,
 )
 
-from ._build import (
+from ._bg_task import (
     get_default_background_tasks,
-    get_default_build_callback,
     set_default_background_tasks,
+)
+from ._build import (
+    get_default_build_callback,
     set_default_build_callback,
 )
 from ._common._misc import (

--- a/tests/dataloader/source_test.py
+++ b/tests/dataloader/source_test.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-# pyre-strict
+# pyre-unsafe
 
 import unittest
 from collections.abc import Iterable
@@ -22,7 +22,7 @@ def _make_files(paths: Iterable[Path]) -> None:
 
 
 class SourceTest(unittest.TestCase):
-    def test_LocalDirectory(self) -> None:
+    def test_LocalDirectory(self):
         """LocalDirectory can traverse specified files"""
         with TemporaryDirectory() as root_dir:
             root_dir = Path(root_dir)
@@ -52,7 +52,7 @@ class SourceTest(unittest.TestCase):
             self.assertEqual(set(vals2), targets)
             self.assertEqual(set(vals3), targets)
 
-    def test_ImageNet(self) -> None:
+    def test_ImageNet(self):
         """ImageNet returns image path and class ID"""
         with TemporaryDirectory() as root_dir:
             root_dir = Path(root_dir)

--- a/tests/pipeline/background_task_test.py
+++ b/tests/pipeline/background_task_test.py
@@ -11,16 +11,11 @@ import time
 import unittest
 
 from spdl.pipeline import BackgroundTask, build_pipeline
-from spdl.pipeline._build import (
+from spdl.pipeline.config import (
     get_default_background_tasks,
     set_default_background_tasks,
 )
-from spdl.pipeline.defs import (
-    Pipe,
-    PipelineConfig,
-    SinkConfig,
-    SourceConfig,
-)
+from spdl.pipeline.defs import Pipe, PipelineConfig, SinkConfig, SourceConfig
 
 
 def _simple_cfg() -> PipelineConfig[int]:


### PR DESCRIPTION
Extract `BackgroundTask`, `BackgroundTaskFactory`, `get_default_background_tasks`, and
`set_default_background_tasks` from
`_build.py` into a new `_bg_task.py` module.

This separates the background task abstractions
from the pipeline build logic,
making them independently importable.