### PR TITLE
[pipeline] Add continuous mode for multi-epoch reuse

### DIFF
--- a/src/spdl/pipeline/__init__.py
+++ b/src/spdl/pipeline/__init__.py
@@ -19,6 +19,7 @@ from ._common._misc import create_task
 from ._components import (
     AsyncQueue,
     is_eof,
+    is_epoch_end,
     PipelineFailure,
     QueuePerfStats,
     StageInfo,
@@ -46,6 +47,7 @@ __all__ = [
     "ProcessGroupStatsMonitor",
     "build_pipeline",
     "is_eof",
+    "is_epoch_end",
     "profile_pipeline",
     "ProfileResult",
     "ProfileHook",

--- a/src/spdl/pipeline/_builder.py
+++ b/src/spdl/pipeline/_builder.py
@@ -86,7 +86,10 @@ class PipelineBuilder(Generic[T, U]):
         self._sink: SinkConfig[U] | None = None
 
     def add_source(
-        self, source: Iterable[T] | AsyncIterable[T]
+        self,
+        source: Iterable[T] | AsyncIterable[T],
+        *,
+        continuous: bool = False,
     ) -> "PipelineBuilder[T, U]":
         """Attach an iterator to the source buffer.
 
@@ -98,11 +101,18 @@ class PipelineBuilder(Generic[T, U]):
                    The source iterator must be lightweight as it is executed in async
                    event loop. If the iterator performs a blocking operation,
                    the entire pipeline will be blocked.
+
+            continuous: If ``True``, the source continuously re-iterates,
+                injecting a sentinel object representing an epoch boundary
+                between iterations. This enables multi-epoch pipeline reuse
+                without rebuilding. Use :py:func:`is_epoch_end` to detect
+                epoch boundaries in custom merge operations if needed;
+                regular pipe stage functions do not need to handle it.
         """
         if self._src is not None:
             raise ValueError("Source already set.")
 
-        self._src = SourceConfig(source)
+        self._src = SourceConfig(source, continuous=continuous)
         return self
 
     def pipe(

--- a/src/spdl/pipeline/_components/__init__.py
+++ b/src/spdl/pipeline/_components/__init__.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from ._common import is_eof, StageInfo
+from ._common import is_eof, is_epoch_end, StageInfo
 from ._hook import (
     get_default_hook_class,
     set_default_hook_class,
@@ -28,6 +28,7 @@ __all__ = [
     "get_default_hook_class",
     "get_default_queue_class",
     "is_eof",
+    "is_epoch_end",
     "PipelineFailure",
     "set_default_hook_class",
     "set_default_queue_class",

--- a/src/spdl/pipeline/_components/_aggregate.py
+++ b/src/spdl/pipeline/_components/_aggregate.py
@@ -14,7 +14,7 @@ from typing import Any
 
 from spdl.pipeline.defs import Aggregator
 
-from ._common import _SKIP, is_eof, StageInfo
+from ._common import _EPOCH_END, _SKIP, is_eof, is_epoch_end, StageInfo
 from ._hook import _stage_hooks, _task_hooks, TaskHook
 from ._pipe import _FailCounter
 from ._queue import _queue_stage_hook, AsyncQueue
@@ -85,6 +85,20 @@ def _aggregate(
             # can consume the result. Otherwise, keep draining without
             # blocking to reduce context switching overhead.
             while True:
+                if is_epoch_end(item):
+                    # Epoch boundary: handle same as EOF.
+                    # If op_requires_eof (drop_last=False), flush the
+                    # aggregator and emit the partial batch.
+                    # Otherwise (drop_last=True), discard partial batch.
+                    if op_requires_eof:
+                        result = wrapper._agg.flush()
+                        if result is not _SKIP and result is not None:
+                            await output_queue.put(result)
+                    else:
+                        wrapper._agg.flush()  # reset state, discard
+                    await output_queue.put(_EPOCH_END)
+                    break
+
                 if is_eof(item) and not op_requires_eof:
                     return
 

--- a/src/spdl/pipeline/_components/_common.py
+++ b/src/spdl/pipeline/_components/_common.py
@@ -6,12 +6,14 @@
 
 __all__ = [
     "_EOF",
+    "_EPOCH_END",
     "_periodic_dispatch",
     "_P2Percentile",
     "_SKIP",
     "_StatsCounter",
     "_time_str",
     "is_eof",
+    "is_epoch_end",
     "StageInfo",
 ]
 
@@ -42,12 +44,22 @@ class _Sentinel:
 
 
 _EOF = _Sentinel("EOF")  # Indicate the end of stream.
+_EPOCH_END = _Sentinel("EPOCH_END")  # Indicate the end of one epoch.
 _SKIP: None = None
 
 
 def is_eof(item: Any) -> bool:
     """Test whether the input item is EOF sentinel value."""
     return bool(item is _EOF)
+
+
+def is_epoch_end(item: Any) -> bool:
+    """Test whether the input item is an epoch-end sentinel value.
+
+    Custom aggregators can use this to handle epoch boundaries,
+    for example to flush or discard partial batches.
+    """
+    return bool(item is _EPOCH_END)
 
 
 def _time_str(val: float) -> str:

--- a/src/spdl/pipeline/_components/_node.py
+++ b/src/spdl/pipeline/_components/_node.py
@@ -42,7 +42,7 @@ from ._pipe import (
 )
 from ._queue import AsyncQueue, get_default_queue_class
 from ._sink import _sink
-from ._source import _source
+from ._source import _source, _source_continuous
 from ._variants import _path_variants_router
 
 T = TypeVar("T")
@@ -539,7 +539,8 @@ def _build_node(
 
     match node:
         case _SourceNode():
-            node._coro = _source(node.cfg.source, node.output_queue)
+            fn = _source_continuous if node.cfg.continuous else _source
+            node._coro = fn(node.cfg.source, node.output_queue)
         case _FanOutNode():
             hooks = task_hook_factory(node.info)
             node._coro = _path_variants_router(
@@ -708,8 +709,32 @@ def _build_pipeline_node(
 
     fc_class = _get_fail_counter()
     node = _convert_config(plc, q_class, _PIPELINE_ID, _MutableInt(stage_id))
+    _validate_continuous_mode(node)
     _build_node_recursive(node, fc_class, hook_factory, max_failures)
     return node
+
+
+def _collect_source_nodes(node: _TNodes) -> list[_SourceNode]:
+    """Collect all source nodes in the pipeline graph."""
+    if isinstance(node, _SourceNode):
+        return [node]
+    result: list[_SourceNode] = []
+    for n in node.upstream:
+        result.extend(_collect_source_nodes(n))
+    return result
+
+
+def _validate_continuous_mode(node: _TNodes) -> None:
+    """Validate that all source nodes agree on continuous mode."""
+    sources = _collect_source_nodes(node)
+    if not sources:
+        return
+    continuous_values = {s.cfg.continuous for s in sources}
+    if len(continuous_values) > 1:
+        raise ValueError(
+            "Mixed continuous mode is not supported. All sources in a pipeline "
+            "(including merged sub-pipelines) must have the same continuous setting."
+        )
 
 
 ################################################################################

--- a/src/spdl/pipeline/_components/_pipe.py
+++ b/src/spdl/pipeline/_components/_pipe.py
@@ -24,7 +24,7 @@ from spdl.pipeline._common._misc import create_task
 from spdl.pipeline._common._types import _TMergeOp
 from spdl.pipeline.defs import _PipeArgs
 
-from ._common import _EOF, _SKIP, is_eof, StageInfo
+from ._common import _EOF, _EPOCH_END, _SKIP, is_eof, is_epoch_end, StageInfo
 from ._hook import _stage_hooks, _task_hooks, TaskHook
 from ._queue import _queue_stage_hook, AsyncQueue
 
@@ -300,6 +300,15 @@ def _pipe(
         i, tasks = 0, set()
         while not fail_counter.too_many_failures():
             item = await input_queue.get()
+
+            if is_epoch_end(item):
+                # Epoch boundary: wait for all in-flight tasks, propagate, continue
+                if tasks:
+                    await asyncio.wait(tasks)
+                    tasks = set()
+                await output_queue.put(_EPOCH_END)
+                continue
+
             if is_eof(item) and not op_requires_eof:
                 break
             # note: Make sure that `afunc` is called directly in this function,
@@ -419,6 +428,10 @@ def _ordered_pipe(
         while not fail_counter.too_many_failures():
             item = await input_queue.get()
 
+            if is_epoch_end(item):
+                await inter_queue.put(_EPOCH_END)
+                continue
+
             if is_eof(item):
                 break
 
@@ -430,6 +443,10 @@ def _ordered_pipe(
     async def get_check_put() -> None:
         while not fail_counter.too_many_failures():
             entry = await inter_queue.get()
+
+            if is_epoch_end(entry):
+                await output_queue.put(_EPOCH_END)
+                continue
 
             if is_eof(entry):
                 # Propagating EOF is done by `_queue_stage_hook`
@@ -473,11 +490,27 @@ async def _disaggregate(items: list[T]) -> AsyncIterator[T]:
 async def _default_merge(
     info: StageInfo, input_queues: Sequence[asyncio.Queue], output_queue: asyncio.Queue
 ) -> None:
+    epoch_end_count: int = 0
+    epoch_end_barrier: asyncio.Event = asyncio.Event()
+
     async def _pass(in_q: asyncio.Queue) -> None:
+        nonlocal epoch_end_count
         while True:
             item = await in_q.get()
             if is_eof(item):
                 return
+            if is_epoch_end(item):
+                epoch_end_count += 1
+                if epoch_end_count >= len(input_queues):
+                    # All sub-pipelines reached epoch end
+                    epoch_end_count = 0
+                    await output_queue.put(_EPOCH_END)
+                    epoch_end_barrier.set()
+                    epoch_end_barrier.clear()
+                else:
+                    # Wait for other sub-pipelines to reach epoch end
+                    await epoch_end_barrier.wait()
+                continue
             await output_queue.put(item)
 
     tasks = [

--- a/src/spdl/pipeline/_components/_source.py
+++ b/src/spdl/pipeline/_components/_source.py
@@ -4,13 +4,14 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-__all__ = ["_source"]
+__all__ = ["_source", "_source_continuous"]
 
 from collections.abc import AsyncIterable, Iterable
 from typing import TypeVar
 
 from spdl.pipeline._common._convert import _to_async_gen
 
+from ._common import _EPOCH_END
 from ._queue import _queue_stage_hook, AsyncQueue
 
 # pyre-strict
@@ -52,3 +53,29 @@ async def _source(
             num_items += 1
             if max_items is not None and num_items >= max_items:
                 return
+
+
+async def _source_continuous(
+    src: Iterable[T] | AsyncIterable[T],
+    queue: AsyncQueue,
+) -> None:
+    """Coroutine that continuously re-iterates the source, injecting epoch-end markers.
+
+    After each iteration of the source exhausts, an ``_EPOCH_END`` sentinel is
+    put into the queue and the source is re-iterated. This continues indefinitely
+    until the coroutine is cancelled (via pipeline shutdown).
+
+    Args:
+        src: The source iterable (synchronous or asynchronous) to consume data from.
+        queue: The async queue to put items into for downstream consumption.
+    """
+    _to_async = _to_async_gen(iter, None)
+
+    async with _queue_stage_hook(queue):
+        while True:
+            src_: AsyncIterable[T] = (  # pyre-ignore: [9]
+                src if hasattr(src, "__aiter__") else _to_async(src)
+            )
+            async for item in src_:
+                await queue.put(item)
+            await queue.put(_EPOCH_END)

--- a/src/spdl/pipeline/_components/_variants.py
+++ b/src/spdl/pipeline/_components/_variants.py
@@ -86,7 +86,7 @@ def _path_variants_router(
     path_queues: Sequence[AsyncQueue],
     router: Callable[[Any], int] | Callable[[Any], Awaitable[int]],
     task_hooks: list[TaskHook],
-) -> Coroutine:
+) -> Coroutine[None, None, None]:
     """Create a coroutine that routes items to per-path queues.
 
     The router reads items from ``input_queue``, calls ``router(item)`` to

--- a/src/spdl/pipeline/_iter_utils/_subprocess.py
+++ b/src/spdl/pipeline/_iter_utils/_subprocess.py
@@ -92,7 +92,7 @@ class _SubprocessIterable(Iterable[T]):
             # pyre-ignore[6]
             _enter_iteration_mode(if_.cmd_q, if_.data_q, if_.timeout, "subprocess")
             yield from _iterate_results(if_.data_q, if_.timeout, "subprocess")
-        except (Exception, KeyboardInterrupt):
+        except BaseException:
             self._shutdown()
             raise
 

--- a/src/spdl/pipeline/_pipeline.py
+++ b/src/spdl/pipeline/_pipeline.py
@@ -22,6 +22,7 @@ from typing import Any, Generic, TypeVar
 
 from spdl._internal import log_api_usage_once
 from spdl.pipeline._common._misc import create_task
+from spdl.pipeline._components import is_epoch_end
 
 __all__ = ["Pipeline"]
 
@@ -208,6 +209,9 @@ class _EventLoopState(IntEnum):
     STOPPED = 2
 
 
+_EOF_MSG: str = "Reached the end of the pipeline."
+
+
 class Pipeline(Generic[T]):
     """Pipeline()
 
@@ -344,7 +348,23 @@ class Pipeline(Generic[T]):
         """
         if _EventLoopState.STARTED <= self._event_loop_state < _EventLoopState.STOPPED:
             self._event_loop.stop()
-            self._event_loop.join(timeout=timeout)
+
+            # Try to join first. If it doesn't join, drain the output queue
+            # to resolve the congestion, then retry.
+            # (e.g. the frontend does not consume any data, thus the upstream tasks
+            # are not able to complete),
+            to1: float = 3 if timeout is None else min(3, timeout)
+            to2: float | None = None if timeout is None else timeout - to1
+            try:
+                self._event_loop.join(timeout=to1)
+            except TimeoutError:
+                # Empty queue, release backpressure
+                while not self._output_queue.empty():
+                    try:
+                        self._output_queue.get_nowait()
+                    except Exception:
+                        break
+                self._event_loop.join(timeout=to2)
             self._event_loop_state = _EventLoopState.STOPPED
             self._finalizer.detach()
 
@@ -380,8 +400,12 @@ class Pipeline(Generic[T]):
             EOFError: When the pipeline is exhausted or cancelled and there are no more items
                 in the sink.
         """
-        eof_message = "Reached the end of the pipeline."
+        item = self._get_item(timeout=timeout)
+        if is_epoch_end(item):
+            raise EOFError(_EOF_MSG)
+        return item
 
+    def _get_item(self, *, timeout: float | None) -> T:
         if not self._event_loop.is_started():
             raise RuntimeError("Pipeline is not started.")
 
@@ -404,7 +428,7 @@ class Pipeline(Generic[T]):
 
             # Now, all the items from the queue are fetched. We can stop the pipeline loop/thread.
             self._event_loop.stop()
-            raise EOFError(eof_message)
+            raise EOFError(_EOF_MSG)
 
         # The task is not completed. To access the sink queue, the async method must be used.
         # The loop keeps running unless we explicitly request stop, so the use of async method
@@ -433,7 +457,7 @@ class Pipeline(Generic[T]):
                 # This case we can switch to EOFError.
                 if self._event_loop.is_task_completed() and self._output_queue.empty():
                     self._event_loop.stop()
-                    raise EOFError(eof_message) from None
+                    raise EOFError(_EOF_MSG) from None
 
         _LG.debug("EventLoop: %s", str(self._event_loop))
 

--- a/src/spdl/pipeline/defs/_defs.py
+++ b/src/spdl/pipeline/defs/_defs.py
@@ -70,6 +70,11 @@ class SourceConfig(Generic[T]):
     source: Iterable | AsyncIterable
     """Generates the series of source data."""
 
+    continuous: bool = False
+    """If True, the source continuously re-iterates, injecting a sentinel
+    object representing an epoch boundary between iterations. This enables
+    multi-epoch pipeline reuse without rebuilding."""
+
     def __post_init__(self) -> None:
         if not (hasattr(self.source, "__aiter__") or hasattr(self.source, "__iter__")):
             raise ValueError("Source must be either generator or async generator.")

--- a/tests/pipeline/continuous_pipeline_test.py
+++ b/tests/pipeline/continuous_pipeline_test.py
@@ -1,0 +1,472 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-unsafe
+
+import time
+import unittest
+import weakref
+from collections.abc import Iterator
+
+from spdl.pipeline import (
+    build_pipeline,
+    PipelineBuilder,
+    PipelineFailure,
+    run_pipeline_in_subprocess,
+)
+from spdl.pipeline.defs import Merge, PipelineConfig, SinkConfig
+
+
+class SourceIterable:
+    """Reusable iterable that yields range(n) on each iteration."""
+
+    def __init__(self, n: int) -> None:
+        self.n = n
+
+    def __iter__(self) -> Iterator[int]:
+        yield from range(self.n)
+
+
+class TestContinuousPipelineBasic(unittest.TestCase):
+    def test_continuous_multi_epoch(self) -> None:
+        """Pipeline with continuous=True can be iterated multiple times."""
+        pipeline = (
+            PipelineBuilder()
+            .add_source(SourceIterable(5), continuous=True)
+            .add_sink(buffer_size=3)
+            .build(num_threads=1)
+        )
+
+        with pipeline.auto_stop():
+            for epoch in range(3):
+                result = list(pipeline.get_iterator(timeout=5))
+                self.assertEqual(result, [0, 1, 2, 3, 4], f"epoch {epoch}")
+
+    def test_continuous_single_epoch(self) -> None:
+        """Continuous pipeline works for a single epoch."""
+        pipeline = (
+            PipelineBuilder()
+            .add_source(SourceIterable(3), continuous=True)
+            .add_sink(buffer_size=3)
+            .build(num_threads=1)
+        )
+
+        with pipeline.auto_stop():
+            result = list(pipeline.get_iterator(timeout=5))
+            self.assertEqual(result, [0, 1, 2])
+
+    def test_continuous_empty_epoch(self) -> None:
+        """Continuous pipeline handles empty iterations."""
+        pipeline = (
+            PipelineBuilder()
+            .add_source(SourceIterable(0), continuous=True)
+            .add_sink(buffer_size=3)
+            .build(num_threads=1)
+        )
+
+        with pipeline.auto_stop():
+            for epoch in range(3):
+                result = list(pipeline.get_iterator(timeout=5))
+                self.assertEqual(result, [], f"epoch {epoch}")
+
+    def test_continuous_single_item_epoch(self) -> None:
+        """Continuous pipeline works with single-item epochs."""
+        pipeline = (
+            PipelineBuilder()
+            .add_source(SourceIterable(1), continuous=True)
+            .add_sink(buffer_size=3)
+            .build(num_threads=1)
+        )
+
+        with pipeline.auto_stop():
+            for epoch in range(3):
+                result = list(pipeline.get_iterator(timeout=5))
+                self.assertEqual(result, [0], f"epoch {epoch}")
+
+
+class TestContinuousPipelinePipe(unittest.TestCase):
+    def test_continuous_pipe_concurrent(self) -> None:
+        """Pipe with concurrency > 1 handles epoch boundaries correctly."""
+
+        def double(x: int) -> int:
+            return x * 2
+
+        pipeline = (
+            PipelineBuilder()
+            .add_source(SourceIterable(5), continuous=True)
+            .pipe(double, concurrency=4)
+            .add_sink(buffer_size=3)
+            .build(num_threads=4)
+        )
+
+        with pipeline.auto_stop():
+            for epoch in range(3):
+                result = sorted(pipeline.get_iterator(timeout=5))
+                self.assertEqual(result, [0, 2, 4, 6, 8], f"epoch {epoch}")
+
+    def test_continuous_pipe_chain(self) -> None:
+        """EPOCH_END propagates through multiple pipe stages."""
+
+        def add_one(x: int) -> int:
+            return x + 1
+
+        def double(x: int) -> int:
+            return x * 2
+
+        pipeline = (
+            PipelineBuilder()
+            .add_source(SourceIterable(3), continuous=True)
+            .pipe(add_one, concurrency=1)
+            .pipe(double, concurrency=1)
+            .add_sink(buffer_size=3)
+            .build(num_threads=2)
+        )
+
+        with pipeline.auto_stop():
+            for epoch in range(3):
+                result = list(pipeline.get_iterator(timeout=5))
+                self.assertEqual(result, [2, 4, 6], f"epoch {epoch}")
+
+
+class TestContinuousPipelineAggregate(unittest.TestCase):
+    def test_continuous_aggregate_exact_batch(self) -> None:
+        """Aggregate with exact batch size across epochs."""
+        pipeline = (
+            PipelineBuilder()
+            .add_source(SourceIterable(6), continuous=True)
+            .aggregate(3)
+            .add_sink(buffer_size=3)
+            .build(num_threads=1)
+        )
+
+        with pipeline.auto_stop():
+            for epoch in range(3):
+                result = list(pipeline.get_iterator(timeout=5))
+                self.assertEqual(result, [[0, 1, 2], [3, 4, 5]], f"epoch {epoch}")
+
+    def test_continuous_aggregate_partial_batch_flushed(self) -> None:
+        """Partial batch at epoch end is flushed by the default aggregator."""
+        pipeline = (
+            PipelineBuilder()
+            .add_source(SourceIterable(5), continuous=True)
+            .aggregate(3)
+            .add_sink(buffer_size=3)
+            .build(num_threads=1)
+        )
+
+        with pipeline.auto_stop():
+            for epoch in range(3):
+                result = list(pipeline.get_iterator(timeout=5))
+                # 5 items, batch_size=3: full batch [0,1,2] + partial batch [3,4]
+                self.assertEqual(result, [[0, 1, 2], [3, 4]], f"epoch {epoch}")
+
+    def test_continuous_aggregate_drop_last(self) -> None:
+        """With drop_last=True, partial batch at epoch end is discarded."""
+        pipeline = (
+            PipelineBuilder()
+            .add_source(SourceIterable(5), continuous=True)
+            .aggregate(3, drop_last=True)
+            .add_sink(buffer_size=3)
+            .build(num_threads=1)
+        )
+
+        with pipeline.auto_stop():
+            for epoch in range(3):
+                result = list(pipeline.get_iterator(timeout=5))
+                # 5 items, batch_size=3, drop_last: only [0,1,2], partial [3,4] dropped
+                self.assertEqual(result, [[0, 1, 2]], f"epoch {epoch}")
+
+
+class TestContinuousPipelineShutdown(unittest.TestCase):
+    def test_continuous_auto_stop_mid_epoch(self) -> None:
+        """auto_stop() exits cleanly even if mid-epoch."""
+        pipeline = (
+            PipelineBuilder()
+            .add_source(SourceIterable(100), continuous=True)
+            .add_sink(buffer_size=3)
+            .build(num_threads=1)
+        )
+
+        with pipeline.auto_stop():
+            it = pipeline.get_iterator(timeout=5)
+            # Consume only a few items
+            self.assertEqual(next(it), 0)
+            self.assertEqual(next(it), 1)
+            # auto_stop exits here — must not hang
+
+    def test_continuous_stop_between_epochs(self) -> None:
+        """stop() between epochs works cleanly."""
+        pipeline = (
+            PipelineBuilder()
+            .add_source(SourceIterable(3), continuous=True)
+            .add_sink(buffer_size=3)
+            .build(num_threads=1)
+        )
+
+        with pipeline.auto_stop():
+            result = list(pipeline.get_iterator(timeout=5))
+            self.assertEqual(result, [0, 1, 2])
+            # auto_stop exits here after one epoch — must not hang
+
+    def test_continuous_get_iterator_reuse(self) -> None:
+        """get_iterator() can be called multiple times within auto_stop()."""
+        pipeline = (
+            PipelineBuilder()
+            .add_source(SourceIterable(3), continuous=True)
+            .add_sink(buffer_size=3)
+            .build(num_threads=1)
+        )
+
+        with pipeline.auto_stop():
+            r1 = list(pipeline.get_iterator(timeout=5))
+            r2 = list(pipeline.get_iterator(timeout=5))
+            r3 = list(pipeline.get_iterator(timeout=5))
+            self.assertEqual(r1, [0, 1, 2])
+            self.assertEqual(r2, [0, 1, 2])
+            self.assertEqual(r3, [0, 1, 2])
+
+    def test_continuous_stop_with_pipe_stage(self) -> None:
+        """Continuous pipeline with pipe stage can be stopped after epochs."""
+
+        def double(x: int) -> int:
+            return x * 2
+
+        pipeline = (
+            PipelineBuilder()
+            .add_source(SourceIterable(5), continuous=True)
+            .pipe(double, concurrency=2)
+            .add_sink(buffer_size=3)
+            .build(num_threads=2)
+        )
+
+        with pipeline.auto_stop():
+            r1 = sorted(pipeline.get_iterator(timeout=5))
+            self.assertEqual(r1, [0, 2, 4, 6, 8])
+            # auto_stop exits — pipeline has items buffered for next epoch
+            # stop() must drain and shut down cleanly
+
+    def test_continuous_stop_with_subprocess_source(self) -> None:
+        """Continuous pipeline reading from subprocess can be stopped."""
+        backend = (
+            PipelineBuilder().add_source(SourceIterable(5)).add_sink(buffer_size=3)
+        )
+        source = run_pipeline_in_subprocess(
+            backend.get_config(),
+            num_threads=1,
+            timeout=10,
+        )
+
+        pipeline = (
+            PipelineBuilder()
+            .add_source(source, continuous=True)
+            .add_sink(buffer_size=3)
+            .build(num_threads=1)
+        )
+
+        with pipeline.auto_stop():
+            r1 = list(pipeline.get_iterator(timeout=5))
+            self.assertEqual(r1, [0, 1, 2, 3, 4])
+            # auto_stop exits — must not hang on subprocess IPC
+
+    def test_continuous_pipeline_in_subprocess_multi_epoch(self) -> None:
+        """A continuous pipeline running inside a subprocess supports
+        multi-epoch iteration without recreating the subprocess."""
+        backend = (
+            PipelineBuilder()
+            .add_source(SourceIterable(5), continuous=True)
+            .add_sink(buffer_size=3)
+        )
+        source = run_pipeline_in_subprocess(
+            backend.get_config(),
+            num_threads=1,
+            timeout=10,
+        )
+
+        # Iterate 3 epochs from the parent — subprocess is reused
+        for epoch in range(3):
+            result = list(source)
+            self.assertEqual(result, [0, 1, 2, 3, 4], f"epoch {epoch}")
+
+    def test_continuous_pipeline_in_subprocess_stop_mid_epoch(self) -> None:
+        """Subprocess with continuous pipeline can be abandoned mid-epoch."""
+        backend = (
+            PipelineBuilder()
+            .add_source(SourceIterable(100), continuous=True)
+            .add_sink(buffer_size=3)
+        )
+        source = run_pipeline_in_subprocess(
+            backend.get_config(),
+            num_threads=1,
+            timeout=10,
+        )
+
+        it = iter(source)
+        self.assertEqual(next(it), 0)
+        self.assertEqual(next(it), 1)
+        # Abandon — must not hang
+        del it
+        del source
+
+    def test_continuous_frontend_backend_multi_epoch(self) -> None:
+        """Frontend continuous pipeline on top of subprocess backend
+        supports multi-epoch iteration."""
+        backend = (
+            PipelineBuilder()
+            .add_source(SourceIterable(5), continuous=True)
+            .add_sink(buffer_size=3)
+        )
+        source = run_pipeline_in_subprocess(
+            backend.get_config(),
+            num_threads=1,
+            timeout=10,
+        )
+
+        pipeline = (
+            PipelineBuilder()
+            .add_source(source, continuous=True)
+            .add_sink(buffer_size=3)
+            .build(num_threads=1)
+        )
+
+        with pipeline.auto_stop():
+            for epoch in range(3):
+                result = list(pipeline.get_iterator(timeout=5))
+                self.assertEqual(result, [0, 1, 2, 3, 4], f"epoch {epoch}")
+
+    def test_continuous_frontend_backend_stop_mid_epoch(self) -> None:
+        """Frontend continuous pipeline on top of subprocess backend
+        can be stopped mid-epoch without hanging."""
+        backend = (
+            PipelineBuilder()
+            .add_source(SourceIterable(100), continuous=True)
+            .add_sink(buffer_size=3)
+        )
+        source = run_pipeline_in_subprocess(
+            backend.get_config(),
+            num_threads=1,
+            timeout=10,
+        )
+
+        pipeline = (
+            PipelineBuilder()
+            .add_source(source, continuous=True)
+            .add_sink(buffer_size=3)
+            .build(num_threads=1)
+        )
+
+        with pipeline.auto_stop():
+            it = pipeline.get_iterator(timeout=5)
+            self.assertEqual(next(it), 0)
+            self.assertEqual(next(it), 1)
+            # auto_stop exits mid-epoch — must not hang
+
+    def test_continuous_frontend_backend_finalizer_shutdown(self) -> None:
+        """Frontend+backend pipeline cleaned up via weakref.finalize.
+
+        Simulates the _SPDLDataLoader pattern: pipeline is started, iterated,
+        then the wrapper goes out of scope. The finalizer calls stop(timeout=10).
+        Must not hang.
+        """
+
+        backend = (
+            PipelineBuilder()
+            .add_source(SourceIterable(5), continuous=True)
+            .add_sink(buffer_size=3)
+        )
+        source = run_pipeline_in_subprocess(
+            backend.get_config(),
+            num_threads=1,
+            timeout=10,
+        )
+
+        pipeline = (
+            PipelineBuilder()
+            .add_source(source, continuous=True)
+            .add_sink(buffer_size=3)
+            .build(num_threads=1)
+        )
+
+        pipeline.start()
+        finalizer = weakref.finalize(pipeline, lambda p: p.stop(timeout=10), pipeline)
+
+        # Iterate 2 epochs
+        for epoch in range(2):
+            result = list(pipeline.get_iterator(timeout=5))
+            self.assertEqual(result, [0, 1, 2, 3, 4], f"epoch {epoch}")
+
+        t0 = time.monotonic()
+        # Trigger finalizer (simulates going out of scope)
+        finalizer()
+        elapsed = time.monotonic() - t0
+        self.assertLess(elapsed, 15, f"finalizer took {elapsed:.1f}s — likely hung")
+
+
+class CustomError(ValueError):
+    pass
+
+
+class TestContinuousPipelineErrors(unittest.TestCase):
+    def test_continuous_source_failure(self) -> None:
+        """Source raising mid-epoch propagates error."""
+
+        class FailingSource:
+            def __iter__(self) -> Iterator[int]:
+                yield 0
+                raise CustomError("source failed")
+
+        pipeline = (
+            PipelineBuilder()
+            .add_source(FailingSource(), continuous=True)
+            .add_sink(buffer_size=3)
+            .build(num_threads=1)
+        )
+
+        with self.assertRaises(PipelineFailure):
+            with pipeline.auto_stop():
+                list(pipeline.get_iterator(timeout=5))
+
+    def test_continuous_pipe_failure(self) -> None:
+        """Pipe function raising propagates error."""
+
+        def failing_fn(x: int) -> int:
+            if x == 2:
+                raise CustomError("pipe failed")
+            return x
+
+        pipeline = (
+            PipelineBuilder()
+            .add_source(SourceIterable(5), continuous=True)
+            .pipe(failing_fn, concurrency=1)
+            .add_sink(buffer_size=3)
+            .build(num_threads=1, max_failures=0)
+        )
+
+        with self.assertRaises(PipelineFailure):
+            with pipeline.auto_stop():
+                list(pipeline.get_iterator(timeout=5))
+
+
+class TestContinuousPipelineValidation(unittest.TestCase):
+    def test_mixed_continuous_mode_rejected(self) -> None:
+        """Mixing continuous and non-continuous sources raises ValueError."""
+        plc_continuous = (
+            PipelineBuilder()
+            .add_source(SourceIterable(3), continuous=True)
+            .add_sink()
+            .get_config()
+        )
+        plc_normal = (
+            PipelineBuilder().add_source(SourceIterable(3)).add_sink().get_config()
+        )
+
+        merged_config = PipelineConfig(
+            src=Merge([plc_continuous, plc_normal]),
+            pipes=[],
+            sink=SinkConfig(buffer_size=3),
+        )
+
+        with self.assertRaisesRegex(ValueError, "Mixed continuous mode"):
+            build_pipeline(merged_config, num_threads=1)


### PR DESCRIPTION
## Motivation

Currently, a Pipeline can only be iterated once -- after `get_iterator()` reaches EOF, subsequent calls immediately raise `EOFError`. For multi-epoch training, users must build a new Pipeline each epoch, paying thread pool creation and source initialization costs every time. This creates a measurable throughput gap at epoch boundaries (observed ~7% sustained throughput loss vs PyTorch DataLoader in the LLM fine-tuning benchmark).

## Approach

Add a continuous parameter to `add_source()` (stored in `SourceConfig`). When enabled, the source stage continuously re-iterates the source iterable, injecting epoch boundary sentinels between iterations. Each pipeline stage (pipe, aggregate, merge, sink) propagates these sentinels downstream. When `get_item()` encounters an epoch boundary sentinel in the output queue, it raises `EOFError` -- causing `get_iterator()` to return -- but the pipeline stays alive. The next `get_iterator()` call picks up items from the next epoch that are already flowing.

Usage:

```python
pipeline = (
    PipelineBuilder()
    .add_source(dataset, continuous=True)
    .pipe(preprocess, concurrency=8)
    .aggregate(batch_size)
    .add_sink(buffer_size=3)
    .build(num_threads=8)
)

with pipeline.auto_stop():
    for epoch in range(num_epochs):
        for batch in pipeline.get_iterator():
            train(batch)
```

## Design decisions

**Epoch boundary as a sentinel flowing through the pipeline** -- rather than adding external synchronization or restarting the pipeline, the epoch boundary is an in-band sentinel that flows through the existing async queue infrastructure. Each stage handles it naturally: pipe stages wait for in-flight tasks (acting as a barrier to prevent cross-epoch mixing), the aggregator flushes its state (the aggregator op decides whether to emit a partial batch or discard it), and the sink passes it through to the output queue.

**continuous on `add_source()`, not `build()`** -- the continuous flag is a property of how the source iterates, not a build-time parameter. This allows per-source control in merged pipelines, and keeps `SourceConfig` self-describing. A validation step rejects mixed continuous/non-continuous sources in merged pipelines at build time.

**`is_epoch_end()` public API** -- follows the same pattern as `is_eof()`. Custom aggregators can use it to handle epoch boundaries. Regular pipe stage functions do not need to handle it -- the pipeline propagates epoch boundaries automatically.

**Merge behavior** -- when multiple sub-pipelines are merged, the merge stage waits for all sub-pipelines to reach an epoch boundary before propagating it downstream. Mixed continuous/non-continuous sub-pipelines are rejected at build time.

**`get_item()` refactored into `get_item()` + `_get_item()`** -- `get_item()` is the public API that checks for epoch-end sentinels and raises EOFError. `_get_item()` is the internal method that returns raw items including sentinels. This keeps the epoch boundary detection in one place.

**`_SubprocessIterable` catches `BaseException`** -- changed from `(Exception, KeyboardInterrupt)` to `BaseException` so that `asyncio.CancelledError` (a `BaseException` subclass) triggers proper subprocess cleanup when a continuous pipeline using a subprocess source is cancelled.

## `Pipeline.stop()` changes for continuous mode

In continuous mode, the pipeline never reaches natural EOF -- the source keeps producing. When `stop()` is called (e.g. after the training loop finishes all epochs), the pipeline may have already started producing items for the next epoch. These items fill the internal async queues. Pipeline stages blocked on `queue.put()` cannot respond to task cancellation because they are waiting for downstream consumers that will never come.

The fix uses a two-phase join in Pipeline.stop():

1. Request stop (which triggers `task.cancel()` in the event loop), then try to join the thread within 3 seconds. For non-continuous pipelines, this always succeeds -- the source has finite items, the pipeline drains naturally, and the thread joins promptly. Items remaining in the output queue are preserved.

2. If the first join times out (continuous mode backpressure), drain the output queue to release the backpressure, then retry join with the remaining timeout. Once backpressure is relieved, the cancelled tasks can unwind and the thread joins.

This two-phase approach preserves backward compatibility: existing code relies on items remaining in the output queue after stop() (e.g. `test_pipeline_cancel_empty` expects to read buffered items after `auto_stop()` exits). Draining unconditionally would break this. Draining only after a timeout ensures we only discard items when the pipeline is actually stuck on back pressure.

Alternatives considered:
- Draining unconditionally before or after `stop()`: broke test_pipeline_cancel_empty which expects items to survive `stop()`.
- Checking `is_task_completed()` to skip drain: race condition -- the task may not be marked completed yet even though all items are produced.
- Replacing `asyncio.run()` with manual event loop management: `asyncio.run()` cleanup calls `shutdown_default_executor(wait=True)` which hangs on executor threads blocked on subprocess IPC reads. However, the drain approach resolves the back pressure before `asyncio.run()` cleanup runs, so this was unnecessary.
- Adding a timeout to `task.cancel()` await: the original `await asyncio.wait([task])` (no timeout) works correctly once back pressure is released by the drain. The cancel itself is not the problem -- it's the back pressure that prevents the cancelled tasks from unwinding.

## Appendix: Implementation details

Internally, the epoch boundary is represented by an `_EPOCH_END` sentinel object (similar to the existing `_EOF` sentinel). The source stage (`_source_continuous`) loops while True, calling `iter(iterable)` and injecting `_EPOCH_END` after each StopIteration. Pipe stages check for `is_epoch_end()` before `is_eof()` in the item loop, wait for all in-flight `asyncio` tasks, put `_EPOCH_END` downstream, and continue. The ordered pipe variant propagates `_EPOCH_END` through both the dispatch and check coroutines. The aggregate stage calls `flush()` on the aggregator op and emits the result if non-None, then propagates `_EPOCH_END`.