### PR TITLE
Replace DEF_DPtr macro with DPtr class template

### DIFF
--- a/src/libspdl/core/detail/ffmpeg/ctx_utils.cpp
+++ b/src/libspdl/core/detail/ffmpeg/ctx_utils.cpp
@@ -25,8 +25,6 @@ namespace {
 // AVDictionary
 //////////////////////////////////////////////////////////////////////////////
 
-DEF_DPtr(AVDictionary, av_dict_free); // This defines AVDictionaryDPtr class
-
 AVDictionaryDPtr get_option_dict(const std::optional<OptionDict>& options) {
   AVDictionaryDPtr opt;
   if (options) {

--- a/src/libspdl/core/detail/ffmpeg/filter_graph.cpp
+++ b/src/libspdl/core/detail/ffmpeg/filter_graph.cpp
@@ -46,8 +46,6 @@ std::vector<std::string> get_filters() {
 // FilterGraphImpl
 ////////////////////////////////////////////////////////////////////////////////
 namespace {
-DEF_DPtr(AVFilterInOut, avfilter_inout_free);
-
 AVFilterGraphPtr make_graph(const std::string& filter_desc) {
   AVFilterGraphPtr graph{CHECK_AVALLOCATE(avfilter_graph_alloc())};
   graph->nb_threads = 1;

--- a/src/libspdl/core/detail/ffmpeg/wrappers.h
+++ b/src/libspdl/core/detail/ffmpeg/wrappers.h
@@ -123,36 +123,37 @@ const char* get_media_format_name(int media_format) {
 
 OptionDict parse_dict(const AVDictionary* metadata);
 
-} // namespace spdl::core::detail
-
 // RAII wrapper for objects that require clean up, but need to expose double
 // pointer. As they are re-allocated by FFmpeg functions.
 // Examples are AVDictionary and AVFilterInOut.
-// They are typically only used in cpp files, so we use macro and let each
-// implementation file defines them in anonymous scope.
-#define DEF_DPtr(Type, delete_func)                         \
-  class Type##DPtr {                                        \
-    Type* p = nullptr;                                      \
-                                                            \
-   public:                                                  \
-    explicit Type##DPtr(Type* p_ = nullptr) : p(p_) {}      \
-    Type##DPtr(const Type##DPtr&) = delete;                 \
-    Type##DPtr& operator=(const Type##DPtr&) = delete;      \
-    Type##DPtr(Type##DPtr&&) noexcept = default;            \
-    Type##DPtr& operator=(Type##DPtr&&) noexcept = default; \
-    ~Type##DPtr() {                                         \
-      delete_func(&p);                                      \
-    }                                                       \
-    operator Type*() const {                                \
-      return p;                                             \
-    }                                                       \
-    operator Type**() {                                     \
-      return &p;                                            \
-    }                                                       \
-    Type* operator->() const {                              \
-      return p;                                             \
-    }                                                       \
+template <typename T, auto DeleteFunc>
+class DPtr {
+  T* p = nullptr;
+
+ public:
+  explicit DPtr(T* p_ = nullptr) : p(p_) {}
+  DPtr(const DPtr&) = delete;
+  DPtr& operator=(const DPtr&) = delete;
+  DPtr(DPtr&&) noexcept = default;
+  DPtr& operator=(DPtr&&) noexcept = default;
+  ~DPtr() {
+    DeleteFunc(&p);
   }
+  operator T*() const {
+    return p;
+  }
+  operator T**() {
+    return &p;
+  }
+  T* operator->() const {
+    return p;
+  }
+};
+
+using AVDictionaryDPtr = DPtr<AVDictionary, av_dict_free>;
+using AVFilterInOutDPtr = DPtr<AVFilterInOut, avfilter_inout_free>;
+
+} // namespace spdl::core::detail
 
 #ifdef SPDL_DEBUG_REFCOUNT
 namespace spdl::core::detail {


### PR DESCRIPTION
Replace the DEF_DPtr preprocessor macro in wrappers.h with a C++17 class template `DPtr<T, auto DeleteFunc>` that uses an auto non-type template parameter to accept the deleter function.

Previously, each .cpp file had to invoke the macro in an anonymous namespace to define wrapper types like AVDictionaryDPtr and AVFilterInOutDPtr. With the template approach, these are now type aliases defined once in the header inside `namespace spdl::core::detail`, eliminating the need for per-file macro invocations.

The behavior is identical: DPtr is a move-only RAII wrapper that calls the specified deleter via double pointer on destruction, and provides implicit conversions to `T*` and `T**` for use with FFmpeg APIs.
