### PR TITLE
Document re-iterability of iterate_in_subprocess and related functions

### DIFF
--- a/src/spdl/pipeline/_build.py
+++ b/src/spdl/pipeline/_build.py
@@ -323,6 +323,21 @@ def run_pipeline_in_subprocess(
 ) -> Iterable[T]:
     """Run the given Pipeline in a subprocess, and iterate on the result.
 
+    The returned :py:class:`Iterable` supports multiple iterations. The
+    subprocess is created once and reused — each call to ``iter()`` (or
+    ``for ... in``) builds a fresh :py:class:`Pipeline` inside the same
+    subprocess without spawning a new process. This avoids the overhead
+    of subprocess creation (fork/spawn, initializer execution, and
+    pickling) on every iteration.
+
+    For multi-epoch training, create the iterable once before the epoch
+    loop and iterate it each epoch::
+
+        src = run_pipeline_in_subprocess(config, num_threads=4)
+        for epoch in range(num_epochs):
+            for batch in src:
+                train(batch)
+
     Args:
         config_or_builder: The definition of :py:class:`Pipeline`. Can be either a
             :py:class:`PipelineConfig` or :py:class:`PipelineBuilder`.
@@ -393,6 +408,21 @@ def run_pipeline_in_subinterpreter(
     **kwargs: Any,
 ) -> Iterable[T]:
     """**[Experimental]** Run the given Pipeline in a subinterpreter, and iterate on the result.
+
+    The returned :py:class:`Iterable` supports multiple iterations. The
+    subinterpreter is created once and reused — each call to ``iter()``
+    (or ``for ... in``) builds a fresh :py:class:`Pipeline` inside the
+    same subinterpreter without creating a new one. This avoids the
+    overhead of repeated subinterpreter creation and initializer
+    execution on every iteration.
+
+    For multi-epoch training, create the iterable once before the epoch
+    loop and iterate it each epoch::
+
+        src = run_pipeline_in_subinterpreter(config, num_threads=4)
+        for epoch in range(num_epochs):
+            for batch in src:
+                train(batch)
 
     Args:
         config: The definition of :py:class:`Pipeline`.

--- a/src/spdl/pipeline/_iter_utils/_subinterpreter.py
+++ b/src/spdl/pipeline/_iter_utils/_subinterpreter.py
@@ -73,7 +73,13 @@ else:
 
     class _SubinterpreterIterable(Iterable[T]):
         """An Iterable interface that manipulates the iterable in a subinterpreter
-        and fetches the results."""
+        and fetches the results.
+
+        This object supports multiple iterations. Each call to ``__iter__()``
+        instructs the worker subinterpreter to create a fresh iterator from the
+        underlying iterable (via ``iter(iterable)``), without creating a new
+        subinterpreter. The subinterpreter is reused across iterations.
+        """
 
         def __init__(self, interface: _iic[T]) -> None:
             self._if: _iic[T] | None = interface
@@ -145,6 +151,28 @@ def iterate_in_subinterpreter(
     Python 3.14's :py:mod:`concurrent.interpreters` module instead of multiprocessing.
     Subinterpreters provide isolation while sharing the same process, which can be
     more lightweight than spawning a separate process.
+
+    The subinterpreter is created once and reused across iterations.
+    The returned :py:class:`Iterable` supports multiple iterations —
+    each call to ``iter()`` (or ``for ... in``) instructs the worker to
+    create a fresh iterator from the underlying iterable without creating
+    a new subinterpreter. Reusing the same worker avoids the overhead of
+    repeated subinterpreter creation and initializer execution.
+
+    .. note::
+
+       ``fn()`` is called once in the subinterpreter to create the iterable.
+       Each subsequent ``iter()`` call creates a fresh iterator by calling
+       ``iter(iterable)`` on the same object. If ``fn()`` returns a proper
+       ``Iterable`` (a class with ``__iter__`` that creates a new iterator
+       each time), re-iteration works as expected.
+
+       However, if ``fn()`` returns a **generator** (or any single-use
+       iterator), re-iteration will silently yield no items. This is
+       because a generator is its own iterator — ``iter(generator)``
+       returns ``self`` — so once exhausted, calling ``iter()`` again
+       returns the same exhausted object. The first iteration will work
+       correctly, but all subsequent iterations will appear empty.
 
     Args:
         fn: Function that returns an iterator. Use :py:func:`functools.partial` to

--- a/src/spdl/pipeline/_iter_utils/_subprocess.py
+++ b/src/spdl/pipeline/_iter_utils/_subprocess.py
@@ -71,7 +71,13 @@ class _ipc(Generic[T]):
 
 class _SubprocessIterable(Iterable[T]):
     """An Iterable interface that manipulates the iterable in worker process
-    and fetch the results."""
+    and fetch the results.
+
+    This object supports multiple iterations. Each call to ``__iter__()``
+    instructs the worker subprocess to create a fresh iterator from the
+    underlying iterable (via ``iter(iterable)``), without spawning a new
+    process. The subprocess is reused across iterations.
+    """
 
     def __init__(self, interface: _ipc[T]) -> None:
         self._interface: _ipc[T] | None = interface
@@ -107,6 +113,29 @@ def iterate_in_subprocess(
     daemon: bool = False,
 ) -> Iterable[T]:
     """**[Experimental]** Run the given ``iterable`` in a subprocess.
+
+    The subprocess is created once and reused across iterations.
+    The returned :py:class:`Iterable` supports multiple iterations —
+    each call to ``iter()`` (or ``for ... in``) instructs the worker to
+    create a fresh iterator from the underlying iterable without spawning
+    a new process. Because process creation involves overhead (fork/spawn,
+    initializer execution, and pickling), reusing the same worker is more
+    efficient than calling this function repeatedly.
+
+    .. note::
+
+       ``fn()`` is called once in the subprocess to create the iterable.
+       Each subsequent ``iter()`` call creates a fresh iterator by calling
+       ``iter(iterable)`` on the same object. If ``fn()`` returns a proper
+       ``Iterable`` (a class with ``__iter__`` that creates a new iterator
+       each time), re-iteration works as expected.
+
+       However, if ``fn()`` returns a **generator** (or any single-use
+       iterator), re-iteration will silently yield no items. This is
+       because a generator is its own iterator — ``iter(generator)``
+       returns ``self`` — so once exhausted, calling ``iter()`` again
+       returns the same exhausted object. The first iteration will work
+       correctly, but all subsequent iterations will appear empty.
 
     Args:
         fn: Function that returns an iterator. Use :py:func:`functools.partial` to


### PR DESCRIPTION
Update docstrings for `iterate_in_subprocess`, `iterate_in_subinterpreter`, `run_pipeline_in_subprocess`, and `run_pipeline_in_subinterpreter` to document that the returned `Iterable` supports multiple iterations without spawning a new worker process each time.

This was motivated by https://github.com/facebookresearch/spdl/pull/1358, where Claude Code used `run_pipeline_in_subprocess` but created a new worker subprocess for each training epoch. The subprocess is created once and reused across iterations, so creating it inside the epoch loop wastes process creation overhead (fork/spawn, initializer execution, pickling) on every epoch. The correct pattern is to create the iterable once before the epoch loop and re-iterate it.

The docstrings also call out a subtle pitfall: if `fn()` returns a generator (or any single-use iterator), the first iteration works correctly but subsequent iterations silently yield nothing. This is because a generator is its own iterator — `iter(generator)` returns `self` — so once exhausted, `iter()` returns the same exhausted object. `fn()` must return a proper `Iterable` whose `__iter__` creates a fresh iterator each time for re-iteration to work.