### PR TITLE
Adopt ExceptionGroup to PipelineFailure

### DIFF
--- a/src/spdl/pipeline/_components/_node.py
+++ b/src/spdl/pipeline/_components/_node.py
@@ -802,23 +802,54 @@ def _gather_error(
     return errs
 
 
-# TODO [Python 3.11]: Migrate to ExceptionGroup
-class PipelineFailure(RuntimeError):
-    """PipelineFailure()
-    Thrown by :py:class:`spdl.pipeline.Pipeline` when pipeline encounters an error.
-    """
+if sys.version_info >= (3, 11):
 
-    def __init__(self, errs: list[tuple[str, Exception]]) -> None:
-        msg = []
-        for k, v in errs:
-            e = str(v)
-            msg.append(f"{k}:{e if e else type(v).__name__}")
-        msg.sort()
+    class PipelineFailure(ExceptionGroup[Exception]):
+        """PipelineFailure()
+        Thrown by :py:class:`spdl.pipeline.Pipeline` when pipeline encounters an error.
 
-        super().__init__(", ".join(msg))
+        On Python 3.11+, this is an :py:class:`ExceptionGroup` subclass, so
+        ``except*`` and :py:meth:`~BaseExceptionGroup.subgroup` /
+        :py:meth:`~BaseExceptionGroup.split` work as expected.
+        Individual exceptions are accessible via the
+        :py:attr:`~BaseExceptionGroup.exceptions` attribute.
+        """
 
-        # This is for unittesting.
-        self._errs = errs
+        def __new__(
+            cls,
+            errs: list[tuple[str, Exception]],
+        ) -> "PipelineFailure":
+            for name, exc in errs:
+                exc.add_note(f"Pipeline stage: {name}")
+            return super().__new__(
+                cls,
+                "pipeline stages failed",
+                [e for _, e in errs],
+            )
+
+        def __init__(self, errs: list[tuple[str, Exception]]) -> None:
+            pass
+
+        def derive(  # pyre-ignore[14]
+            self, excs: Sequence[Exception]
+        ) -> "PipelineFailure":
+            return super().__new__(type(self), self.message, excs)
+
+else:
+
+    class PipelineFailure(RuntimeError):  # type: ignore[no-redef]
+        """PipelineFailure()
+        Thrown by :py:class:`spdl.pipeline.Pipeline` when pipeline encounters an error.
+        """
+
+        def __init__(self, errs: list[tuple[str, Exception]]) -> None:
+            msg = []
+            for k, v in errs:
+                e = str(v)
+                msg.append(f"{k}:{e if e else type(v).__name__}")
+            msg.sort()
+            super().__init__(", ".join(msg))
+            self.exceptions: tuple[Exception, ...] = tuple(e for _, e in errs)
 
 
 async def _run_pipeline_coroutines(

--- a/tests/pipeline/pipeline_builder_test.py
+++ b/tests/pipeline/pipeline_builder_test.py
@@ -11,6 +11,7 @@ import os
 import platform
 import random
 import re
+import sys
 import threading
 import time
 import unittest
@@ -2523,7 +2524,7 @@ class TestPipelinePropagate(unittest.TestCase):
             .add_sink()
             .build(num_threads=1)
         )
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(PipelineFailure):
             with pipeline.auto_stop():
                 pass
 
@@ -2606,3 +2607,110 @@ class TestOverrideStage(unittest.TestCase):
             .add_sink()
             .build(num_threads=1, queue_class=CheckNameQueue, stage_id=ref)
         )
+
+
+class TestPipelineFailureStructure(unittest.TestCase):
+    def _build_failing_pipeline(self):
+        def failing_range(n):
+            yield from range(n)
+            raise ValueError("Iterator failed")
+
+        return (
+            PipelineBuilder()
+            .add_source(failing_range(3))
+            .pipe(passthrough)
+            .add_sink(1000)
+            .build(num_threads=1)
+        )
+
+    def test_pipeline_failure_is_exception_group(self) -> None:
+        pipeline = self._build_failing_pipeline()
+
+        with self.assertRaises(PipelineFailure) as ctx:
+            with pipeline.auto_stop():
+                list(pipeline.get_iterator(timeout=10))
+
+        pf = ctx.exception
+        if sys.version_info >= (3, 11):
+            self.assertIsInstance(pf, ExceptionGroup)
+        else:
+            self.assertIsInstance(pf, RuntimeError)
+        self.assertGreaterEqual(len(pf.exceptions), 1)
+        exception_types = {type(e) for e in pf.exceptions}
+        self.assertTrue(exception_types & {ValueError})
+
+    def test_pipeline_failure_individual_exceptions(self) -> None:
+        def failing_range(n):
+            yield from range(n)
+            raise TypeError("source failed")
+
+        pipeline = (
+            PipelineBuilder()
+            .add_source(failing_range(3))
+            .pipe(passthrough)
+            .add_sink(1000)
+            .build(num_threads=1)
+        )
+
+        with self.assertRaises(PipelineFailure) as ctx:
+            with pipeline.auto_stop():
+                list(pipeline.get_iterator(timeout=10))
+
+        pf = ctx.exception
+        if sys.version_info >= (3, 11):
+            self.assertIsInstance(pf, ExceptionGroup)
+        else:
+            self.assertIsInstance(pf, RuntimeError)
+        self.assertGreaterEqual(len(pf.exceptions), 1)
+        self.assertTrue(
+            any(isinstance(e, TypeError) for e in pf.exceptions),
+        )
+
+    @unittest.skipIf(sys.version_info < (3, 11), "ExceptionGroup requires Python 3.11+")
+    def test_pipeline_failure_subgroup(self) -> None:
+        def failing_range(n):
+            yield from range(n)
+            raise ValueError("Iterator failed")
+
+        pipeline = (
+            PipelineBuilder()
+            .add_source(failing_range(3))
+            .pipe(passthrough)
+            .add_sink(1000)
+            .build(num_threads=1)
+        )
+
+        with self.assertRaises(PipelineFailure) as ctx:
+            with pipeline.auto_stop():
+                list(pipeline.get_iterator(timeout=10))
+
+        pf = ctx.exception
+        sub = pf.subgroup(ValueError)
+        self.assertIsNotNone(sub)
+        self.assertIsInstance(sub, PipelineFailure)
+        self.assertTrue(all(isinstance(e, ValueError) for e in sub.exceptions))
+
+    @unittest.skipIf(sys.version_info < (3, 11), "ExceptionGroup requires Python 3.11+")
+    def test_pipeline_failure_notes_contain_stage_name(self) -> None:
+        def failing_range(n):
+            yield from range(n)
+            raise ValueError("Iterator failed")
+
+        pipeline = (
+            PipelineBuilder()
+            .add_source(failing_range(3))
+            .pipe(passthrough)
+            .add_sink(1000)
+            .build(num_threads=1)
+        )
+
+        with self.assertRaises(PipelineFailure) as ctx:
+            with pipeline.auto_stop():
+                list(pipeline.get_iterator(timeout=10))
+
+        pf = ctx.exception
+        for exc in pf.exceptions:
+            notes = getattr(exc, "__notes__", [])
+            self.assertTrue(
+                any(note.startswith("Pipeline stage:") for note in notes),
+            )

--- a/tests/pipeline/pipeline_failure_exceptstar_test.py
+++ b/tests/pipeline/pipeline_failure_exceptstar_test.py
@@ -1,0 +1,51 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-unsafe
+
+"""Tests for PipelineFailure using ``except*`` syntax (Python 3.11+ only).
+
+This file is separated from pipeline_builder_test.py because ``except*`` is a
+syntactic construct that causes SyntaxError on Python < 3.11 at import time,
+which would prevent the entire module from loading.
+"""
+
+import sys
+import unittest
+
+if sys.version_info < (3, 11):
+    raise unittest.SkipTest("except* syntax requires Python 3.11+")
+
+from spdl.pipeline import PipelineBuilder
+
+
+def passthrough(x):
+    return x
+
+
+class TestPipelineFailureExceptStar(unittest.TestCase):
+    def test_pipeline_failure_except_star(self) -> None:
+        def failing_range(n):
+            yield from range(n)
+            raise ValueError("Iterator failed")
+
+        pipeline = (
+            PipelineBuilder()
+            .add_source(failing_range(3))
+            .pipe(passthrough)
+            .add_sink(1000)
+            .build(num_threads=1)
+        )
+
+        caught = []
+        try:
+            with pipeline.auto_stop():
+                list(pipeline.get_iterator(timeout=10))
+        except* ValueError as eg:
+            caught.extend(eg.exceptions)
+
+        self.assertGreaterEqual(len(caught), 1)
+        self.assertIsInstance(caught[0], ValueError)


### PR DESCRIPTION
Migrate `PipelineFailure` to subclass `ExceptionGroup` on Python 3.11+ while maintaining backward compatibility with 3.10 via a `RuntimeError` fallback.

On 3.11+, `PipelineFailure` now leverages native `ExceptionGroup` features: `.exceptions` for accessing individual errors, `.message` for the group message, and support for `except*` syntax and `.subgroup()`/`.split()` methods. The `derive()` method bypasses custom `__new__` to avoid reconstruction overhead.