### PR TITLE
[SPDL] Add thread-based AsyncQueue for low-latency pipeline sink handoff

### DIFF
--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -24,3 +24,4 @@ Examples
    benchmark_wav
    benchmark_tarfile
    benchmark_video
+   benchmark_thread_output_queue

--- a/examples/benchmark_thread_output_queue.py
+++ b/examples/benchmark_thread_output_queue.py
@@ -1,0 +1,206 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""Benchmark: SPDL pipeline handoff latency with and without thread output queue.
+
+Compares main-thread ``get_item`` latency between the default asyncio-based
+handoff (``run_coroutine_threadsafe`` + ``Future.result`` polling) and the
+``queue.Queue``-based handoff (direct ``queue.Queue.get``).
+
+The benchmark emulates a realistic training loop: each iteration the
+foreground thread receives a batch, does simulated work (busy-wait to
+mimic a GPU forward/backward pass), and then times how long the *next*
+``get_item`` call takes.  When the simulated work is long enough the
+producer has time to pre-fill the queue, so the handoff latency
+isolates the cross-thread scheduling overhead.
+
+Foreground work is swept from 0ms to 30ms in 3ms steps.
+
+Usage::
+
+    buck2 run //spdl/examples:benchmark_thread_output_queue
+
+Example results (devserver, no GPU, 500 lightweight int items)::
+
+    FG work   default (p50)   default (p99)   thread_q (p50)   thread_q (p99)
+    -------   -------------   -------------   --------------   --------------
+      0ms         199us           625us           116us            313us
+      3ms         246us           642us           223us            646us
+      6ms         232us           532us           190us            555us
+      9ms         287us           485us           153us            549us
+     12ms         280us           822us            14us            464us
+     15ms         221us           396us             8us            385us
+     18ms         227us           431us             9us             70us
+     21ms         224us           450us            11us             41us
+     24ms         240us           533us            12us             34us
+     27ms         227us           470us            12us             27us
+     30ms         242us           512us            12us             26us
+
+The default asyncio path stays flat at ~220-280us regardless of overlap
+time — that is the fixed ``run_coroutine_threadsafe`` scheduling tax.
+The thread output queue drops to ~8-14us once the foreground work is
+long enough (>= ~12ms on this machine) for the producer to pre-fill it.
+"""
+
+from __future__ import annotations
+
+import statistics
+import time
+from dataclasses import dataclass, field
+
+from spdl.pipeline import PipelineBuilder
+
+__all__ = ["BenchResult", "main"]
+
+
+@dataclass
+class BenchResult:
+    """Collected latency measurements for a single benchmark run."""
+
+    name: str
+    latencies_us: list[float] = field(default_factory=list)
+
+    @property
+    def p50(self) -> float:
+        s = sorted(self.latencies_us)
+        return s[len(s) // 2]
+
+    @property
+    def p95(self) -> float:
+        s = sorted(self.latencies_us)
+        return s[int(len(s) * 0.95)]
+
+    @property
+    def p99(self) -> float:
+        s = sorted(self.latencies_us)
+        return s[int(len(s) * 0.99)]
+
+    @property
+    def mean(self) -> float:
+        return statistics.mean(self.latencies_us)
+
+    def summary(self) -> str:
+        """Return a one-line summary string with mean/p50/p95/p99."""
+        return (
+            f"{self.name:<50s}  "
+            f"mean={self.mean:>9.1f}us  "
+            f"p50={self.p50:>9.1f}us  "
+            f"p95={self.p95:>9.1f}us  "
+            f"p99={self.p99:>9.1f}us  "
+            f"({len(self.latencies_us)} meas)"
+        )
+
+
+def _busy_wait_us(us: float) -> None:
+    """Busy-wait for *us* microseconds (spin-loop)."""
+    deadline = time.perf_counter() + us / 1e6
+    while time.perf_counter() < deadline:
+        pass
+
+
+def _run_bench(
+    name: str,
+    n_items: int,
+    buffer_size: int,
+    use_thread_output_queue: bool,
+    work_us: float,
+    warmup: int = 20,
+) -> BenchResult:
+    """Run a single benchmark: source -> sink pipeline with foreground work.
+
+    Builds a trivial pipeline (source of *n_items* integers -> sink) and
+    iterates it.  Between each consumed item the foreground thread
+    busy-waits for *work_us* microseconds to simulate consumer-side
+    compute (e.g. a GPU training step).  After warmup, the time spent
+    inside each ``get_item`` call is recorded.
+
+    Args:
+        name: Human-readable label for the result.
+        n_items: Total number of items the source produces.
+        buffer_size: Sink buffer size (number of slots).
+        use_thread_output_queue: Whether to use the thread output queue handoff.
+        work_us: Duration of simulated foreground work in microseconds.
+        warmup: Number of items to consume before recording latencies.
+    """
+    items = list(range(n_items))
+    pipeline = (
+        PipelineBuilder()
+        .add_source(iter(items))
+        .add_sink(buffer_size=buffer_size)
+        .build(num_threads=2, use_thread_output_queue=use_thread_output_queue)
+    )
+
+    result = BenchResult(name=name)
+    consumed = 0
+    for _ in pipeline.get_iterator(timeout=60):
+        consumed += 1
+
+        # Simulate foreground work (e.g. GPU fwd+bwd).
+        # This gives the producer time to pre-fill the queue
+        # so the next get_item measures pure handoff overhead.
+        _busy_wait_us(work_us)
+
+        if consumed <= warmup:
+            continue
+
+        # Time the next get_item call — this is what we're measuring.
+        t0 = time.perf_counter()
+        try:
+            next(pipeline.get_iterator(timeout=60))
+        except StopIteration:
+            break
+        result.latencies_us.append((time.perf_counter() - t0) * 1e6)
+        consumed += 1
+
+        # Do work after the timed item too, so the *next* iteration's
+        # measurement also has overlap time.
+        _busy_wait_us(work_us)
+
+    return result
+
+
+def main() -> None:
+    """Run the full benchmark sweep and print results."""
+    n_items = 500
+    buffer_size = 8
+
+    print("SPDL Pipeline Thread Output Queue Handoff Benchmark")
+    print("=" * 90)
+
+    results: list[BenchResult] = []
+
+    work_ms_values = list(range(0, 31, 3))
+    for work_ms in work_ms_values:
+        work_us = work_ms * 1000.0
+        label = f"{work_ms}ms foreground work"
+        print(f"\n--- {label} ({n_items} items, buffer_size={buffer_size}) ---")
+
+        for use_toq, tag in [
+            (False, "default asyncio"),
+            (True, "thread output queue"),
+        ]:
+            r = _run_bench(
+                f"{tag}, {label}",
+                n_items,
+                buffer_size,
+                use_thread_output_queue=use_toq,
+                work_us=work_us,
+            )
+            results.append(r)
+            print(f"  {r.summary()}")
+
+    print(f"\n{'=' * 90}")
+    print("SUMMARY — main thread get_item() latency (lower is better)")
+    print(f"{'=' * 90}")
+    for r in results:
+        if r.latencies_us:
+            print(f"  {r.summary()}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/spdl/pipeline/_build.py
+++ b/src/spdl/pipeline/_build.py
@@ -128,6 +128,7 @@ def _build_pipeline(
     task_hook_factory: Callable[[StageInfo], list[TaskHook]] | None = None,
     stage_id: int = 0,
     background_tasks: list[BackgroundTaskFactory] | None = None,
+    use_thread_output_queue: bool = False,
 ) -> Pipeline[U]:
     if _DEFAULT_BUILD_CALLBACK is not None:
         try:
@@ -155,6 +156,7 @@ def _build_pipeline(
         task_hook_factory=task_hook_factory,
         stage_id=stage_id,
         background_tasks=all_bg_tasks or None,
+        use_thread_output_queue=use_thread_output_queue,
     )
 
     executor = ThreadPoolExecutor(
@@ -175,6 +177,7 @@ def build_pipeline(
     task_hook_factory: Callable[[StageInfo], list[TaskHook]] | None = None,
     stage_id: int = 0,
     background_tasks: list[BackgroundTaskFactory] | None = None,
+    use_thread_output_queue: bool = False,
 ) -> Pipeline[U]:
     """Build a pipeline from the config.
 
@@ -240,6 +243,12 @@ def build_pipeline(
             :py:meth:`~BackgroundTask.run` method runs alongside the pipeline stages.
             Tasks are cancelled when the pipeline completes. Their errors are logged
             but do not cause the pipeline to fail.
+
+        use_thread_output_queue: If ``True``, replace the sink's output queue with a
+            :py:class:`queue.Queue`-backed queue for the final handoff from the
+            background event loop to the foreground consumer thread. This bypasses
+            ``asyncio.run_coroutine_threadsafe``, reducing per-batch latency from
+            ~200-400us to ~10us. Default: ``False``.
     """
     from . import _profile
 
@@ -255,6 +264,7 @@ def build_pipeline(
         task_hook_factory=task_hook_factory,
         stage_id=stage_id,
         background_tasks=background_tasks,
+        use_thread_output_queue=use_thread_output_queue,
     )
 
 
@@ -283,6 +293,7 @@ class _Wrapper(Generic[U]):
         queue_class: type[AsyncQueue] | None,
         task_hook_factory: Callable[[StageInfo], list[TaskHook]] | None = None,
         background_tasks: list[BackgroundTaskFactory] | None = None,
+        use_thread_output_queue: bool = False,
     ) -> None:
         self.config = config
         self.num_threads = num_threads
@@ -291,6 +302,7 @@ class _Wrapper(Generic[U]):
         self.queue_class = queue_class
         self.task_hook_factory = task_hook_factory
         self.background_tasks = background_tasks
+        self.use_thread_output_queue = use_thread_output_queue
         self._pipeline: Pipeline[U] | None = None
         if _has_continuous_source(config):
             self._pipeline = self._build()
@@ -305,6 +317,7 @@ class _Wrapper(Generic[U]):
             queue_class=self.queue_class,
             task_hook_factory=self.task_hook_factory,
             background_tasks=self.background_tasks,
+            use_thread_output_queue=self.use_thread_output_queue,
         )
 
     def __iter__(self) -> Iterator[U]:
@@ -340,6 +353,7 @@ def run_pipeline_in_subprocess(
     queue_class: type[AsyncQueue] | None = None,
     task_hook_factory: Callable[[StageInfo], list[TaskHook]] | None = None,
     background_tasks: list[BackgroundTaskFactory] | None = None,
+    use_thread_output_queue: bool = False,
     **kwargs: Any,
 ) -> Iterable[T]:
     """Run the given Pipeline in a subprocess, and iterate on the result.
@@ -405,6 +419,7 @@ def run_pipeline_in_subprocess(
             queue_class=queue_class,
             task_hook_factory=task_hook_factory,
             background_tasks=background_tasks,
+            use_thread_output_queue=use_thread_output_queue,
         ),
         initializer=initializer,
         **kwargs,
@@ -426,6 +441,7 @@ def run_pipeline_in_subinterpreter(
     queue_class: type[AsyncQueue] | None = None,
     task_hook_factory: Callable[[StageInfo], list[TaskHook]] | None = None,
     background_tasks: list[BackgroundTaskFactory] | None = None,
+    use_thread_output_queue: bool = False,
     **kwargs: Any,
 ) -> Iterable[T]:
     """**[Experimental]** Run the given Pipeline in a subinterpreter, and iterate on the result.
@@ -471,6 +487,7 @@ def run_pipeline_in_subinterpreter(
             queue_class=queue_class,
             task_hook_factory=task_hook_factory,
             background_tasks=background_tasks,
+            use_thread_output_queue=use_thread_output_queue,
         ),
         initializer=initializer,
         **kwargs,

--- a/src/spdl/pipeline/_builder.py
+++ b/src/spdl/pipeline/_builder.py
@@ -291,6 +291,7 @@ class PipelineBuilder(Generic[T, U]):
         queue_class: type[AsyncQueue] | None = None,
         task_hook_factory: Callable[[StageInfo], list[TaskHook]] | None = None,
         stage_id: int = 0,
+        use_thread_output_queue: bool = False,
     ) -> Pipeline[U]:
         """Build the pipeline.
 
@@ -328,6 +329,10 @@ class PipelineBuilder(Generic[T, U]):
                 To disable hooks, provide a function that returns an empty list.
 
             stage_id: The index of the initial stage  used for logging.
+
+            use_thread_output_queue: If ``True``, replace the sink's output queue with a
+                ``queue.Queue``-backed queue for lower-latency batch handoff.
+                Default: ``False``.
         """
         return build_pipeline(
             self.get_config(),
@@ -337,4 +342,5 @@ class PipelineBuilder(Generic[T, U]):
             report_stats_interval=report_stats_interval,
             task_hook_factory=task_hook_factory,
             stage_id=stage_id,
+            use_thread_output_queue=use_thread_output_queue,
         )

--- a/src/spdl/pipeline/_components/__init__.py
+++ b/src/spdl/pipeline/_components/__init__.py
@@ -14,6 +14,7 @@ from ._hook import (
 )
 from ._node import _build_pipeline_coro, _get_global_id, _set_global_id, PipelineFailure
 from ._queue import (
+    _ThreadBasedAsyncQueue,
     AsyncQueue,
     get_default_queue_class,
     QueuePerfStats,
@@ -30,6 +31,7 @@ __all__ = [
     "is_eof",
     "is_epoch_end",
     "PipelineFailure",
+    "_ThreadBasedAsyncQueue",
     "set_default_hook_class",
     "set_default_queue_class",
     "TaskHook",

--- a/src/spdl/pipeline/_components/_node.py
+++ b/src/spdl/pipeline/_components/_node.py
@@ -40,7 +40,7 @@ from ._pipe import (
     _ordered_pipe,
     _pipe,
 )
-from ._queue import AsyncQueue, get_default_queue_class
+from ._queue import _ThreadBasedAsyncQueue, AsyncQueue, get_default_queue_class
 from ._sink import _sink
 from ._source import _source, _source_continuous
 from ._variants import _path_variants_router
@@ -431,6 +431,7 @@ def _convert_config(
     pipeline_id: int,
     stage_id: _MutableInt,
     disable_sink: bool = False,
+    use_thread_output_queue: bool = False,
 ) -> _TOutputNodes:
     """Convert a :py:class:`~spdl.pipeline.defs.PipelineConfig` into a linked list of
     :py:class:`~spdl.pipeline._components._node._Node` objects.
@@ -472,7 +473,10 @@ def _convert_config(
     if not disable_sink:
         info = _get_stage_info(plc.sink, pipeline_id, stage_id)
         stage_id += 1
-        sink_out_q = q_class(info, buffer_size=plc.sink.buffer_size)
+        if use_thread_output_queue:
+            sink_out_q = _ThreadBasedAsyncQueue(info, buffer_size=plc.sink.buffer_size)
+        else:
+            sink_out_q = q_class(info, buffer_size=plc.sink.buffer_size)
         n = _Node(
             info, plc.sink, [n], input_queue=n.output_queue, output_queue=sink_out_q
         )
@@ -696,6 +700,7 @@ def _build_pipeline_node(
     queue_class: type[AsyncQueue] | None,
     task_hook_factory: Callable[[StageInfo], list[TaskHook]] | None,
     stage_id: int,
+    use_thread_output_queue: bool = False,
 ) -> _TOutputNodes:
     global _PIPELINE_ID
     _PIPELINE_ID += 1
@@ -708,7 +713,13 @@ def _build_pipeline_node(
     )
 
     fc_class = _get_fail_counter()
-    node = _convert_config(plc, q_class, _PIPELINE_ID, _MutableInt(stage_id))
+    node = _convert_config(
+        plc,
+        q_class,
+        _PIPELINE_ID,
+        _MutableInt(stage_id),
+        use_thread_output_queue=use_thread_output_queue,
+    )
     _validate_continuous_mode(node)
     _build_node_recursive(node, fc_class, hook_factory, max_failures)
     return node
@@ -758,7 +769,7 @@ def _cancel_recursive(node: _TNodes) -> None:
 
 def _cancel_orphaned(node: _TNodes) -> None:
     """
-    Cancel upstream tasks when the current node's task has completed to prevent orphaned producers.
+    Cancel upstream tasks when this node's task completes to avoid leaving producer tasks orphaned.
 
     This function traverses the pipeline graph upstream from the given node.
     If the current node's asyncio Task is done (completed, errored, or cancelled),
@@ -950,6 +961,7 @@ def _build_pipeline_coro(
     task_hook_factory: Callable[[StageInfo], list[TaskHook]] | None = None,
     stage_id: int = 0,
     background_tasks: Sequence[BackgroundTaskFactory] | None = None,
+    use_thread_output_queue: bool = False,
 ) -> tuple[Coroutine[None, None, None], asyncio.Queue]:
     try:
         node = _build_pipeline_node(
@@ -959,6 +971,7 @@ def _build_pipeline_coro(
             queue_class=queue_class,
             task_hook_factory=task_hook_factory,
             stage_id=stage_id,
+            use_thread_output_queue=use_thread_output_queue,
         )
         coro = _run_pipeline_coroutines(node, background_tasks=background_tasks)
 

--- a/src/spdl/pipeline/_components/_queue.py
+++ b/src/spdl/pipeline/_components/_queue.py
@@ -8,10 +8,12 @@
 
 import asyncio
 import logging
+import queue
 import time
 from collections.abc import AsyncGenerator, AsyncIterator
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
+from typing import Any
 
 from spdl.pipeline._common._misc import create_task
 
@@ -20,6 +22,7 @@ from ._common import _EOF, _periodic_dispatch, _StatsCounter, _time_str, StageIn
 __all__ = [
     "_queue_stage_hook",
     "AsyncQueue",
+    "_ThreadBasedAsyncQueue",
     "StatsQueue",
     "QueuePerfStats",
     "set_default_queue_class",
@@ -334,6 +337,74 @@ class StatsQueue(AsyncQueue):
             100 * stats.occupancy_rate,
             stacklevel=2,
         )
+
+
+class _ThreadBasedAsyncQueue(AsyncQueue):
+    """AsyncQueue backed by :py:class:`queue.Queue` instead of
+    :py:class:`asyncio.Queue`.
+
+    The default :py:class:`AsyncQueue` is an :py:class:`asyncio.Queue`.
+    When the foreground (non-async) consumer thread needs the next item,
+    it must go through ``asyncio.run_coroutine_threadsafe`` to schedule a
+    ``get()`` coroutine on the background event loop, then poll the
+    resulting ``Future``.  This cross-thread coroutine scheduling adds
+    ~200-280us of CPU-side overhead per call — a fixed tax that cannot be
+    hidden by GPU compute overlap.
+
+    This class replaces the underlying storage with a standard
+    :py:class:`queue.Queue`, whose blocking ``get``/``put`` release the
+    GIL while waiting.  The async ``put``/``get`` methods delegate to the
+    queue via ``run_in_executor`` so the event loop is never blocked.
+    The foreground consumer can also call ``_queue.get(timeout=...)``
+    directly, bypassing the asyncio event loop entirely and reducing
+    handoff latency to ~10us when an item is already available.
+
+    Benchmark (devserver, 500 int items, simulated foreground work)::
+
+        FG work   default (p50)   default (p99)   thread_q (p50)   thread_q (p99)
+        -------   -------------   -------------   --------------   --------------
+          0ms         199us           625us           116us            313us
+          3ms         246us           642us           223us            646us
+          6ms         232us           532us           190us            555us
+          9ms         287us           485us           153us            549us
+         12ms         280us           822us            14us            464us
+         15ms         221us           396us             8us            385us
+         18ms         227us           431us             9us             70us
+         21ms         224us           450us            11us             41us
+         24ms         240us           533us            12us             34us
+         27ms         227us           470us            12us             27us
+         30ms         242us           512us            12us             26us
+
+    See ``spdl/examples/benchmark_thread_output_queue.py`` for the full
+    benchmark.
+    """
+
+    def __init__(
+        self,
+        info: StageInfo,
+        *,
+        buffer_size: int = 1,
+    ) -> None:
+        # Skip asyncio.Queue.__init__ — we don't use the underlying queue.
+        self.info = info
+        self._queue: queue.Queue[Any] = queue.Queue(maxsize=buffer_size)
+
+    async def put(self, item: object) -> None:
+        loop = asyncio.get_running_loop()
+        await loop.run_in_executor(None, self._queue.put, item)  # pyre-ignore[32]
+
+    async def get(self) -> object:
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(None, self._queue.get)  # pyre-ignore[32]
+
+    def get_nowait(self) -> object:
+        return self._queue.get_nowait()
+
+    def empty(self) -> bool:
+        return self._queue.empty()
+
+    def qsize(self) -> int:
+        return self._queue.qsize()
 
 
 _DEFAULT_QUEUE_CLASS: type[AsyncQueue] = StatsQueue

--- a/src/spdl/pipeline/_pipeline.py
+++ b/src/spdl/pipeline/_pipeline.py
@@ -9,6 +9,7 @@
 import asyncio
 import concurrent.futures
 import logging
+import queue
 import time
 import warnings
 import weakref
@@ -20,9 +21,8 @@ from enum import IntEnum
 from threading import Event as SyncEvent, Thread
 from typing import Any, Generic, TypeVar
 
-from spdl._internal import log_api_usage_once
 from spdl.pipeline._common._misc import create_task
-from spdl.pipeline._components import is_epoch_end
+from spdl.pipeline._components import _ThreadBasedAsyncQueue, is_epoch_end
 
 __all__ = ["Pipeline"]
 
@@ -292,6 +292,11 @@ class _PipelineImpl(Generic[T]):
         if not self._event_loop.is_started():
             raise RuntimeError("Pipeline is not started.")
 
+        if isinstance(self._output_queue, _ThreadBasedAsyncQueue):
+            return self._get_item_thread_queue(timeout=timeout)
+        return self._get_item_async_queue(timeout=timeout)
+
+    def _get_item_async_queue(self, *, timeout: float | None) -> T:
         # The event loop (thread) was started, but it might be stopped by now.
         # However, what matters for `get_item` method is whether the task is running or not.
         # Because if the task is running, then accessing the sink queue must be done through
@@ -345,6 +350,30 @@ class _PipelineImpl(Generic[T]):
         _LG.debug("EventLoop: %s", str(self._event_loop))
 
         raise TimeoutError(f"The next item is not available after {elapsed:.1f} sec.")
+
+    def _get_item_thread_queue(self, *, timeout: float | None) -> T:
+        q = self._output_queue._queue  # pyre-ignore[16]
+
+        if self._event_loop.is_task_completed():
+            if not q.empty():
+                return q.get_nowait()
+            self._event_loop.stop()
+            raise EOFError(_EOF_MSG)
+
+        max_elapsed = float("inf") if timeout is None else timeout
+        t0 = time.monotonic()
+        while (elapsed := time.monotonic() - t0) < max_elapsed:
+            remaining = max_elapsed - elapsed
+            try:
+                return q.get(timeout=min(0.1, remaining))
+            except queue.Empty:
+                if self._event_loop.is_task_completed() and q.empty():
+                    self._event_loop.stop()
+                    raise EOFError(_EOF_MSG) from None
+
+        raise TimeoutError(
+            f"The next item is not available after {time.monotonic() - t0:.1f} sec."
+        )
 
 
 ################################################################################


### PR DESCRIPTION
Replace the last queue of Pipeline with an opt-in `queue.Queue`-backed `AsyncQueue` for lower-latency batch handoff from the background async event loop to the foreground consumer thread.

The default `Pipeline.get_item()` uses
`asyncio.run_coroutine_threadsafe` + `Future.result(timeout=0.1)` polling, which imposes a fixed ~200-280us CPU-side scheduling tax per batch that cannot be hidden by GPU compute overlap.

This diff adds `_ThreadBasedAsyncQueue`, an `AsyncQueue` subclass backed by `queue.Queue` instead of `asyncio.Queue`.
When `use_thread_output_queue=True` is passed to `build_pipeline` or `PipelineBuilder.build`, only the sink output queue is replaced all internal inter-stage queues remain `AsyncQueue`.

The foreground `_get_item_thread_queue` reads directly from the `queue.Queue` via its blocking `get()`, which releases the GIL while waiting and returns in microseconds when a slot is pre-filled.

Benchmark results

| FG work | default (p50) | default (p99) | thread_q (p50) | thread_q (p99) | 
|---------|---------------|---------------|----------------|----------------|
| 0ms     | 199us         | 625us         | 116us          | 313us          |
| 3ms     | 246us         | 642us         | 223us          | 646us          |
| 6ms     | 232us         | 532us         | 190us          | 555us          |
| 9ms     | 287us         | 485us         | 153us          | 549us          |
| 12ms    | 280us         | 822us         | 14us           | 464us          |
| 15ms    | 221us         | 396us         | 8us            | 385us          |
| 18ms    | 227us         | 431us         | 9us            | 70us           |
| 21ms    | 224us         | 450us         | 11us           | 41us           |
| 24ms    | 240us         | 533us         | 12us           | 34us           |
| 27ms    | 227us         | 470us         | 12us           | 27us           |
| 30ms    | 242us         | 512us         | 12us           | 26us           |

The asyncio path stays flat at ~220-280us (p50). The thread queue drops to ~8-14us (p50) once foreground work >= ~12ms gives the producer enough time to pre-fill.
At >= 18ms foreground work, the p99 also drops dramatically (from ~430-530us to ~26-70us).