### PR TITLE
Support continuous pipeline in run_pipeline_in_subprocess

### DIFF
--- a/src/spdl/pipeline/_build.py
+++ b/src/spdl/pipeline/_build.py
@@ -35,7 +35,7 @@ from spdl.pipeline._components import (
     TaskHook,
 )
 from spdl.pipeline._iter_utils import iterate_in_subinterpreter, iterate_in_subprocess
-from spdl.pipeline.defs import PipelineConfig
+from spdl.pipeline.defs import MergeConfig, PipelineConfig, SourceConfig
 
 from ._pipeline import Pipeline
 
@@ -263,6 +263,16 @@ def build_pipeline(
 ################################################################################
 
 
+def _has_continuous_source(config: PipelineConfig[Any]) -> bool:
+    """Check if any source in the pipeline config is continuous."""
+    src = config.src
+    if isinstance(src, SourceConfig):
+        return src.continuous
+    if isinstance(src, MergeConfig):
+        return any(_has_continuous_source(plc) for plc in src.pipeline_configs)
+    return False
+
+
 class _Wrapper(Generic[U]):
     def __init__(
         self,
@@ -281,9 +291,11 @@ class _Wrapper(Generic[U]):
         self.queue_class = queue_class
         self.task_hook_factory = task_hook_factory
         self.background_tasks = background_tasks
+        self._continuous: bool = _has_continuous_source(config)
+        self._pipeline: Pipeline[U] | None = None
 
-    def __iter__(self) -> Iterator[U]:
-        pipeline = build_pipeline(
+    def _build(self) -> Pipeline[U]:
+        return build_pipeline(
             self.config,
             num_threads=self.num_threads,
             max_failures=self.max_failures,
@@ -292,8 +304,25 @@ class _Wrapper(Generic[U]):
             task_hook_factory=self.task_hook_factory,
             background_tasks=self.background_tasks,
         )
-        with pipeline.auto_stop():
-            yield from pipeline
+
+    def _get_reusable_pipeline(self) -> Pipeline[U]:
+        assert self._continuous
+        if self._pipeline is None:
+            self._pipeline = self._build()
+            self._pipeline.start()
+        assert self._pipeline is not None
+        return self._pipeline
+
+    def __iter__(self) -> Iterator[U]:
+        if self._continuous:
+            # Reuse the same pipeline across iterations. Build once on
+            # first iter, then use get_iterator() per epoch. This avoids
+            # rebuilding the thread pool and event loop each epoch.
+            yield from self._get_reusable_pipeline().get_iterator()
+        else:
+            pipeline = self._build()
+            with pipeline.auto_stop():
+                yield from pipeline
 
 
 def _get_initializer(kwargs: Any) -> Sequence[Callable[[], None]]:

--- a/tests/pipeline/continuous_pipeline_test.py
+++ b/tests/pipeline/continuous_pipeline_test.py
@@ -6,6 +6,9 @@
 
 # pyre-unsafe
 
+import os
+import sys
+import threading
 import time
 import unittest
 import weakref
@@ -15,6 +18,7 @@ from spdl.pipeline import (
     build_pipeline,
     PipelineBuilder,
     PipelineFailure,
+    run_pipeline_in_subinterpreter,
     run_pipeline_in_subprocess,
 )
 from spdl.pipeline.defs import Merge, PipelineConfig, SinkConfig
@@ -470,3 +474,123 @@ class TestContinuousPipelineValidation(unittest.TestCase):
 
         with self.assertRaisesRegex(ValueError, "Mixed continuous mode"):
             build_pipeline(merged_config, num_threads=1)
+
+
+class _RecordIDs:
+    """Pipe function that records the thread ID and process ID."""
+
+    def __init__(self) -> None:
+        self.thread_ids: list[int] = []
+        self.process_ids: list[int] = []
+
+    def __call__(self, x: int) -> int:
+        self.thread_ids.append(threading.get_ident())
+        self.process_ids.append(os.getpid())
+        return x
+
+
+class TestContinuousSubprocessPipelineReuse(unittest.TestCase):
+    def test_subprocess_pipeline_reused_across_epochs(self) -> None:
+        """Thread and process IDs stay the same across epochs, proving
+        the pipeline is reused rather than rebuilt."""
+        recorder = _RecordIDs()
+
+        backend = (
+            PipelineBuilder()
+            .add_source(SourceIterable(5), continuous=True)
+            .pipe(recorder, concurrency=1)
+            .add_sink(buffer_size=3)
+        )
+        source = run_pipeline_in_subprocess(
+            backend.get_config(),
+            num_threads=1,
+            timeout=10,
+        )
+
+        all_thread_ids: list[set[int]] = []
+        all_process_ids: list[set[int]] = []
+
+        for epoch in range(3):
+            recorder.thread_ids.clear()
+            recorder.process_ids.clear()
+            result = list(source)
+            self.assertEqual(sorted(result), [0, 1, 2, 3, 4], f"epoch {epoch}")
+            all_thread_ids.append(set(recorder.thread_ids))
+            all_process_ids.append(set(recorder.process_ids))
+
+        # All epochs should use the same thread(s) — pipeline was reused
+        self.assertEqual(
+            all_thread_ids[0],
+            all_thread_ids[1],
+            "Thread IDs changed between epoch 0 and 1 — pipeline was rebuilt",
+        )
+        self.assertEqual(
+            all_thread_ids[1],
+            all_thread_ids[2],
+            "Thread IDs changed between epoch 1 and 2 — pipeline was rebuilt",
+        )
+
+        # All epochs should run in the same subprocess
+        self.assertEqual(
+            all_process_ids[0],
+            all_process_ids[1],
+            "Process IDs changed between epoch 0 and 1",
+        )
+        self.assertEqual(
+            all_process_ids[1],
+            all_process_ids[2],
+            "Process IDs changed between epoch 1 and 2",
+        )
+
+
+@unittest.skipIf(
+    sys.version_info < (3, 14),
+    "Subinterpreters require Python 3.14+",
+)
+class TestContinuousSubinterpreterPipelineReuse(unittest.TestCase):
+    def test_subinterpreter_pipeline_reused_across_epochs(self) -> None:
+        """Thread and process IDs stay the same across epochs in subinterpreter."""
+        recorder = _RecordIDs()
+
+        config = (
+            PipelineBuilder()
+            .add_source(SourceIterable(5), continuous=True)
+            .pipe(recorder, concurrency=1)
+            .add_sink(buffer_size=3)
+            .get_config()
+        )
+        source = run_pipeline_in_subinterpreter(
+            config,
+            num_threads=1,
+            timeout=10,
+        )
+
+        all_thread_ids: list[set[int]] = []
+        all_process_ids: list[set[int]] = []
+
+        for epoch in range(3):
+            recorder.thread_ids.clear()
+            recorder.process_ids.clear()
+            result = list(source)
+            self.assertEqual(sorted(result), [0, 1, 2, 3, 4], f"epoch {epoch}")
+            all_thread_ids.append(set(recorder.thread_ids))
+            all_process_ids.append(set(recorder.process_ids))
+
+        # All epochs should use the same thread(s) — pipeline was reused
+        self.assertEqual(
+            all_thread_ids[0],
+            all_thread_ids[1],
+            "Thread IDs changed between epoch 0 and 1 — pipeline was rebuilt",
+        )
+        self.assertEqual(
+            all_thread_ids[1],
+            all_thread_ids[2],
+            "Thread IDs changed between epoch 1 and 2 — pipeline was rebuilt",
+        )
+
+        # All epochs should run in the same process (subinterpreter shares process)
+        self.assertEqual(
+            all_process_ids[0],
+            all_process_ids[1],
+            "Process IDs changed between epoch 0 and 1",
+        )


### PR DESCRIPTION
When the pipeline config has `continuous=True` on its source, the internal `_Wrapper` used by `run_pipeline_in_subprocess` and `run_pipeline_in_subinterpreter` now builds the pipeline once and reuses it across `iter()` calls via `get_iterator()`. This avoids rebuilding the thread pool and event loop each epoch, keeping threads alive across epoch boundaries inside the subprocess.

Previously, every `iter()` call on the wrapper rebuilt the pipeline from scratch, creating a new `ThreadPoolExecutor` and asyncio event loop.
For continuous sources with epoch boundary markers (`_EPOCH_END`), this was wasteful — the pipeline should stay alive and simply yield items until the next epoch boundary.

The `_has_continuous_source()` helper inspects the `PipelineConfig` tree (including `MergeConfig` sub-pipelines) to detect whether the source is continuous, and the check is performed once in `__init__`.