### PR TITLE
[example] Run pipeline in subprocess

### DIFF
--- a/examples/llm_finetune/llm_finetuning.py
+++ b/examples/llm_finetune/llm_finetuning.py
@@ -57,8 +57,7 @@ from __future__ import annotations
 
 __all__ = [
     "build_model",
-    "build_pipeline",
-    "iterate_pipeline",
+    "build_spdl_dataloader",
     "load_data",
     "main",
     "train",
@@ -69,139 +68,35 @@ __all__ = [
 import argparse
 import logging
 import os
-import threading
 import time
-from collections.abc import Callable, Iterator
+from collections.abc import Callable
 from datetime import timedelta
 from pathlib import Path
-from typing import TYPE_CHECKING
 
 import torch
 import torch.distributed as dist
-from spdl.pipeline import PipelineBuilder
-from spdl.source import DistributedRandomSampler
 from torch.nn.parallel import DistributedDataParallel as DDP
 
-if TYPE_CHECKING:
-    from transformers import PreTrainedTokenizerBase
-
 try:
+    from examples.llm_finetune.utils.pipeline import (  # pyre-ignore[21]
+        build_spdl_dataloader,
+    )
     from examples.llm_finetune.utils.utils import (  # pyre-ignore[21]
-        format_prompt,
         load_data,
         report_progress,
         resolve_model_path,
     )
 except ImportError:
+    from spdl.examples.llm_finetune.utils.pipeline import (
+        build_spdl_dataloader,
+    )
     from spdl.examples.llm_finetune.utils.utils import (
-        format_prompt,
         load_data,
         report_progress,
         resolve_model_path,
     )
 
 _LG: logging.Logger = logging.getLogger(__name__)
-
-
-# ---------------------------------------------------------------------------
-# SPDL data pipeline
-# ---------------------------------------------------------------------------
-
-
-def build_pipeline(
-    samples: list[dict[str, str]],
-    tokenizer: PreTrainedTokenizerBase,
-    max_seq_len: int,
-    batch_size: int,
-    rank: int,
-    world_size: int,
-    num_threads: int,
-    seed: int,
-) -> PipelineBuilder:
-    """Build an SPDL pipeline for concurrent tokenization.
-
-    Pipeline stages:
-      1. Source: DistributedRandomSampler yields sample indices
-      2. Pipe: Look up sample by index
-      3. Pipe (concurrent): Format prompt and tokenize
-      4. Aggregate: Group into batches
-      5. Pipe: Collate into tensors
-      6. Sink: Buffer for the training loop
-    """
-
-    sampler = DistributedRandomSampler(
-        len(samples),
-        rank=rank,
-        world_size=world_size,
-        seed=seed,
-    )
-
-    # The HuggingFace fast tokenizer's Rust backend is not thread-safe.
-    # Use thread-local copies so each SPDL worker thread has its own instance.
-    class _TokenizerTLS(threading.local):
-        tokenizer: PreTrainedTokenizerBase | None = None
-
-    _tls: _TokenizerTLS = _TokenizerTLS()
-
-    def _get_tokenizer() -> PreTrainedTokenizerBase:
-        if _tls.tokenizer is None:
-            import copy
-
-            _tls.tokenizer = copy.deepcopy(tokenizer)
-        return _tls.tokenizer
-
-    def lookup(idx: int) -> dict[str, str]:
-        return samples[idx]
-
-    def tokenize(sample: dict[str, str]) -> dict[str, torch.Tensor]:
-        tok = _get_tokenizer()
-        text = format_prompt(sample)
-        enc = tok(
-            text,
-            max_length=max_seq_len,
-            truncation=True,
-            padding="max_length",
-            return_tensors="pt",
-        )
-        input_ids = enc["input_ids"].squeeze(0)
-        attention_mask = enc["attention_mask"].squeeze(0)
-        # For causal LM, labels = input_ids; mask padding with -100
-        labels = input_ids.clone()
-        labels[attention_mask == 0] = -100
-        return {
-            "input_ids": input_ids,
-            "attention_mask": attention_mask,
-            "labels": labels,
-        }
-
-    def collate(items: list[dict[str, torch.Tensor]]) -> dict[str, torch.Tensor]:
-        return {
-            "input_ids": torch.stack([it["input_ids"] for it in items]),
-            "attention_mask": torch.stack([it["attention_mask"] for it in items]),
-            "labels": torch.stack([it["labels"] for it in items]),
-        }
-
-    return (
-        PipelineBuilder()
-        .add_source(sampler)
-        .pipe(lookup)
-        .pipe(tokenize, concurrency=num_threads)
-        .aggregate(batch_size)
-        .pipe(collate)
-        .add_sink(buffer_size=3)
-    )
-
-
-def iterate_pipeline(
-    pipeline_builder: PipelineBuilder,
-    num_threads: int,
-    device: torch.device,
-) -> Iterator[dict[str, torch.Tensor]]:
-    """Build, run, and iterate over the SPDL pipeline, transferring to device."""
-    pipeline = pipeline_builder.build(num_threads=num_threads)
-    with pipeline.auto_stop():
-        for batch in pipeline.get_iterator(timeout=120):
-            yield {k: v.to(device, non_blocking=True) for k, v in batch.items()}
 
 
 # ---------------------------------------------------------------------------
@@ -319,6 +214,17 @@ def train(
         eta_min=lr * 0.1,
     )
 
+    # --- Build data source ---
+    dataloader = build_spdl_dataloader(
+        samples=samples,
+        tokenizer=tokenizer,
+        max_seq_len=max_seq_len,
+        batch_size=batch_size,
+        rank=rank,
+        world_size=world_size,
+        num_threads=num_workers,
+    )
+
     # --- Training loop ---
     global_step = 0
     ddp_model.train()
@@ -326,22 +232,11 @@ def train(
     for epoch in range(num_epochs):
         _LG.info("Epoch %d/%d", epoch + 1, num_epochs)
 
-        pipeline_builder = build_pipeline(
-            samples=samples,
-            tokenizer=tokenizer,
-            max_seq_len=max_seq_len,
-            batch_size=batch_size,
-            rank=rank,
-            world_size=world_size,
-            num_threads=num_workers,
-            seed=epoch,  # different shuffle per epoch
-        )
-
         t0 = time.monotonic()
         epoch_loss = 0.0
         num_batches = 0
 
-        for batch in iterate_pipeline(pipeline_builder, num_workers, device):
+        for batch in dataloader:
             outputs = ddp_model(
                 input_ids=batch["input_ids"],
                 attention_mask=batch["attention_mask"],

--- a/examples/llm_finetune/utils/pipeline.py
+++ b/examples/llm_finetune/utils/pipeline.py
@@ -1,0 +1,180 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""SPDL pipeline builder for LLM fine-tuning."""
+
+from __future__ import annotations
+
+import threading
+from collections.abc import Iterable, Iterator
+from typing import TYPE_CHECKING, TypedDict
+
+import spdl.pipeline
+import spdl.source.utils
+from spdl.io import transfer_tensor
+from spdl.pipeline import PipelineBuilder
+from spdl.pipeline.defs import PipelineConfig
+from spdl.source import DistributedRandomSampler
+from torch import Tensor
+
+from .utils import _collate, _tokenize_sample
+
+if TYPE_CHECKING:
+    from transformers import PreTrainedTokenizerBase
+
+__all__ = [
+    "build_spdl_dataloader",
+]
+
+
+class _Lookup:
+    """Picklable callable that looks up a sample by index."""
+
+    def __init__(self, samples: list[dict[str, str]]) -> None:
+        self.samples = samples
+
+    def __call__(self, idx: int) -> dict[str, str]:
+        return self.samples[idx]
+
+
+# subclass threading.local for better type inference
+class ThreadLocalTokenizer(threading.local):
+    def __init__(self, model_path: str) -> None:
+        self._model_path = model_path
+        self._tokenizer: "PreTrainedTokenizerBase | None" = None
+
+    @property
+    def tokenizer(self) -> "PreTrainedTokenizerBase":
+        if self._tokenizer is None:
+            from transformers import AutoTokenizer
+
+            tok = AutoTokenizer.from_pretrained(self._model_path)
+            if tok.pad_token is None:
+                tok.pad_token = tok.eos_token
+            self._tokenizer = tok
+        assert self._tokenizer is not None
+        return self._tokenizer
+
+
+class _Tokenize:
+    """Picklable callable that tokenizes a sample using a thread-local tokenizer.
+
+    Uses thread-local storage so each SPDL worker thread gets its own
+    tokenizer copy, since the HuggingFace fast tokenizer's Rust backend
+    is not thread-safe. Implements ``__getstate__``/``__setstate__`` so
+    the callable can be pickled for ``run_pipeline_in_subprocess``.
+    """
+
+    def __init__(self, model_path: str, max_seq_len: int) -> None:
+        self.model_path = model_path
+        self.max_seq_len = max_seq_len
+        self._tlt = ThreadLocalTokenizer(self.model_path)
+
+    class _State(TypedDict):
+        model_path: str
+        max_seq_len: int
+
+    def __getstate__(self) -> _State:
+        # threading.local is not picklable; reconstruct it in the subprocess.
+        return {"model_path": self.model_path, "max_seq_len": self.max_seq_len}
+
+    def __setstate__(self, state: _State) -> None:
+        self.model_path = state["model_path"]
+        self.max_seq_len = state["max_seq_len"]
+        self._tlt = ThreadLocalTokenizer(self.model_path)
+
+    def __call__(self, sample: dict[str, str]) -> dict[str, Tensor]:
+        return _tokenize_sample(sample, self._tlt.tokenizer, self.max_seq_len)
+
+
+class _DataLoaderWrapper(Iterable[dict[str, Tensor]]):
+    """Wraps a SPDL pipeline into an iterable."""
+
+    def __init__(self, config: PipelineConfig, num_threads: int) -> None:
+        self.config = config
+        self.num_threads = num_threads
+
+    def __iter__(self) -> Iterator[dict[str, Tensor]]:
+        pipeline = spdl.pipeline.build_pipeline(
+            self.config, num_threads=self.num_threads
+        )
+
+        with pipeline.auto_stop():
+            yield from pipeline.get_iterator(timeout=120)
+
+
+def build_spdl_dataloader(
+    samples: list[dict[str, str]],
+    tokenizer: PreTrainedTokenizerBase,
+    max_seq_len: int,
+    batch_size: int,
+    rank: int,
+    world_size: int,
+    num_threads: int,
+    mp_context: str = "forkserver",
+) -> Iterable[dict[str, Tensor]]:
+    """Build a reusable SPDL data loader with nested pipeline architecture.
+
+    Creates two nested pipelines to separate CPU-bound data loading from
+    GPU transfer, reducing the noisy-neighbour effect where data loading
+    threads in the main process compete with the training loop for CPU
+    time, delaying GPU kernel launches.
+
+    **Inner pipeline** (runs in a subprocess):
+      Sampling → lookup → tokenize (concurrent) → aggregate → collate.
+      All CPU work runs in a dedicated subprocess with its own thread pool,
+      completely isolating it from the training process. The subprocess is
+      created once and reused across epochs — each ``for ... in`` call
+      rebuilds the pipeline inside the same subprocess.
+
+    **Outer pipeline** (runs in the main process):
+      Receives CPU batches from the subprocess via IPC queue and transfers
+      them to GPU using ``transfer_tensor`` with a dedicated single-thread
+      executor. This ensures GPU transfer uses a consistent CUDA stream
+      and overlaps with training computation.
+
+    Build once before the training loop and iterate each epoch::
+
+        dataloader = build_spdl_dataloader(samples, tokenizer, ...)
+        for epoch in range(num_epochs):
+            for batch in dataloader:
+                train(batch)
+    """
+    sampler = DistributedRandomSampler(
+        len(samples),
+        rank=rank,
+        world_size=world_size,
+    )
+    source = spdl.source.utils.embed_shuffle(sampler)
+
+    model_path: str = tokenizer.name_or_path
+
+    backend = (
+        PipelineBuilder()
+        .add_source(source)
+        .pipe(_Lookup(samples))
+        .pipe(_Tokenize(model_path, max_seq_len), concurrency=num_threads)
+        .aggregate(batch_size)
+        .pipe(_collate)
+        .add_sink(buffer_size=3)
+    )
+
+    source2 = spdl.pipeline.run_pipeline_in_subprocess(
+        backend.get_config(),
+        num_threads=num_threads,
+        mp_context=mp_context,
+    )
+
+    frontend = (
+        PipelineBuilder()
+        .add_source(source2)
+        .pipe(transfer_tensor)
+        .add_sink(buffer_size=3)
+    )
+
+    return _DataLoaderWrapper(frontend.get_config(), num_threads=1)

--- a/examples/llm_finetune/utils/utils.py
+++ b/examples/llm_finetune/utils/utils.py
@@ -6,8 +6,11 @@
 
 """Data loading and model resolution helpers (OSS version, local filesystem)."""
 
+from __future__ import annotations
+
 __all__ = [
-    "format_prompt",
+    "_collate",
+    "_tokenize_sample",
     "load_data",
     "report_progress",
     "resolve_model_path",
@@ -19,8 +22,13 @@ import builtins
 import json
 import logging
 from collections.abc import Sequence
+from typing import TYPE_CHECKING
 
-_LG: logging.Logger = logging.getLogger(__name__)
+import torch
+from torch import Tensor
+
+if TYPE_CHECKING:
+    from transformers import PreTrainedTokenizerBase
 
 try:
     from .fb.helpers import open_fn, report_progress, resolve_model_path
@@ -36,9 +44,7 @@ except ImportError:
         pass
 
 
-# ---------------------------------------------------------------------------
-# Data loading
-# ---------------------------------------------------------------------------
+_LG: logging.Logger = logging.getLogger(__name__)
 
 
 def _load_jsonl(path: str) -> list[dict[str, str]]:
@@ -63,7 +69,7 @@ def load_data(paths: Sequence[str]) -> list[dict[str, str]]:
     return samples
 
 
-def format_prompt(sample: dict[str, str]) -> str:
+def _format_prompt(sample: dict[str, str]) -> str:
     """Format an Alpaca-style sample into a single prompt string."""
     instruction = sample["instruction"]
     inp = sample.get("input", "")
@@ -75,3 +81,37 @@ def format_prompt(sample: dict[str, str]) -> str:
             f"### Response:\n{output}"
         )
     return f"### Instruction:\n{instruction}\n\n### Response:\n{output}"
+
+
+def _tokenize_sample(
+    sample: dict[str, str],
+    tokenizer: "PreTrainedTokenizerBase",
+    max_seq_len: int,
+) -> dict[str, Tensor]:
+    """Format and tokenize a single Alpaca-style sample."""
+    text = _format_prompt(sample)
+    enc = tokenizer(
+        text,
+        max_length=max_seq_len,
+        truncation=True,
+        padding="max_length",
+        return_tensors="pt",
+    )
+    input_ids = enc["input_ids"].squeeze(0)
+    attention_mask = enc["attention_mask"].squeeze(0)
+    labels = input_ids.clone()
+    labels[attention_mask == 0] = -100
+    return {
+        "input_ids": input_ids,
+        "attention_mask": attention_mask,
+        "labels": labels,
+    }
+
+
+def _collate(items: list[dict[str, Tensor]]) -> dict[str, Tensor]:
+    """Stack a list of tokenized samples into a batch."""
+    return {
+        "input_ids": torch.stack([it["input_ids"] for it in items]),
+        "attention_mask": torch.stack([it["attention_mask"] for it in items]),
+        "labels": torch.stack([it["labels"] for it in items]),
+    }


### PR DESCRIPTION
Summary:

Extract SPDL pipeline to utils/pipeline.py with picklable callables for subprocess compatibility. The pipeline now runs in a subprocess via run_pipeline_in_subprocess. This isolates CPU-bound tokenization from the training process and enables async GPU transfer overlap.

Differential Revision: D101432538
