### PR TITLE
Add continuous iteration mode to iterate_in_subprocess

### DIFF
--- a/src/spdl/pipeline/_iter_utils/_common.py
+++ b/src/spdl/pipeline/_iter_utils/_common.py
@@ -29,6 +29,8 @@ __all__ = [
     "_enter_iteration_mode",
     "_iterate_results",
     "_execute_iterable",
+    "_execute_iterable_continuous",
+    "_drain_until_finished",
 ]
 
 T = TypeVar("T")
@@ -453,3 +455,150 @@ def _iterate_results(
                     raise RuntimeError(
                         f"[INTERNAL ERROR] Unexpected return value: {item}"
                     )
+
+
+def _drain_until_finished(
+    data_q: _Queue[_Msg[T]], timeout: float, worker_type: str
+) -> None:
+    """Drain items from the queue until ``ITERATION_FINISHED`` is found.
+
+    Used by continuous mode to discard residual items from a partially
+    consumed iteration before starting the next one.
+
+    Raises:
+        RuntimeError: If the worker fails, sends an unexpected message,
+            or does not produce any data within the timeout.
+    """
+    wtype = f"worker {worker_type}"
+    wait = min(0.1, timeout)
+    t0 = time.monotonic()
+    while True:
+        try:
+            item = data_q.get(timeout=wait)
+            t0 = time.monotonic()
+        except queue.Empty:
+            if (elapsed := time.monotonic() - t0) > timeout:
+                raise RuntimeError(
+                    f"The {wtype} did not produce any data for {elapsed:.2f} seconds."
+                ) from None
+            continue
+        else:
+            match item.status:
+                case _Status.ITERATION_FINISHED:
+                    return
+                case _Status.ITERATOR_SUCCESS:
+                    continue  # discard
+                case _Status.ITERATOR_FAILED:
+                    raise RuntimeError(f"The {wtype} quit. {item.message}")
+                case _:
+                    raise RuntimeError(
+                        f"[INTERNAL ERROR] Unexpected message while draining: {item}"
+                    )
+
+
+def _execute_iterable_continuous(
+    cmd_q: "mp.Queue[_Cmd]",
+    data_q: "mp.Queue[_Msg[T]]",
+    fn: Callable[[], Iterable[T]],
+    initializers: Sequence[Callable[[], None]] | None,
+) -> None:
+    """Worker that continuously iterates without waiting for commands.
+
+    After initialization, immediately starts iterating. After each
+    ``StopIteration``, starts the next iteration without returning to
+    stand-by. ``data_q.put()`` blocks when the queue is full, providing
+    natural backpressure. Only ``ABORT`` is checked (non-blocking, each
+    item step).
+
+    .. mermaid::
+
+       stateDiagram-v2
+           state Initialization {
+               init0: Call Initializer
+               init1: Create Iterable
+               init0 --> init1
+           }
+           state Iteration {
+               j0: Create Iterator
+               j1: Check ABORT (non-blocking)
+               j2: Get Next Item
+               j3: Push ITERATOR_SUCCESS (blocks when full)
+               j4: Push ITERATION_FINISHED
+
+               j0 --> j1
+               j1 --> j2: No command
+               j1 --> Done: ABORT
+               j2 --> j3: Success
+               j2 --> j4: StopIteration
+               j2 --> Done: Error
+               j3 --> j1
+               j4 --> j0: Start next epoch
+           }
+
+           [*] --> Initialization
+           Initialization --> Iteration: Success
+           Initialization --> Done: Fail
+           Done --> [*]
+    """
+    if initializers is not None:
+        try:
+            for initializer in initializers:
+                initializer()
+        except Exception as e:
+            data_q.put(
+                _Msg(
+                    _Status.INITIALIZATION_FAILED,
+                    message=f"Initializer failed: {e}",
+                )
+            )
+            return
+
+    try:
+        iterable = fn()
+    except Exception as e:
+        data_q.put(
+            _Msg(
+                _Status.INITIALIZATION_FAILED,
+                message=f"Failed to create the iterable: {e}",
+            )
+        )
+        return
+
+    data_q.put(_Msg(_Status.INITIALIZATION_SUCCEEDED))
+
+    # Continuous iteration loop — no stand-by, no START_ITERATION
+    while True:
+        try:
+            gen = iter(iterable)
+        except Exception as e:
+            data_q.put(
+                _Msg(
+                    _Status.ITERATOR_FAILED,
+                    message=f"Failed to create the iterator: {e}",
+                )
+            )
+            return
+
+        while True:
+            try:
+                cmd = cmd_q.get_nowait()
+            except queue.Empty:
+                pass
+            else:
+                if cmd == _Cmd.ABORT:
+                    return
+
+            try:
+                item = next(gen)
+                data_q.put(_Msg(_Status.ITERATOR_SUCCESS, message=item))
+            except StopIteration:
+                data_q.put(_Msg(_Status.ITERATION_FINISHED))
+                break
+            except Exception as e:
+                data_q.put(
+                    _Msg(
+                        _Status.ITERATOR_FAILED,
+                        message=f"Failed to fetch the next item: {e}",
+                    )
+                )
+                return

--- a/src/spdl/pipeline/_iter_utils/_subprocess.py
+++ b/src/spdl/pipeline/_iter_utils/_subprocess.py
@@ -23,8 +23,10 @@ from typing import Generic, TypeVar
 from spdl.pipeline._iter_utils._common import (
     _Cmd,
     _drain,
+    _drain_until_finished,
     _enter_iteration_mode,
     _execute_iterable,
+    _execute_iterable_continuous,
     _iterate_results,
     _Msg,
     _wait_for_init,
@@ -103,6 +105,47 @@ class _SubprocessIterable(Iterable[T]):
             self._interface = None
 
 
+class _ContinuousSubprocessIterable(Iterable[T]):
+    """Iterable backed by a continuously-iterating subprocess.
+
+    The worker produces items non-stop, separated by ``ITERATION_FINISHED``
+    markers at epoch boundaries. Each ``__iter__()`` call consumes one epoch
+    of items (up to the next ``ITERATION_FINISHED``). Items for the next
+    epoch may already be buffered in ``data_q``.
+
+    If the previous iteration was abandoned early (parent broke out of the
+    ``for`` loop), residual items are drained from ``data_q`` until the next
+    ``ITERATION_FINISHED`` before yielding items from the new epoch.
+    """
+
+    def __init__(self, interface: _ipc[T]) -> None:
+        self._interface: _ipc[T] | None = interface
+        self._finalizer = weakref.finalize(self, interface.terminate)
+        self._partially_consumed: bool = False
+
+    def __iter__(self) -> Iterator[T]:
+        if (if_ := self._interface) is None:
+            raise RuntimeError("The worker process is shutdown. Cannot iterate again.")
+
+        try:
+            # If previous iteration was abandoned early, drain residual items
+            if self._partially_consumed:
+                _drain_until_finished(if_.data_q, if_.timeout, "subprocess")
+
+            self._partially_consumed = True
+            yield from _iterate_results(if_.data_q, if_.timeout, "subprocess")
+            self._partially_consumed = False
+        except (Exception, KeyboardInterrupt):
+            self._shutdown()
+            raise
+
+    def _shutdown(self) -> None:
+        if (interface := self._interface) is not None:
+            interface.terminate()
+            self._finalizer.detach()
+            self._interface = None
+
+
 def iterate_in_subprocess(
     fn: Callable[[], Iterable[T]],
     *,
@@ -111,6 +154,7 @@ def iterate_in_subprocess(
     mp_context: str | None = None,
     timeout: float | None = None,
     daemon: bool = False,
+    continuous: bool = False,
 ) -> Iterable[T]:
     """**[Experimental]** Run the given ``iterable`` in a subprocess.
 
@@ -147,6 +191,11 @@ def iterate_in_subprocess(
         timeout: Timeout for inactivity. If the generator function does not yield
             any item for this amount of time, the process is terminated.
         daemon: Whether to run the process as a daemon. Use it only for debugging.
+        continuous: If ``True``, the worker continuously iterates without
+            waiting for commands. After each ``StopIteration``, it immediately
+            starts the next ``iter(iterable)``. ``data_q`` backpressure
+            provides flow control. This eliminates idle time at epoch
+            boundaries in multi-epoch training.
 
     Returns:
         Iterator over the results of the generator function.
@@ -168,11 +217,13 @@ def iterate_in_subprocess(
         else ([initializer] if not isinstance(initializer, Sequence) else initializer)
     )
 
+    target = _execute_iterable_continuous if continuous else _execute_iterable
+
     ctx = mp.get_context(mp_context)
     cmd_q: queue.Queue[_Cmd] = ctx.Queue()
     data_q: queue.Queue[_Msg[T]] = ctx.Queue(maxsize=buffer_size)
     process = ctx.Process(
-        target=_execute_iterable,
+        target=target,
         args=(cmd_q, data_q, fn, initializers),
         daemon=daemon,
     )
@@ -183,4 +234,6 @@ def iterate_in_subprocess(
 
     _wait_for_init(if_.data_q, if_.timeout, "subprocess")
 
+    if continuous:
+        return _ContinuousSubprocessIterable(if_)
     return _SubprocessIterable(if_)

--- a/tests/pipeline/subprocess_test.py
+++ b/tests/pipeline/subprocess_test.py
@@ -469,3 +469,222 @@ class TestIterateInSubprocessFailures(unittest.TestCase):
 
         global _VERY_BAD_REFERENCE
         _VERY_BAD_REFERENCE = iterate_in_subprocess(partial(SourceIterable, 3))
+
+
+# ---------------------------------------------------------------------------
+# Continuous mode tests
+# ---------------------------------------------------------------------------
+
+
+def _continuous_src(n: int) -> Iterable[int]:
+    return SourceIterable(n)
+
+
+class _FailsOnNthEpoch:
+    """Iterable whose iter() raises on the Nth call."""
+
+    def __init__(self, n: int, fail_epoch: int) -> None:
+        self.n = n
+        self.fail_epoch = fail_epoch
+        self.epoch = 0
+
+    def __iter__(self) -> Iterator[int]:
+        self.epoch += 1
+        if self.epoch == self.fail_epoch:
+            raise ValueError(f"Failed on epoch {self.epoch}")
+        yield from range(self.n)
+
+
+class _FailsAfterN:
+    """Iterable whose iterator raises after yielding N items."""
+
+    def __init__(self, total: int, fail_after: int) -> None:
+        self.total = total
+        self.fail_after = fail_after
+
+    def __iter__(self) -> Iterator[int]:
+        for i in range(self.total):
+            if i == self.fail_after:
+                raise ValueError(f"Failed at item {i}")
+            yield i
+
+
+def _fails_on_nth_epoch(n: int, fail_epoch: int) -> Iterable[int]:
+    return _FailsOnNthEpoch(n, fail_epoch)
+
+
+def _fails_after_n(total: int, fail_after: int) -> Iterable[int]:
+    return _FailsAfterN(total, fail_after)
+
+
+class TestContinuousIteration(unittest.TestCase):
+    def test_continuous_multi_epoch(self) -> None:
+        """continuous mode iterates correctly across multiple epochs"""
+        N = 5
+        src = iterate_in_subprocess(
+            partial(_continuous_src, N), continuous=True, timeout=10,
+        )
+
+        for epoch in range(3):
+            result = list(src)
+            self.assertEqual(result, list(range(N)), f"epoch {epoch}")
+
+    def test_continuous_single_item(self) -> None:
+        """continuous mode works with single-item epochs"""
+        src = iterate_in_subprocess(
+            partial(_continuous_src, 1), continuous=True, timeout=10,
+        )
+
+        for epoch in range(5):
+            result = list(src)
+            self.assertEqual(result, [0], f"epoch {epoch}")
+
+    def test_continuous_empty_epoch(self) -> None:
+        """continuous mode handles empty iterations (0 items)"""
+        src = iterate_in_subprocess(
+            partial(_continuous_src, 0), continuous=True, timeout=10,
+        )
+
+        for epoch in range(3):
+            result = list(src)
+            self.assertEqual(result, [], f"epoch {epoch}")
+
+    def test_continuous_abort_mid_iteration(self) -> None:
+        """deleting the iterable mid-iteration triggers clean shutdown"""
+        src = iterate_in_subprocess(
+            partial(_continuous_src, 100), continuous=True, timeout=10,
+        )
+        it = iter(src)
+        # Consume a few items then abandon
+        self.assertEqual(next(it), 0)
+        self.assertEqual(next(it), 1)
+        # Delete should trigger ABORT via finalizer — must not hang
+        del it
+        del src
+
+    def test_continuous_abort_between_epochs(self) -> None:
+        """deleting the iterable between epochs triggers clean shutdown"""
+        src = iterate_in_subprocess(
+            partial(_continuous_src, 3), continuous=True, timeout=10,
+        )
+        result = list(src)
+        self.assertEqual(result, [0, 1, 2])
+        # Delete between epochs — must not hang
+        del src
+
+    def test_continuous_early_break(self) -> None:
+        """breaking mid-epoch then iterating again gets correct next epoch"""
+        N = 10
+        src = iterate_in_subprocess(
+            partial(_continuous_src, N), continuous=True, timeout=10,
+        )
+
+        # Consume only 3 items from first epoch
+        it = iter(src)
+        for i in range(3):
+            self.assertEqual(next(it), i)
+        del it  # abandon
+
+        # Next epoch should get full correct items (not leftovers)
+        result = list(src)
+        self.assertEqual(result, list(range(N)))
+
+    def test_continuous_iteration_failure_mid_epoch(self) -> None:
+        """next() raising mid-epoch propagates error to parent"""
+        src = iterate_in_subprocess(
+            partial(_fails_after_n, total=10, fail_after=3),
+            continuous=True,
+            timeout=10,
+        )
+        it = iter(src)
+        self.assertEqual(next(it), 0)
+        self.assertEqual(next(it), 1)
+        self.assertEqual(next(it), 2)
+
+        with self.assertRaisesRegex(RuntimeError, "Failed at item 3"):
+            next(it)
+
+        # Subsequent iteration should fail — worker is dead
+        with self.assertRaisesRegex(RuntimeError, "shutdown"):
+            list(src)
+
+    def test_continuous_iter_creation_failure(self) -> None:
+        """iter(iterable) failure on 2nd epoch propagates error"""
+        src = iterate_in_subprocess(
+            partial(_fails_on_nth_epoch, n=3, fail_epoch=2),
+            continuous=True,
+            timeout=10,
+        )
+        # First epoch succeeds
+        result = list(src)
+        self.assertEqual(result, [0, 1, 2])
+
+        # Second epoch: iter() fails in worker
+        with self.assertRaisesRegex(RuntimeError, "Failed on epoch 2"):
+            list(src)
+
+        # Worker is dead
+        with self.assertRaisesRegex(RuntimeError, "shutdown"):
+            list(src)
+
+    def test_continuous_subprocess_crash(self) -> None:
+        """subprocess dying unexpectedly (e.g. segfault) raises timeout error.
+
+        When the worker process is killed, the parent should eventually get
+        a timeout error instead of hanging forever.
+        """
+        import os
+        import signal
+
+        class _CrashMidIteration:
+            """Yields a few items then kills the process."""
+
+            def __init__(self) -> None:
+                self.epoch = 0
+
+            def __iter__(self) -> Iterator[int]:
+                self.epoch += 1
+                for i in range(10):
+                    if self.epoch >= 2 and i == 5:
+                        os.kill(os.getpid(), signal.SIGKILL)
+                    yield i
+
+        def _crash_source() -> Iterable[int]:
+            return _CrashMidIteration()
+
+        src = iterate_in_subprocess(
+            _crash_source, continuous=True, timeout=3, buffer_size=1,
+        )
+
+        # Consume items until the crash causes a timeout
+        with self.assertRaisesRegex(RuntimeError, "did not produce any data"):
+            for _ in range(100):
+                list(src)
+
+    def test_continuous_backpressure(self) -> None:
+        """worker blocks on put() when buffer is full — no unbounded memory"""
+        src = iterate_in_subprocess(
+            partial(_continuous_src, 1000),
+            continuous=True,
+            timeout=10,
+            buffer_size=1,
+        )
+        # Don't consume — just let the worker fill the tiny buffer
+        time.sleep(1)
+        # Now consume — should get correct items
+        result = list(src)
+        self.assertEqual(result, list(range(1000)))
+
+    def test_continuous_with_run_pipeline_in_subprocess(self) -> None:
+        """end-to-end with PipelineBuilder + continuous=True"""
+        from spdl.pipeline import PipelineBuilder, run_pipeline_in_subprocess
+
+        builder = PipelineBuilder().add_source(SourceIterable(5)).add_sink()
+
+        src = run_pipeline_in_subprocess(
+            builder, num_threads=1, continuous=True, timeout=10,
+        )
+
+        for epoch in range(3):
+            result = list(src)
+            self.assertEqual(result, list(range(5)), f"epoch {epoch}")


### PR DESCRIPTION
Summary: Add continuous=True option to iterate_in_subprocess and run_pipeline_in_subprocess. In continuous mode, the worker subprocess iterates non-stop without waiting for START_ITERATION commands. After each StopIteration, it immediately starts the next iter(iterable). data_q backpressure (blocking put) provides natural flow control. This eliminates idle time at epoch boundaries.

Differential Revision: D101547182


