### PR TITLE
[pipeline] Support specifying MP context in ProcessGroupStatsMonitor

### DIFF
--- a/src/spdl/pipeline/_pgrp_stats.py
+++ b/src/spdl/pipeline/_pgrp_stats.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import multiprocessing
+import multiprocessing.context
 import os
 import signal
 from collections.abc import Awaitable, Callable
@@ -560,16 +561,21 @@ class ProcessGroupStatsMonitor(BackgroundTask):
         callback: An async callable that receives a
             :class:`ProcessGroupResourceUsage` snapshot each interval.
         interval: Collection interval in seconds (default 60).
+        mp_context: A :mod:`multiprocessing` context (e.g. from
+            ``multiprocessing.get_context("forkserver")``) used to spawn the
+            monitor subprocess.  ``None`` (default) uses the default context.
     """
 
     def __init__(
         self,
         callback: Callable[[ProcessGroupResourceUsage], Awaitable[None]],
         interval: float = _PGRP_INTERVAL_SEC,
+        mp_context: multiprocessing.context.BaseContext | None = None,
     ) -> None:
         super().__init__()
         self._callback = callback
         self._interval = interval
+        self._mp_context = mp_context
 
     async def run(self) -> None:
         """Spawn a daemon subprocess to collect process-group stats and wait for it.
@@ -585,7 +591,8 @@ class ProcessGroupStatsMonitor(BackgroundTask):
         is terminated (then killed if it does not exit within 5 seconds)
         and ``CancelledError`` is re-raised.
         """
-        proc = multiprocessing.Process(
+        ctx = self._mp_context or multiprocessing.get_context()
+        proc = ctx.Process(
             target=_pgrp_monitor_subprocess,
             args=(self._interval, self._callback),
             daemon=True,

--- a/tests/pipeline/pgrp_stats_test.py
+++ b/tests/pipeline/pgrp_stats_test.py
@@ -383,20 +383,22 @@ class ProcessGroupStatsMonitorSubprocessTest(unittest.TestCase):
         mock_proc.pid = 12345
         mock_proc.is_alive.side_effect = [True, True, False]
 
-        with patch(f"{_MODULE}.multiprocessing.Process") as mock_cls:
-            mock_cls.return_value = mock_proc
+        mock_ctx: MagicMock = MagicMock()
+        mock_ctx.Process.return_value = mock_proc
 
-            async def run_monitor() -> None:
-                monitor = ProcessGroupStatsMonitor(callback=AsyncMock())
-                task = asyncio.create_task(monitor.run())
-                await asyncio.sleep(0.01)
-                task.cancel()
-                try:
-                    await task
-                except asyncio.CancelledError:
-                    pass
+        async def run_monitor() -> None:
+            monitor = ProcessGroupStatsMonitor(
+                callback=AsyncMock(), mp_context=mock_ctx
+            )
+            task = asyncio.create_task(monitor.run())
+            await asyncio.sleep(0.01)
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
 
-            asyncio.run(run_monitor())
+        asyncio.run(run_monitor())
 
         mock_proc.start.assert_called_once()
         mock_proc.terminate.assert_called_once()
@@ -409,15 +411,17 @@ class ProcessGroupStatsMonitorSubprocessTest(unittest.TestCase):
         mock_proc.exitcode = 1
         mock_proc.is_alive.return_value = False
 
-        with patch(f"{_MODULE}.multiprocessing.Process") as mock_cls:
-            mock_cls.return_value = mock_proc
+        mock_ctx: MagicMock = MagicMock()
+        mock_ctx.Process.return_value = mock_proc
 
-            async def run_monitor() -> None:
-                monitor = ProcessGroupStatsMonitor(callback=AsyncMock())
-                await monitor.run()
+        async def run_monitor() -> None:
+            monitor = ProcessGroupStatsMonitor(
+                callback=AsyncMock(), mp_context=mock_ctx
+            )
+            await monitor.run()
 
-            with self.assertLogs(_MODULE, level="WARNING") as cm:
-                asyncio.run(run_monitor())
+        with self.assertLogs(_MODULE, level="WARNING") as cm:
+            asyncio.run(run_monitor())
 
         exit_warnings = [m for m in cm.output if "exited unexpectedly" in m]
         self.assertEqual(len(exit_warnings), 1)


### PR DESCRIPTION
Add an optional mp_context parameter to `ProcessGroupStatsMonitor.__init__` so callers can specify the multiprocessing start method. When `None` (the default), the system default context is used.