### PR TITLE
Simplify pipeline management in LLM example

### DIFF
--- a/docs/source/getting_started/intro.rst
+++ b/docs/source/getting_started/intro.rst
@@ -36,6 +36,20 @@ perform the operations in an async event loop in a background thread.
 Running a Pipeline
 ------------------
 
+.. note::
+
+   The v0.4.0 introduced the experimental automatic start and stop.
+   The :py:meth:`Pipeline.get_item` method ensures that the background
+   thread is started, and the :py:meth:`Pipeline.stop` method is called
+   when the Pipeline object is garbage collected.
+
+   You should be simply able to do ``for item in pipeline:``.
+   Please file an issue if you find any problems with the automatic start
+   and stop.
+
+   If you need to control the resource usage, then you can explicitly call
+   :py:meth:`start` and `stop`.
+
 To run the pipeline, call :py:meth:`Pipeline.start`.
 Once the pipeline starts executing, you can iterate on the pipeline.
 Finally call :py:meth:`Pipeline.stop` to stop the background thread.

--- a/examples/llm_finetune/utils/pipeline.py
+++ b/examples/llm_finetune/utils/pipeline.py
@@ -11,15 +11,12 @@
 from __future__ import annotations
 
 import threading
-import weakref
-from collections.abc import Iterator
 from typing import TYPE_CHECKING
 
 import spdl.pipeline
 import spdl.source.utils
 from spdl.io import transfer_tensor
-from spdl.pipeline import build_pipeline, Pipeline, PipelineBuilder
-from spdl.pipeline.defs import PipelineConfig
+from spdl.pipeline import PipelineBuilder
 from spdl.source import DistributedRandomSampler
 
 from .utils import _collate, _TDataLoader, _tokenize_sample, _TSample
@@ -86,29 +83,6 @@ class _Tokenize:
 
     def __call__(self, sample: dict[str, str]) -> _TSample:
         return _tokenize_sample(sample, self._tlt.tokenizer, self.max_seq_len)
-
-
-def _stop_pipeline(pipeline: Pipeline) -> None:
-    """Stop a pipeline and wait for it to finish."""
-    pipeline.stop(timeout=10)
-
-
-class _SPDLDataLoader:
-    """Wraps a continuous Pipeline to match the PyTorch DataLoader interface.
-
-    Each ``for batch in dl:`` loop consumes one epoch (up to the next
-    epoch boundary marker). The pipeline stays alive across epochs.
-    The pipeline is automatically stopped when this object is garbage
-    collected.
-    """
-
-    def __init__(self, cfg: PipelineConfig[_TSample]) -> None:
-        self._pipeline: Pipeline[_TSample] = build_pipeline(cfg, num_threads=1)
-        self._pipeline.start()
-        self._finalizer = weakref.finalize(self, _stop_pipeline, self._pipeline)
-
-    def __iter__(self) -> Iterator[_TSample]:
-        return self._pipeline.get_iterator(timeout=120)
 
 
 def build_spdl_dataloader(
@@ -178,4 +152,4 @@ def build_spdl_dataloader(
         .pipe(transfer_tensor)
         .add_sink(buffer_size=3)
     )
-    return _SPDLDataLoader(frontend.get_config())
+    return frontend.build(num_threads=1)

--- a/src/spdl/pipeline/_build.py
+++ b/src/spdl/pipeline/_build.py
@@ -291,8 +291,10 @@ class _Wrapper(Generic[U]):
         self.queue_class = queue_class
         self.task_hook_factory = task_hook_factory
         self.background_tasks = background_tasks
-        self._continuous: bool = _has_continuous_source(config)
         self._pipeline: Pipeline[U] | None = None
+        if _has_continuous_source(config):
+            self._pipeline = self._build()
+            self._pipeline.start()
 
     def _build(self) -> Pipeline[U]:
         return build_pipeline(
@@ -305,20 +307,10 @@ class _Wrapper(Generic[U]):
             background_tasks=self.background_tasks,
         )
 
-    def _get_reusable_pipeline(self) -> Pipeline[U]:
-        assert self._continuous
-        if self._pipeline is None:
-            self._pipeline = self._build()
-            self._pipeline.start()
-        assert self._pipeline is not None
-        return self._pipeline
-
     def __iter__(self) -> Iterator[U]:
-        if self._continuous:
-            # Reuse the same pipeline across iterations. Build once on
-            # first iter, then use get_iterator() per epoch. This avoids
-            # rebuilding the thread pool and event loop each epoch.
-            yield from self._get_reusable_pipeline().get_iterator()
+        if (pipeline := self._pipeline) is not None:
+            # The pipeline is in continuous mode. It is already running.
+            yield from pipeline
         else:
             pipeline = self._build()
             with pipeline.auto_stop():

--- a/src/spdl/pipeline/_pipeline.py
+++ b/src/spdl/pipeline/_pipeline.py
@@ -179,25 +179,6 @@ class _EventLoop:
         return asyncio.run_coroutine_threadsafe(coro, self._loop)  # pyre-ignore[6]
 
 
-def _ensure_stopped(event_loop: _EventLoop) -> None:
-    """Stop the pipeline if running."""
-    # Check if the event loop was actually started by checking the thread
-    if event_loop.is_started() and not event_loop.is_task_completed():
-        warnings.warn(
-            "Pipeline is running in the background, but "
-            "there is no valid reference pointing the foreground object. "
-            "Stopping the background thread. "
-            "It is strongly advised to stop the pipeline explicitly, "
-            "using the `auto_stop` context manager. "
-            "If you are using a framework and you cannot use the "
-            "context manager, try calling `stop` in done callback and "
-            "error callback.",
-            stacklevel=1,
-        )
-        event_loop.stop()
-        event_loop.join()
-
-
 ################################################################################
 # Pipeline
 ################################################################################
@@ -210,6 +191,174 @@ class _EventLoopState(IntEnum):
 
 
 _EOF_MSG: str = "Reached the end of the pipeline."
+
+
+class _PipelineImpl(Generic[T]):
+    """Internal implementation of the data processing pipeline.
+
+    Use :py:class:`Pipeline` (the public facade) instead.
+    """
+
+    def __init__(
+        self,
+        coro: Coroutine[None, None, None],
+        output_queue: AsyncQueue,
+        executor: ThreadPoolExecutor,
+        *,
+        desc: str,
+    ) -> None:
+        self._str: str = "\n".join([repr(self), desc])
+
+        self._output_queue: AsyncQueue = output_queue
+        self._event_loop = _EventLoop(coro, executor)
+        self._event_loop_state: _EventLoopState = _EventLoopState.NOT_STARTED
+
+    def __str__(self) -> str:
+        return self._str
+
+    def start(self, *, timeout: float | None = None, **kwargs: Any) -> None:
+        """Start the pipeline in background thread.
+
+        Args:
+            timeout: Timeout value used when starting the thread and
+                waiting for the pipeline to be initialized. [Unit: second]
+
+        .. note::
+
+           Calling ``start`` multiple times raises ``RuntimeError``.
+        """
+        if self._event_loop_state >= _EventLoopState.STARTED:
+            raise RuntimeError("The pipeline was already started.")
+
+        self._event_loop.start(timeout=timeout, **kwargs)
+        self._event_loop_state = _EventLoopState.STARTED
+
+    def stop(self, *, timeout: float | None = None) -> None:
+        """Stop the pipeline.
+
+        Args:
+            timeout: Timeout value used when stopping the pipeline and
+                waiting for the thread to join. [Unit: second]
+
+        .. note::
+
+           It is safe to call ``stop`` multiple times.
+        """
+        if _EventLoopState.STARTED <= self._event_loop_state < _EventLoopState.STOPPED:
+            self._event_loop.stop()
+
+            # Try to join first. If it doesn't join, drain the output queue
+            # to resolve the congestion, then retry.
+            # (e.g. the frontend does not consume any data, thus the upstream tasks
+            # are not able to complete),
+            to1: float = 3 if timeout is None else min(3, timeout)
+            to2: float | None = None if timeout is None else timeout - to1
+            try:
+                self._event_loop.join(timeout=to1)
+            except TimeoutError:
+                # Empty queue, release backpressure
+                while not self._output_queue.empty():
+                    try:
+                        self._output_queue.get_nowait()
+                    except Exception:
+                        break
+                self._event_loop.join(timeout=to2)
+            self._event_loop_state = _EventLoopState.STOPPED
+
+        if self._event_loop._task_exception is not None:
+            raise self._event_loop._task_exception
+
+    def get_item(self, *, timeout: float | None = None) -> T:
+        """Get the next item.
+
+        Args:
+            timeout: The duration to wait for the next item to become available. [Unit: second]
+                If ``None`` (default), it waits indefinitely.
+
+        Raises:
+            RuntimeError: The pipeline is not started.
+
+            TimeoutError: When pipeline is not producing the next item within the given time.
+
+            EOFError: When the pipeline is exhausted or cancelled and there are no more items
+                in the sink.
+        """
+        item = self._get_item(timeout=timeout)
+        if is_epoch_end(item):
+            raise EOFError(_EOF_MSG)
+        return item
+
+    def _get_item(self, *, timeout: float | None) -> T:
+        if not self._event_loop.is_started():
+            raise RuntimeError("Pipeline is not started.")
+
+        # The event loop (thread) was started, but it might be stopped by now.
+        # However, what matters for `get_item` method is whether the task is running or not.
+        # Because if the task is running, then accessing the sink queue must be done through
+        # async method, invoked via event loop's `run_coroutine_threadsafe` method.
+        # If the task is not running, then, sync method can be used to access sink queue,
+        # even if the loop is not running.
+
+        if self._event_loop.is_task_completed():
+            # The pipeline is stopped.
+            # The sink queue is not accessed by background event loop anymore, so we can use
+            # sync access without being worried about thread safety.
+
+            # There are remaining items in the queue if the pipeline was stopped by client code
+            # before it processes all the items.
+            if not self._output_queue.empty():
+                return self._output_queue.get_nowait()
+
+            # Now, all the items from the queue are fetched. We can stop the pipeline loop/thread.
+            self._event_loop.stop()
+            raise EOFError(_EOF_MSG)
+
+        # The task is not completed. To access the sink queue, the async method must be used.
+        # The loop keeps running unless we explicitly request stop, so the use of async method
+        # itself is fine.
+
+        # However, the background task can complete at any point.
+        # It turned out to be very easy to hit the race condition where the foreground execution
+        # control reaches here, in the short time window between the background thread puts the
+        # last item and issues task completion.
+        # In this case, without timeout, the foreground gets stuck.
+        # Therefore, we split the timeout into small window and periodically check the state of
+        # the background task.
+        max_elapsed = float("inf") if timeout is None else timeout
+
+        future = self._event_loop.run_coroutine_threadsafe(self._output_queue.get())
+        t0 = time.monotonic()
+        while (elapsed := time.monotonic() - t0) < max_elapsed:
+            try:
+                return future.result(timeout=min(0.1, max_elapsed))
+            except concurrent.futures.TimeoutError:
+                # The sink queue is empty.
+                # In this condition, we cannot really tell if it is due to EOF or
+                # pipeline being too slow.
+
+                # One exception is that the task is now complete and queue is still empty.
+                # This case we can switch to EOFError.
+                if self._event_loop.is_task_completed() and self._output_queue.empty():
+                    self._event_loop.stop()
+                    raise EOFError(_EOF_MSG) from None
+
+        _LG.debug("EventLoop: %s", str(self._event_loop))
+
+        raise TimeoutError(f"The next item is not available after {elapsed:.1f} sec.")
+
+
+################################################################################
+# Pipeline (Public Facade)
+################################################################################
+
+_STOP_TIMEOUT: float = 10.0
+
+
+def _stop_impl(impl: _PipelineImpl[Any]) -> None:
+    try:
+        impl.stop(timeout=_STOP_TIMEOUT)
+    except Exception:
+        _LG.debug("Exception during automatic pipeline shutdown.", exc_info=True)
 
 
 class Pipeline(Generic[T]):
@@ -295,6 +444,20 @@ class Pipeline(Generic[T]):
                for item in pipeline.get_iterator(timeout=30):
                    # do something with the decoded image
                    ...
+
+    When the ``Pipeline`` object is garbage collected, the background thread is
+    automatically stopped. You can still use :py:meth:`auto_stop` or
+    :py:meth:`stop` for deterministic, scoped lifecycle management.
+
+    .. versionchanged:: 0.4.0
+
+       **[Experimental]** Calling :py:meth:`start` and :py:meth:`stop` is now
+       optional. When iterating a pipeline that has not been explicitly started,
+       the background thread is started automatically on the first item request.
+       When the ``Pipeline`` object is garbage collected, the background thread
+       is stopped automatically via :py:func:`weakref.finalize`.
+       Explicit :py:meth:`start` / :py:meth:`stop` and the :py:meth:`auto_stop`
+       context manager continue to work as before.
     """
 
     def __init__(
@@ -305,18 +468,13 @@ class Pipeline(Generic[T]):
         *,
         desc: str,
     ) -> None:
-        self._str: str = "\n".join([repr(self), desc])
-
-        self._output_queue: AsyncQueue = output_queue
-        self._event_loop = _EventLoop(coro, executor)
-        self._event_loop_state: _EventLoopState = _EventLoopState.NOT_STARTED
-
-        self._finalizer = weakref.finalize(self, _ensure_stopped, self._event_loop)
-
-        log_api_usage_once("spdl.pipeline.Pipeline")
+        self._impl: _PipelineImpl[T] = _PipelineImpl(
+            coro, output_queue, executor, desc=desc
+        )
+        self._finalizer = weakref.finalize(self, _stop_impl, self._impl)
 
     def __str__(self) -> str:
-        return self._str
+        return str(self._impl)
 
     def start(self, *, timeout: float | None = None, **kwargs: Any) -> None:
         """Start the pipeline in background thread.
@@ -329,11 +487,7 @@ class Pipeline(Generic[T]):
 
            Calling ``start`` multiple times raises ``RuntimeError``.
         """
-        if self._event_loop_state >= _EventLoopState.STARTED:
-            raise RuntimeError("The pipeline was already started.")
-
-        self._event_loop.start(timeout=timeout, **kwargs)
-        self._event_loop_state = _EventLoopState.STARTED
+        self._impl.start(timeout=timeout, **kwargs)
 
     def stop(self, *, timeout: float | None = None) -> None:
         """Stop the pipeline.
@@ -346,37 +500,16 @@ class Pipeline(Generic[T]):
 
            It is safe to call ``stop`` multiple times.
         """
-        if _EventLoopState.STARTED <= self._event_loop_state < _EventLoopState.STOPPED:
-            self._event_loop.stop()
-
-            # Try to join first. If it doesn't join, drain the output queue
-            # to resolve the congestion, then retry.
-            # (e.g. the frontend does not consume any data, thus the upstream tasks
-            # are not able to complete),
-            to1: float = 3 if timeout is None else min(3, timeout)
-            to2: float | None = None if timeout is None else timeout - to1
-            try:
-                self._event_loop.join(timeout=to1)
-            except TimeoutError:
-                # Empty queue, release backpressure
-                while not self._output_queue.empty():
-                    try:
-                        self._output_queue.get_nowait()
-                    except Exception:
-                        break
-                self._event_loop.join(timeout=to2)
-            self._event_loop_state = _EventLoopState.STOPPED
-            self._finalizer.detach()
-
-        if self._event_loop._task_exception is not None:
-            raise self._event_loop._task_exception
+        self._impl.stop(timeout=timeout)
+        self._finalizer.detach()
 
     @contextmanager
     def auto_stop(self, *, timeout: float | None = None) -> Iterator[None]:
         """Context manager to start/stop the background thread automatically.
 
         Args:
-            timeout: The duration to wait for the thread initialization / shutdown. [Unit: second]
+            timeout: The duration to wait for the thread
+                initialization / shutdown. [Unit: second]
                 If ``None`` (default), it waits indefinitely.
         """
         self.start(timeout=timeout)
@@ -400,68 +533,12 @@ class Pipeline(Generic[T]):
             EOFError: When the pipeline is exhausted or cancelled and there are no more items
                 in the sink.
         """
-        item = self._get_item(timeout=timeout)
-        if is_epoch_end(item):
-            raise EOFError(_EOF_MSG)
-        return item
-
-    def _get_item(self, *, timeout: float | None) -> T:
-        if not self._event_loop.is_started():
-            raise RuntimeError("Pipeline is not started.")
-
-        # The event loop (thread) was started, but it might be stopped by now.
-        # However, what matters for `get_item` method is whether the task is running or not.
-        # Because if the task is running, then accessing the sink queue must be done through
-        # async method, invoked via event loop's `run_coroutine_threadsafe` method.
-        # If the task is not running, then, sync method can be used to access sink queue,
-        # even if the loop is not running.
-
-        if self._event_loop.is_task_completed():
-            # The pipeline is stopped.
-            # The sink queue is not accessed by background event loop anymore, so we can use
-            # sync access without being worried about thread safety.
-
-            # There are remaining items in the queue if the pipeline was stopped by client code
-            # before it processes all the items.
-            if not self._output_queue.empty():
-                return self._output_queue.get_nowait()
-
-            # Now, all the items from the queue are fetched. We can stop the pipeline loop/thread.
-            self._event_loop.stop()
-            raise EOFError(_EOF_MSG)
-
-        # The task is not completed. To access the sink queue, the async method must be used.
-        # The loop keeps running unless we explicitly request stop, so the use of async method
-        # itself is fine.
-
-        # However, the background task can complete at any point.
-        # It turned out to be very easy to hit the race condition where the foreground execution
-        # control reaches here, in the short time window between the background thread puts the
-        # last item and issues task completion.
-        # In this case, without timeout, the foreground gets stuck.
-        # Therefore, we split the timeout into small window and periodically check the state of
-        # the background task.
-        max_elapsed = float("inf") if timeout is None else timeout
-
-        future = self._event_loop.run_coroutine_threadsafe(self._output_queue.get())
-        t0 = time.monotonic()
-        while (elapsed := time.monotonic() - t0) < max_elapsed:
-            try:
-                return future.result(timeout=min(0.1, max_elapsed))
-            except concurrent.futures.TimeoutError:
-                # The sink queue is empty.
-                # In this condition, we cannot really tell if it is due to EOF or
-                # pipeline being too slow.
-
-                # One exception is that the task is now complete and queue is still empty.
-                # This case we can switch to EOFError.
-                if self._event_loop.is_task_completed() and self._output_queue.empty():
-                    self._event_loop.stop()
-                    raise EOFError(_EOF_MSG) from None
-
-        _LG.debug("EventLoop: %s", str(self._event_loop))
-
-        raise TimeoutError(f"The next item is not available after {elapsed:.1f} sec.")
+        # Ensure that the pipeline is started before accessing the sink queue.
+        # Note: This check-then-start pattern is not thread-safe, but `get_item` is not
+        # it is not supposed to be called from multiple threads.
+        if self._impl._event_loop_state == _EventLoopState.NOT_STARTED:
+            self._impl.start()
+        return self._impl.get_item(timeout=timeout)
 
     def get_iterator(self, *, timeout: float | None = None) -> Iterator[T]:
         """Get an iterator, which iterates over the pipeline outputs.

--- a/src/spdl/pipeline/_profile.py
+++ b/src/spdl/pipeline/_profile.py
@@ -215,7 +215,7 @@ def _profile_pipe(
             qps_, outputs = _run(pipeline)
 
         occupancy_rate = (
-            pipeline._output_queue._get_lap_stats().occupancy_rate  # pyre-ignore[16]
+            pipeline._impl._output_queue._get_lap_stats().occupancy_rate  # pyre-ignore[16]
         )
         _LG.info(" - Concurrency: %d", concurrency)
         _LG.info(" - QPS: %.2f", qps_)

--- a/tests/pipeline/pipeline_builder_test.py
+++ b/tests/pipeline/pipeline_builder_test.py
@@ -1256,8 +1256,6 @@ class TestPipelineNoop(unittest.TestCase):
         """AsyncPipeline2 functions without pipe."""
 
         apl = PipelineBuilder().add_source(range(10)).add_sink(1).build(num_threads=1)
-        with self.assertRaises(RuntimeError):
-            apl.get_item(timeout=1)
 
         with apl.auto_stop():
             for i in range(10):
@@ -1282,8 +1280,6 @@ class TestPipelinePassthrough(unittest.TestCase):
             .add_sink(1)
             .build(num_threads=1)
         )
-        with self.assertRaises(RuntimeError):
-            apl.get_item(timeout=1)
 
         with apl.auto_stop():
             for i in range(10):
@@ -1334,8 +1330,6 @@ class TestPipelineLambda(unittest.TestCase):
             .add_sink(1)
             .build(num_threads=1)
         )
-        with self.assertRaises(RuntimeError):
-            apl.get_item(timeout=1)
 
         with apl.auto_stop():
             for i in range(10):
@@ -1611,9 +1605,6 @@ class TestPipelineFail(unittest.TestCase):
             .add_sink(1)
             .build(num_threads=1)
         )
-
-        with self.assertRaises(RuntimeError):
-            apl.get_item(timeout=1)
 
         with self.assertRaises(PipelineFailure):
             with apl.auto_stop():

--- a/tests/pipeline/pipeline_cleanup_test.py
+++ b/tests/pipeline/pipeline_cleanup_test.py
@@ -17,8 +17,8 @@ class TestPipelineCleanup(unittest.TestCase):
     """Test class for Pipeline cleanup functionality."""
 
     def test_cleanup_called_on_garbage_collection(self) -> None:
-        """Test that _cleanup_pipeline is called implicitly during garbage collection
-        when Pipeline is not explicitly stopped."""
+        """Test that the pipeline background thread is automatically stopped
+        on garbage collection without warnings."""
 
         # Setup: Create a pipeline and start it
         pipeline = (
@@ -28,10 +28,13 @@ class TestPipelineCleanup(unittest.TestCase):
         pipeline.start(timeout=3)
 
         # Verify the pipeline is running
-        self.assertTrue(pipeline._event_loop.is_started())
+        self.assertTrue(pipeline._impl._event_loop.is_started())
+
+        # Keep a reference to the impl to verify it stopped
+        impl = pipeline._impl
 
         # Execute: Delete the pipeline reference without calling stop()
-        # This should trigger the weakref.finalize cleanup
+        # The facade's finalizer should cleanly stop the pipeline
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
 
@@ -39,18 +42,16 @@ class TestPipelineCleanup(unittest.TestCase):
             del pipeline
             gc.collect()
 
-            # Assert: Verify that a warning was issued from the cleanup function
-            # The cleanup function should warn when stopping an implicitly stopped pipeline
+            # Assert: No warning should be issued — the facade handles cleanup
             cleanup_warnings = [
                 warning
                 for warning in w
                 if "Pipeline is running in the background" in str(warning.message)
             ]
-            self.assertGreaterEqual(len(cleanup_warnings), 1)
-            self.assertIn(
-                "Stopping the background thread",
-                str(cleanup_warnings[0].message),
-            )
+            self.assertEqual(len(cleanup_warnings), 0)
+
+        # Verify the background thread actually stopped
+        self.assertTrue(impl._event_loop.is_task_completed())
 
     def test_cleanup_not_called_when_explicitly_stopped(self) -> None:
         """Test that _cleanup_pipeline is not called when Pipeline is explicitly stopped."""
@@ -112,3 +113,91 @@ class TestPipelineCleanup(unittest.TestCase):
                 if "Pipeline is running in the background" in str(warning.message)
             ]
             self.assertEqual(len(cleanup_warnings), 0)
+
+    def test_auto_start_and_cleanup_without_explicit_start_stop(self) -> None:
+        """Test that iterating a pipeline without calling start/stop works:
+        the background thread is started automatically on first iteration,
+        and the finalizer cleans it up on garbage collection."""
+
+        pipeline = (
+            PipelineBuilder().add_source(range(10)).add_sink(1000).build(num_threads=1)
+        )
+
+        # Pipeline should not be started yet
+        self.assertFalse(pipeline._impl._event_loop.is_started())
+
+        # Iterate without explicit start — auto-start should kick in
+        items = []
+        for item in pipeline:
+            items.append(item)
+
+        # Verify auto-start happened
+        self.assertTrue(pipeline._impl._event_loop.is_started())
+        self.assertEqual(sorted(items), list(range(10)))
+
+        # Keep a reference to the impl to verify cleanup
+        impl = pipeline._impl
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+
+            del pipeline
+            gc.collect()
+
+            cleanup_warnings = [
+                warning
+                for warning in w
+                if "Pipeline is running in the background" in str(warning.message)
+            ]
+            self.assertEqual(len(cleanup_warnings), 0)
+
+        # Verify the impl was stopped (stop was called by finalizer)
+        self.assertTrue(impl._event_loop.is_task_completed())
+
+    def test_auto_start_and_cleanup_continuous_source(self) -> None:
+        """Test auto start/stop with a continuous source iterated multiple times.
+
+        With continuous=True the source re-iterates, injecting epoch boundary
+        sentinels. Each ``for ... in pipeline`` consumes one epoch. The pipeline
+        should auto-start on the first epoch and remain running across epochs,
+        then clean up on garbage collection."""
+
+        pipeline = (
+            PipelineBuilder()
+            .add_source(range(5), continuous=True)
+            .add_sink(1000)
+            .build(num_threads=1)
+        )
+
+        self.assertFalse(pipeline._impl._event_loop.is_started())
+
+        num_epochs = 3
+        all_epoch_items = []
+        for _ in range(num_epochs):
+            epoch_items = []
+            for item in pipeline:
+                epoch_items.append(item)
+            all_epoch_items.append(sorted(epoch_items))
+
+        # Verify auto-start happened and each epoch produced the same items
+        self.assertTrue(pipeline._impl._event_loop.is_started())
+        for epoch_items in all_epoch_items:
+            self.assertEqual(epoch_items, list(range(5)))
+
+        # Verify cleanup on garbage collection
+        impl = pipeline._impl
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+
+            del pipeline
+            gc.collect()
+
+            cleanup_warnings = [
+                warning
+                for warning in w
+                if "Pipeline is running in the background" in str(warning.message)
+            ]
+            self.assertEqual(len(cleanup_warnings), 0)
+
+        self.assertTrue(impl._event_loop.is_task_completed())


### PR DESCRIPTION
With the changes https://github.com/facebookresearch/spdl/pull/1373 and https://github.com/facebookresearch/spdl/pull/1375, we no longer need to explicitly start pipeline.

This allows to simply do `for item in pipeline:`.

Simplifies the example as such