### PR TITLE
Add PyTorch DataLoader option for performance comparison (#1362)

### DIFF
--- a/examples/llm_finetune/llm_finetuning.py
+++ b/examples/llm_finetune/llm_finetuning.py
@@ -57,6 +57,7 @@ from __future__ import annotations
 
 __all__ = [
     "build_model",
+    "build_pytorch_dataloader",
     "build_spdl_dataloader",
     "load_data",
     "main",
@@ -78,6 +79,9 @@ import torch.distributed as dist
 from torch.nn.parallel import DistributedDataParallel as DDP
 
 try:
+    from examples.llm_finetune.utils.dataloader import (  # pyre-ignore[21]
+        build_pytorch_dataloader,
+    )
     from examples.llm_finetune.utils.pipeline import (  # pyre-ignore[21]
         build_spdl_dataloader,
     )
@@ -87,6 +91,7 @@ try:
         resolve_model_path,
     )
 except ImportError:
+    from spdl.examples.llm_finetune.utils.dataloader import build_pytorch_dataloader
     from spdl.examples.llm_finetune.utils.pipeline import (
         build_spdl_dataloader,
     )
@@ -157,6 +162,8 @@ def train(
     lora_alpha: int,
     lora_dropout: float,
     num_workers: int,
+    dataloader: str = "spdl",
+    mp_context: str = "forkserver",
     progress_fn: Callable[[int, int], None] | None = None,
 ) -> None:
     """Main training function, called per-rank."""
@@ -166,7 +173,13 @@ def train(
     device = torch.device(f"cuda:{local_rank}")
     torch.cuda.set_device(device)
 
-    _LG.info("Rank %d/%d on device %s", rank, world_size, device)
+    _LG.info(
+        "Rank %d/%d on device %s (dataloader=%s)",
+        rank,
+        world_size,
+        device,
+        dataloader,
+    )
 
     # --- Data ---
     samples = load_data(data_path)
@@ -215,15 +228,29 @@ def train(
     )
 
     # --- Build data source ---
-    dataloader = build_spdl_dataloader(
-        samples=samples,
-        tokenizer=tokenizer,
-        max_seq_len=max_seq_len,
-        batch_size=batch_size,
-        rank=rank,
-        world_size=world_size,
-        num_threads=num_workers,
-    )
+    if dataloader == "pytorch":
+        dl = build_pytorch_dataloader(
+            samples=samples,
+            tokenizer=tokenizer,
+            max_seq_len=max_seq_len,
+            batch_size=batch_size,
+            rank=rank,
+            world_size=world_size,
+            num_workers=num_workers,
+            mp_context=mp_context,
+            device=device,
+        )
+    else:
+        dl = build_spdl_dataloader(
+            samples=samples,
+            tokenizer=tokenizer,
+            max_seq_len=max_seq_len,
+            batch_size=batch_size,
+            rank=rank,
+            world_size=world_size,
+            num_threads=num_workers,
+            mp_context=mp_context,
+        )
 
     # --- Training loop ---
     global_step = 0
@@ -236,7 +263,7 @@ def train(
         epoch_loss = 0.0
         num_batches = 0
 
-        for batch in dataloader:
+        for batch in dl:
             outputs = ddp_model(
                 input_ids=batch["input_ids"],
                 attention_mask=batch["attention_mask"],
@@ -328,7 +355,21 @@ def parse_args() -> argparse.Namespace:
         "--num-workers",
         type=int,
         default=8,
-        help="Concurrent tokenization workers in the SPDL pipeline",
+        help="Concurrent tokenization workers in the data pipeline",
+    )
+    parser.add_argument(
+        "--dataloader",
+        type=str,
+        choices=["spdl", "pytorch"],
+        default="spdl",
+        help="Data loading backend: 'spdl' (default) or 'pytorch' (torch DataLoader)",
+    )
+    parser.add_argument(
+        "--mp-context",
+        type=str,
+        choices=["fork", "spawn", "forkserver"],
+        default="forkserver",
+        help="Multiprocessing context for workers (default: forkserver)",
     )
     return parser.parse_args()
 
@@ -360,6 +401,8 @@ def main(args: argparse.Namespace) -> None:
             lora_alpha=args.lora_alpha,
             lora_dropout=args.lora_dropout,
             num_workers=args.num_workers,
+            dataloader=args.dataloader,
+            mp_context=args.mp_context,
             progress_fn=report_progress,
         )
     finally:

--- a/examples/llm_finetune/utils/dataloader.py
+++ b/examples/llm_finetune/utils/dataloader.py
@@ -1,0 +1,112 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""PyTorch DataLoader for LLM fine-tuning."""
+
+from __future__ import annotations
+
+__all__ = ["build_pytorch_dataloader"]
+
+# pyre-strict
+from collections.abc import Iterator
+from typing import TYPE_CHECKING
+
+import torch
+import torch.utils.data
+
+from .utils import _collate, _tokenize_sample
+
+if TYPE_CHECKING:
+    from transformers import PreTrainedTokenizerBase
+
+
+class _InstructDataset(torch.utils.data.Dataset):
+    """Map-style dataset that tokenizes Alpaca-style samples on the fly."""
+
+    def __init__(
+        self,
+        samples: list[dict[str, str]],
+        tokenizer: PreTrainedTokenizerBase,
+        max_seq_len: int,
+    ) -> None:
+        self.samples = samples
+        self.tokenizer = tokenizer
+        self.max_seq_len = max_seq_len
+
+    def __len__(self) -> int:
+        return len(self.samples)
+
+    def __getitem__(self, idx: int) -> dict[str, torch.Tensor]:
+        return _tokenize_sample(self.samples[idx], self.tokenizer, self.max_seq_len)
+
+
+class _DeviceDataLoader:
+    """Wraps a DataLoader to transfer each batch to a CUDA device on iteration.
+
+    Automatically calls ``DistributedSampler.set_epoch`` on each iteration,
+    ensuring proper reshuffling across epochs. Build once and reuse across
+    epochs—no manual ``set_epoch`` call required.
+    """
+
+    def __init__(
+        self,
+        dataloader: torch.utils.data.DataLoader,
+        device: torch.device | None = None,
+    ) -> None:
+        self.dataloader = dataloader
+        self.device = device
+        self._epoch: int = 0
+
+    def __iter__(self) -> Iterator[dict[str, torch.Tensor]]:
+        sampler = self.dataloader.sampler
+        if isinstance(sampler, torch.utils.data.DistributedSampler):
+            sampler.set_epoch(self._epoch)
+        self._epoch += 1
+        if self.device is not None:
+            for batch in self.dataloader:
+                yield {
+                    k: v.to(self.device, non_blocking=True) for k, v in batch.items()
+                }
+        else:
+            yield from self.dataloader
+
+
+def build_pytorch_dataloader(
+    samples: list[dict[str, str]],
+    tokenizer: PreTrainedTokenizerBase,
+    max_seq_len: int,
+    batch_size: int,
+    rank: int,
+    world_size: int,
+    num_workers: int,
+    mp_context: str = "forkserver",
+    device: torch.device | None = None,
+) -> _DeviceDataLoader:
+    """Build a reusable PyTorch DataLoader for distributed LLM fine-tuning.
+
+    Build once before the training loop and reuse across epochs.
+    The returned wrapper automatically calls ``DistributedSampler.set_epoch``
+    on each iteration, so no manual ``set_epoch`` call is needed.
+    """
+    dataset = _InstructDataset(samples, tokenizer, max_seq_len)
+    sampler = torch.utils.data.DistributedSampler(
+        dataset,
+        num_replicas=world_size,
+        rank=rank,
+        shuffle=True,
+    )
+    dl = torch.utils.data.DataLoader(
+        dataset,
+        batch_size=batch_size,
+        sampler=sampler,
+        num_workers=num_workers,
+        collate_fn=_collate,
+        pin_memory=True,
+        prefetch_factor=3 if num_workers > 0 else None,
+        persistent_workers=num_workers > 0,
+        multiprocessing_context=mp_context if num_workers > 0 else None,
+    )
+    return _DeviceDataLoader(dl, device)


### PR DESCRIPTION
Summary:

Add --dataloader {spdl,pytorch} flag to the LLM fine-tuning example so both data loading backends can be benchmarked on identical workloads. Both dataloaders are built once before the training loop and reused across epochs.

**PyTorch DataLoader** (utils/dataloader.py):
- _InstructDataset: map-style dataset that tokenizes Alpaca-style samples on the fly
- _DeviceDataLoader: wraps DataLoader with automatic DistributedSampler.set_epoch per iteration and GPU transfer via Tensor.to(device, non_blocking=True)
- build_pytorch_dataloader(): creates DataLoader with DistributedSampler, forkserver mp_context, pin_memory, persistent_workers

**Training loop** (llm_finetuning.py):
- Unified for batch in dl: loop works for both backends
- --dataloader and --mp-context CLI args
- Entrypoint updated with corresponding parameters

Reviewed By: kiminoue7

Differential Revision: D101202924


