### PR TITLE
[sampler] Clarify DistributedSampler auto-reshuffle behavior

### DIFF
--- a/src/spdl/source/_sampler.py
+++ b/src/spdl/source/_sampler.py
@@ -60,6 +60,11 @@ class DistributedDeterministicSampler:
     subset of the data indices. When distributed training is not initialized, it returns
     all indices.
 
+    The iteration order is deterministic and always the same: indices are assigned
+    in a round-robin fashion (``range(rank, N, world_size)``). Every iteration
+    produces the identical sequence. If you need a different order each epoch,
+    use :py:class:`DistributedRandomSampler` instead.
+
     Args:
         n: The size of the dataset.
 
@@ -187,32 +192,6 @@ class DistributedRandomSampler:
     subset of the data indices. When distributed training is not initialized, it returns
     all indices.
 
-    This sampler can apply two randomness; shuffling and wieghted sampling.
-
-    .. admonition:: Example
-       :class: note
-
-       >>> sampler = DistributedRandomSampler(5, rank=0, world_size=1)
-       >>> list(sampler)
-       [4, 2, 0, 1, 3]
-       >>> # If not shuffling, the second iteratoin generates the same sequence
-       >>> list(sampler)
-       [4, 2, 0, 1, 3]
-       >>> sampler.shuffle(seed=1)
-       >>> list(sampler)
-       [3, 2, 4, 1, 5]
-
-       You can use :py:func:`~spdl.source.utils.embed_shuffle` to shuffle automatically
-       at each iteration.
-
-       >>> sampler = embed_shuffle(DistributedRandomSampler(5, rank=0, world_size=1))
-       >>> list(sampler)
-       [4, 2, 0, 1, 3]
-       >>> list(sampler)
-       [3, 2, 4, 1, 5]
-       >>> list(sampler)
-       [2, 1, 4, 3, 5]
-
     .. admonition:: Example - Distributed sampling
        :class: note
 
@@ -228,6 +207,66 @@ class DistributedRandomSampler:
        >>> sampler = DistributedRandomSampler(N, rank=2, world_size=3)
        >>> list(sampler)
        [5, 8, 0]
+
+    Without calling :py:meth:`shuffle`, the sampler produces the **same** sequence
+    on every iteration. To get a different order each epoch, call
+    ``sampler.shuffle(seed=epoch)`` before iterating:
+
+    .. admonition:: Example
+       :class: note
+
+       >>> sampler = DistributedRandomSampler(5, rank=0, world_size=1)
+       >>> list(sampler)
+       [4, 2, 0, 1, 3]
+       >>> # If not shuffling, the second iteratoin generates the same sequence
+       >>> list(sampler)
+       [4, 2, 0, 1, 3]
+       >>> sampler.shuffle(seed=1)
+       >>> list(sampler)
+       [3, 2, 4, 1, 5]
+
+    You can use :py:func:`~spdl.source.utils.embed_shuffle` to shuffle automatically
+    at each iteration.
+
+    .. admonition:: Example - Auto-shuffle
+       :class: note
+
+       >>> sampler = embed_shuffle(DistributedRandomSampler(5, rank=0, world_size=1))
+       >>> list(sampler)
+       [4, 2, 0, 1, 3]
+       >>> list(sampler)
+       [3, 2, 4, 1, 5]
+       >>> list(sampler)
+       [2, 1, 4, 3, 5]
+
+    This is especially useful when the sampler is iterated in a subprocess via
+    :py:func:`~spdl.pipeline.iterate_in_subprocess`, where calling
+    :py:meth:`shuffle` manually from the main process has no effect on the subprocess
+    copy.
+
+    .. admonition:: Example - Running in a subprocess
+       :class: note
+
+       When iterating the sampler in a subprocess, wrap it with
+       :py:func:`~spdl.source.utils.embed_shuffle` so that each epoch is automatically
+       reshuffled inside the subprocess:
+
+       .. code-block:: python
+
+          from functools import partial
+          from spdl.pipeline import iterate_in_subprocess
+          from spdl.source import DistributedRandomSampler
+          from spdl.source.utils import embed_shuffle
+
+          sampler = DistributedRandomSampler(N, rank=rank, world_size=world_size)
+          src = iterate_in_subprocess(embed_shuffle(sampler))
+
+          # Each epoch, ranks generate different disjoint set of indices
+          for epoch in range(num_epochs):
+              for idx in src:
+                  ...
+
+    This sampler supports wieghted sampling.
 
     .. admonition:: Example - Weighted sampling
        :class: note
@@ -258,16 +297,15 @@ class DistributedRandomSampler:
         world_size: The number of ranks in the distributed communication config.
             You can fetch the values with :py:func:`torch.distributed.get_world_size`.
 
-        num_draws: The number of samples to draw at each iteration.
-            If peforming weighted sampling, (``deterministic=False`` and
-            ``weights`` is provided)  then it can be greater than the
-            size of dataset. Otherwise, it must be smaller than or equal
-            to the size of dataset.
+        num_draws: *Oprional* The number of samples to draw at each iteration.
+            When performing weighted sampling (``weights`` is provided),
+            this can be greater than the size of the dataset. Otherwise,
+            it must be smaller than or equal to the size of the dataset.
 
         weights: *Optional* The sampling weight of each sample in the dataset.
-            When provided, the length of the sequence must match the size of the dataset.
-            (``size``).
-            This option is ignored if ``deterministic=True``.
+            When provided, the length of the sequence must match the size of
+            the dataset. (``size``).
+            Indices are drawn with replacement when weights are provided.
 
         seed: The seed value for generating the sequence.
     """
@@ -312,5 +350,11 @@ class DistributedRandomSampler:
         yield from indices[self._rank :: self._world_size]
 
     def shuffle(self, seed: int) -> None:
-        """Set the random seed for future iterations."""
+        """Set the random seed for future iterations.
+
+        The resulting sequence depends only on the given ``seed`` value and is not
+        affected by any prior iterations or previous calls to :py:meth:`shuffle`.
+        Calling ``shuffle(seed=K)`` always produces the same sequence for a given
+        sampler configuration, regardless of history.
+        """
         self._seed = seed

--- a/tests/dataloader/sampler_test.py
+++ b/tests/dataloader/sampler_test.py
@@ -66,6 +66,18 @@ class TestDistributedSamplerDeterministic(unittest.TestCase):
             self.assertEqual(set(c.keys()), set(range(num_iters)))
             self.assertTrue(all(v == 1 for v in c.values()))
 
+    def test_deterministic_iter_stable_across_epochs(self) -> None:
+        """Deterministic sampler produces the same sequence on every iteration."""
+        N = 30
+        world_size = 4
+        for rank in range(world_size):
+            sampler = DistributedDeterministicSampler(
+                N, rank=rank, world_size=world_size
+            )
+            first_epoch = list(sampler)
+            for _ in range(5):
+                self.assertEqual(list(sampler), first_epoch)
+
 
 class TestDistributedSamplerRandom(unittest.TestCase):
     def test_shuffle(self) -> None:
@@ -74,7 +86,7 @@ class TestDistributedSamplerRandom(unittest.TestCase):
         rank = 3
         world_size = 8
 
-        previous = []
+        previous: list[int] = []
         for epoch in range(100):
             sampler = DistributedRandomSampler(N, rank=rank, world_size=world_size)
             sampler.shuffle(seed=epoch)
@@ -83,6 +95,61 @@ class TestDistributedSamplerRandom(unittest.TestCase):
             print(f"{indices=}")
             self.assertNotEqual(indices, previous)
             previous = indices
+
+    def test_shuffle_epoch_loop(self) -> None:
+        """Calling shuffle(seed=epoch) on a single sampler produces different sequences each epoch."""
+        N = 640
+        world_size = 8
+
+        for rank in range(world_size):
+            sampler = DistributedRandomSampler(N, rank=rank, world_size=world_size)
+            previous: list[int] = []
+            for epoch in range(10):
+                sampler.shuffle(seed=epoch)
+                indices = list(sampler)
+                self.assertEqual(len(indices), N // world_size)
+                self.assertNotEqual(indices, previous)
+                previous = indices
+
+    def test_shuffle_is_stateless(self) -> None:
+        """shuffle(seed) output depends only on the seed, not on prior iteration history."""
+        N = 640
+        world_size = 8
+
+        for rank in range(world_size):
+            sampler = DistributedRandomSampler(N, rank=rank, world_size=world_size)
+            for i in range(10):
+                sampler.shuffle(seed=i)
+                list(sampler)
+            sampler.shuffle(seed=5)
+            after_many = list(sampler)
+
+            fresh = DistributedRandomSampler(N, rank=rank, world_size=world_size)
+            fresh.shuffle(seed=5)
+            from_fresh = list(fresh)
+
+            self.assertEqual(after_many, from_fresh)
+
+    def test_shuffle_epoch_loop_mutual_exclusive(self) -> None:
+        """All ranks together cover the full dataset at each epoch when using shuffle(seed=epoch)."""
+        N = 640
+        world_size = 8
+
+        samplers = [
+            DistributedRandomSampler(N, rank=rank, world_size=world_size)
+            for rank in range(world_size)
+        ]
+
+        for epoch in range(10):
+            c = Counter()
+            for sampler in samplers:
+                sampler.shuffle(seed=epoch)
+                c.update(sampler)
+
+            self.assertEqual(c.total(), N)
+            self.assertEqual(len(c.keys()), N)
+            self.assertEqual(set(c.keys()), set(range(N)))
+            self.assertTrue(all(v == 1 for v in c.values()))
 
     @parameterized.expand(
         [


### PR DESCRIPTION
Update `DistributedDeterministicSampler` and `DistributedRandomSampler` docstrings to explicitly document their iteration behavior across epochs.

The random sampler requires explicit `shuffle(seed=epoch)` calls to produce different sequences each epoch, while the deterministic sampler always yields the same order.

Add tests confirming that `shuffle(seed)` is stateless — the output depends only on the seed value, not iteration history — preventing confusion about when `embed_shuffle` is needed.