### PR TITLE
Add agent skills for analyzing and optimizing pipeline performance

### DIFF
--- a/tools/skills/pipeline_perf/how_to_interpret_pipeline_stats.md
+++ b/tools/skills/pipeline_perf/how_to_interpret_pipeline_stats.md
@@ -1,0 +1,126 @@
+# How to Interpret Pipeline Stats
+
+## Event Name Parsing
+
+SPDL events follow this naming convention:
+
+### Runtime stats (logged every ~59 seconds)
+
+Format: `pipeline:{stage_name}_{metric_suffix}`
+
+Where `{stage_name}` is like `0:1:download[96]` (pipeline_id:stage_index:func_name[concurrency]) and queue names append `_queue`.
+
+| Metric Suffix | Description | Unit |
+|--------------|-------------|------|
+| `_ave_time` | Average task execution time | seconds |
+| `_num_tasks` | Number of tasks completed (including failures) | count |
+| `_num_failures` | Number of failed tasks | count |
+| `_qps` | Queue throughput (items/second) | items/s |
+| `_put` | Average time waiting to put result in downstream queue | seconds |
+| `_get` | Average time waiting to get item from upstream queue | seconds |
+| `_num_items` | Items that passed through the queue | count |
+| `_occupation_rate` | Fraction of time queue was non-empty (0.0-1.0) | ratio |
+
+### Extracting stage names from event strings
+
+Use this regex to parse events: `pipeline:(\d+:\d+:.+?)_(ave_time|num_tasks|num_failures)$` for task metrics, and `pipeline:(\d+:\d+:.+?)_(qps|put|get|num_items|occupation_rate)$` for queue metrics.
+
+Group stages by stripping the metric suffix. Each stage will have both task metrics and queue metrics.
+
+## Quick Reference: Queue Health
+
+| Scenario | Queue Put Time | Queue Get Time | Occupancy |
+|---|---|---|---|
+| Pipeline fast enough | High (queues full) | Low (data ready) | High (~1.0) |
+| Pipeline too slow | Low (rarely full) | High (data unavailable) | Low (~0.0) |
+
+**Sink queue data readiness is the single most important metric** — it directly equals the time the training loop waits for data.
+
+## Bottleneck Analysis Heuristics
+
+### Understanding Queue Metrics
+
+Each stage has an **output queue** that sits between it and the next stage. The queue metrics describe this output queue:
+
+- `_occupation_rate`: Fraction of time the output queue is **non-empty** (0.0 = always empty, 1.0 = always has items)
+- `_put`: Time the stage spends waiting to **put** its result into its output queue (high = output queue is full, downstream is slow)
+- `_get`: Time the **next** stage spends waiting to **get** an item from this queue (high = queue is often empty, this stage is slow)
+
+**Key insight**: A stage's output queue occupation rate tells you the **balance between that stage (producer) and the next stage (consumer)**:
+- **High occupancy (near 1.0)**: Producer is faster than consumer. Data is always available. The producer is NOT the bottleneck — look downstream.
+- **Low occupancy (near 0.0)**: Producer is slower than consumer. The consumer frequently finds the queue empty and waits. The producer IS the bottleneck for downstream stages.
+
+### 1. Execution Time Bottleneck
+The stage with the highest `_ave_time` is the primary compute bottleneck. Compare relative execution times — if one stage is 10x slower than others, it dominates pipeline latency. But also account for concurrency: a stage with 0.2s avg time and concurrency 16 has effective throughput of ~80 items/s, while a stage with 0.01s avg time and concurrency 1 has ~100 items/s.
+
+### 2. Backpressure Detection
+**Symptoms**: High `_put` wait time on a stage AND high `_occupation_rate` (near 1.0) on that stage's own output queue.
+**Meaning**: This stage's output queue is full because the downstream stage can't keep up. The stage is blocked trying to enqueue results. The downstream stage is the actual bottleneck.
+**Fix**: Increase concurrency of the downstream stage, or optimize the downstream stage's processing.
+
+### 3. Data Starvation Detection
+**Symptoms**: High `_get` wait time on a stage's queue AND low `_occupation_rate` on that same queue.
+**Meaning**: The queue is frequently empty. The stage producing into this queue is too slow — downstream stages are idle waiting.
+**How to trace the bottleneck**: Walk upstream through the pipeline. If stage N's output queue has low occupancy, stage N is the slow producer. Check stage N's `_ave_time` and concurrency — it may need higher concurrency or optimization.
+**Fix**: Increase concurrency of the slow upstream stage, or optimize its processing.
+
+**Important**: Do NOT confuse a queue with high occupancy for starvation. High occupancy means data is plentiful — the opposite of starvation. If a stage has high `_get` wait but its upstream queue has HIGH occupancy, the wait is likely lock contention or dequeue overhead, not starvation.
+
+### 4. Identifying the Pipeline Bottleneck Stage
+Walk through the pipeline from source to sink and look at each stage's output queue occupancy:
+- Stages **before** the bottleneck have high output queue occupancy (data accumulates because the bottleneck slows everything downstream)
+- The **bottleneck stage** itself has LOW output queue occupancy (it can't produce fast enough to keep its output queue full)
+- Stages **after** the bottleneck also have low-to-moderate output queue occupancy (they're limited by the bottleneck's throughput)
+
+The transition from high-to-low occupancy pinpoints the bottleneck.
+
+### 5. Failure Analysis
+**Symptoms**: Non-zero `_num_failures` for any stage.
+**Severity**: Calculate failure ratio = `num_failures / num_tasks`. Above 5% is concerning; above 20% is critical.
+**Action**: Failures cause retries and waste compute. Investigate error logs for the failing stage.
+
+### 6. Throughput Consistency
+Compare `_qps` across all stages. In a healthy pipeline, QPS should be roughly equal (accounting for aggregate/disaggregate stages that change item count). Large divergence indicates a bottleneck stage.
+
+### 7. Straggler Detection (multi-rank)
+Compare `_ave_time` for the same stage across ranks. Ranks with significantly higher (>2x) execution times are stragglers, often caused by:
+- Slow network/storage on specific hosts
+- Data skew (some ranks get harder examples)
+- Resource contention
+
+Also compare `_occupation_rate` and `_get` times across ranks for the same queue. If a specific rank has lower occupancy and higher get-wait on the same queue, upstream stages on that rank are slower — indicating a rank-specific bottleneck.
+
+## Output Format
+
+Present results as a structured markdown report:
+
+```markdown
+## SPDL Pipeline Performance Report
+
+**Rank**: <rank> | **Ranks Available**: <total_ranks>
+
+### Pipeline Architecture
+
+| # | Stage | Type | Concurrency | Source |
+|---|-------|------|-------------|--------|
+| 0 | download | PipeConfig | 96 | preprocess.py:407 |
+| 1 | decode | PipeConfig | 10 | preprocess.py:412 |
+
+### Performance Summary
+
+| Stage | Avg Time (s) | p50 (s) | p90 (s) | p99 (s) | QPS | Failures | Occupancy | Put Wait (s) | Get Wait (s) |
+|-------|-------------|---------|---------|---------|-----|----------|-----------|-------------|-------------|
+| download | 0.15 | 0.14 | 0.18 | 0.25 | 42.3 | 0 | 0.85 | 0.001 | 0.05 |
+| decode | 0.82 | 0.79 | 0.95 | 1.20 | 12.1 | 3 | 0.32 | 0.42 | 0.001 |
+
+### Bottleneck Analysis
+
+- **Primary bottleneck**: `decode` — highest avg execution time (0.82s), causing backpressure upstream
+- **Data starvation**: None detected
+- **Failures**: 3 failures in `decode` stage (0.1% failure rate — acceptable)
+
+### Recommendations
+
+1. Increase `decode` concurrency (currently 10) — this is the pipeline bottleneck
+2. Consider profiling `decode` with SPDL diagnostic mode for optimal concurrency
+```

--- a/tools/skills/pipeline_perf/optimization_strategies.md
+++ b/tools/skills/pipeline_perf/optimization_strategies.md
@@ -1,0 +1,309 @@
+# SPDL Pipeline Optimization Strategies
+
+## How SPDL Pipelines Work
+
+SPDL pipelines are async, multi-stage data processing pipelines for AI training. A pipeline is built with `PipelineBuilder`:
+
+```python
+pipeline = (
+    PipelineBuilder()
+    .add_source(sampler)
+    .pipe(download, concurrency=16)    # I/O-bound: high concurrency
+    .pipe(preprocess, concurrency=8)   # CPU-bound: moderate concurrency
+    .aggregate(batch_size)
+    .pipe(collate)
+    .pipe(gpu_transfer)                # hardware-bound: no concurrency
+    .add_sink(buffer_size=3)
+    .build(num_threads=16)
+)
+```
+
+### Stage Types
+- **Source**: produces items (samplers, index iterators)
+- **Pipe**: transforms items; `concurrency` controls how many run in parallel
+- **Aggregate**: batches N items into one
+- **Disaggregate**: unbatches one item into N
+- **Sink**: output buffer for the consumer
+
+### Key Parameters
+| Parameter | Location | Guidance |
+|---|---|---|
+| `concurrency` | `.pipe(fn, concurrency=N)` | I/O stages: 16-32. CPU stages: 4-8. GPU transfer: 1 |
+| `num_threads` | `.build(num_threads=N)` | Must be >= max concurrency of any sync stage |
+| `buffer_size` | `.add_sink(N)` | 2-10; affects memory, NOT throughput |
+| `output_order` | `.pipe(fn, output_order=...)` | "completion" for I/O (avoids head-of-line blocking), "input" for determinism |
+
+## Recommended Architecture: Multi-Threading in Subprocess (MTP)
+
+The production pattern runs the CPU-heavy pipeline in a **subprocess** and only does GPU transfer in the main process.
+
+### MTP Structure
+
+```python
+import spdl.pipeline
+import spdl.source.utils
+from spdl.io import transfer_tensor
+from spdl.pipeline import PipelineBuilder
+from spdl.source import DistributedRandomSampler
+
+
+def build_spdl_pipeline(
+    samples, tokenizer, max_seq_len, batch_size,
+    rank, world_size, num_threads, mp_context="forkserver",
+):
+    # embed_shuffle ensures correct sampling across iterations
+    source = spdl.source.utils.embed_shuffle(
+        DistributedRandomSampler(len(samples), rank=rank, world_size=world_size)
+    )
+
+    # Inner pipeline (subprocess) — all CPU work
+    # Stage functions must be picklable — see "Pickling Constraints" section
+    backend = (
+        PipelineBuilder()
+        .add_source(source, continuous=True)
+        .pipe(lookup_fn)          # e.g., _Lookup(samples) or partial(_lookup, samples=samples)
+        .pipe(tokenize_fn, concurrency=num_threads)  # must use TLS for HF tokenizers
+        .aggregate(batch_size, drop_last=True)
+        .pipe(collate_fn)
+        .add_sink(buffer_size=3)
+    )
+
+    # Move to subprocess
+    source2 = spdl.pipeline.run_pipeline_in_subprocess(
+        backend.get_config(),
+        num_threads=num_threads,
+        mp_context=mp_context,
+    )
+
+    # Outer pipeline (main process) — GPU transfer only
+    frontend = (
+        PipelineBuilder()
+        .add_source(source2, continuous=True)
+        .pipe(transfer_tensor)
+        .add_sink(buffer_size=3)
+    )
+    return frontend.build(num_threads=1)
+```
+
+### Training Loop with MTP
+
+Build the dataloader **once** before the epoch loop. The Pipeline object supports re-iteration — each `for batch in dl:` triggers a fresh run inside the subprocess:
+
+```python
+dl = build_spdl_pipeline(
+    samples=samples, tokenizer=tokenizer, max_seq_len=max_seq_len,
+    batch_size=batch_size, rank=rank, world_size=world_size,
+    num_threads=num_workers, mp_context=mp_context,
+)
+
+for epoch in range(num_epochs):
+    for batch in dl.get_iterator(timeout=900):
+        train_step(batch)
+```
+
+**Do NOT** restructure into a flat `next(data_iter)` loop — MTP's re-iteration pattern requires per-epoch `for ... in dl:`.
+
+### MTP Best Practices
+
+1. **`continuous=True`** on `.add_source()` — always use it. Eliminates pipeline teardown/rebuild between epochs. Harmless even when not strictly needed.
+2. **`spdl.source.utils.embed_shuffle()`** — wrap `DistributedRandomSampler` with this for correct sampling behavior across iterations.
+3. **`spdl.io.transfer_tensor`** — use for GPU transfer in the frontend pipeline. Use a dedicated thread (ThreadPoolExecutor with 1 worker) so that it uses own CUDA stream which allows overlapping data transfer and compute.
+4. **`aggregate(batch_size, drop_last=True)`** — `drop_last=True` avoids partial batches that cause shape mismatches in DDP.
+5. **`mp_context="forkserver"`** (the default). Try `"spawn"` and `"fork"` only if multiprocessing with "forkserver" fails.
+6. **Do NOT use `output_order="completion"`** — only needed when output ordering matters (e.g., evaluation). For performance optimization pipelines, do not use it.
+
+Benefits: isolates CPU work from GPU kernel launches, avoids the noisy-neighbour effect. Dedicated thread and CUDA stream for transferring the batch to GPU.
+
+## The Noisy-Neighbour Effect
+
+When CPU utilization exceeds ~40%, the OS cannot schedule GPU kernel launches promptly, causing GPU idle time even when data is available. **Keep total CPU utilization at or below 40%.** Using all CPUs for data loading is an anti-pattern.
+
+## Python Garbage Collection Stalls
+
+Python's GC can cause periodic spikes in step time by pausing threads. When data loading uses multi-threading in the main process, GC runs more frequently due to higher object allocation rates.
+
+**Mitigation by scale:**
+- **Medium scale**: Using MTP (subprocess architecture) naturally reduces GC impact in the main process, since most object-heavy work runs in the subprocess.
+- **Large scale** (many GPUs/nodes): In distributed training, all ranks synchronize at `nccl:all_reduce` — the slowest rank determines the step time. GC is inevitable and must happen occasionally, but if ranks trigger GC at random times, multiple training steps are slowed down (each time a different rank pauses). By aligning GC to a fixed step interval, all ranks pause at roughly the same time, so only one step is affected instead of many. This effect is most visible in long-running jobs with many distributed nodes — for short training runs or small-scale setups the impact is negligible.
+
+```python
+import gc
+gc.disable()
+
+for step, batch in enumerate(dataloader):
+    train(batch)
+    if step % gc_interval == 0:
+        gc.collect()
+```
+
+If using TorchTNT, use `torchtnt.framework.callbacks.GarbageCollector(step_interval=N)` instead of manual GC management.
+
+When diagnosing step time spikes that appear at irregular intervals (not correlated with epochs), GC is a likely cause.
+
+## Why `next(dataloader)` Time Is Misleading
+
+A common mistake is measuring `next(dataloader)` time alone to evaluate data loading performance. This can be deeply misleading due to GIL contention.
+
+When data loading runs in multi-threaded mode in the main process (without MTP), GIL contention between data loading threads and the training loop can slow down model training itself (forward/backward/parameter update). The training step takes longer, which gives the data loader more time to catch up — so `next(dataloader)` superficially drops to near zero. The pipeline looks fast, but overall training is slower.
+
+**What to check instead:**
+1. **Training step time** (forward + backward + parameter update): compare against the baseline. If step time increased, GIL contention is the likely cause — even if `next(dataloader)` looks fine.
+2. **Pipeline stats**: queue occupancy and throughput at each stage give an accurate picture independent of GIL effects.
+3. **SM Utilization**: if it dropped despite `next(dataloader)` being fast, the GPU is starved due to delayed kernel launches from GIL contention.
+
+This is a key reason to use MTP (subprocess mode) — it eliminates GIL contention between data loading and training entirely.
+
+## System Metrics
+
+- **SM Utilization (%)**: How active GPU streaming multiprocessors are. Target: ≥40%.
+- **GPU Device Utilization (%)**: Overall GPU busy percentage.
+- **CPU Utilization (%)**: Host CPU usage. Should stay ≤40%.
+
+## Fixing Bottlenecks
+
+1. **Adjust concurrency**: Usually 4-8 is enough. Never exceed `num_CPU_cores / 8`. Over-concurrency triggers noisy-neighbour.
+2. **Split monolithic stages**: Separate I/O-bound, CPU-bound, and memory-bound operations into distinct `.pipe()` stages with independent concurrency.
+3. **Move to subprocess**: Use `run_pipeline_in_subprocess()` to isolate CPU work.
+4. **Profile the function**: Look for GIL contention (use `spdl.io.load_npz` instead of numpy NPZ), unnecessary `asyncio.run()` wrappers (pass async functions directly), or expensive serialization.
+5. **Use coalesced data access**: Batching I/O requests (reading multiple samples per call) can be significantly faster than single-sample access.
+
+## Pickling Constraints (Subprocess Mode)
+
+When using `run_pipeline_in_subprocess()`, all pipeline stage functions must be picklable because they are serialized and sent to the subprocess.
+
+### What NOT to use
+
+- **Lambda functions** — cannot be pickled.
+- **Locally defined (inner/nested) functions** — not picklable.
+- **Bound methods of non-picklable objects** (e.g., objects holding open file handles or locks).
+
+### Two-Tier Approach for MTP Stage Functions
+
+#### Tier 1 (try first): Module-level functions with `functools.partial`
+
+The simplest approach. Define functions at module level, use `functools.partial` to bind picklable arguments. Re-create objects lazily in the subprocess when possible:
+
+```python
+from functools import partial
+
+_tokenizer_tls = threading.local()
+
+def _lookup(idx: int, samples: list[dict[str, str]]) -> dict[str, str]:
+    return samples[idx]
+
+def _tokenize(sample: dict, model_path: str, max_seq_len: int) -> dict:
+    tok = getattr(_tokenizer_tls, 'tokenizer', None)
+    if tok is None:
+        tok = AutoTokenizer.from_pretrained(model_path)
+        _tokenizer_tls.tokenizer = tok
+    # ... tokenize ...
+
+pipeline.pipe(partial(_lookup, samples=samples))
+pipeline.pipe(partial(_tokenize, model_path=model_path, max_seq_len=512), concurrency=8)
+```
+
+This works when the subprocess can successfully import and re-create the objects.
+
+#### Tier 2 (fallback): Picklable callable classes
+
+If Tier 1 fails (subprocess crashes on startup, silent 0-batch output), switch to **callable classes** that pickle objects directly from the main process, bypassing subprocess imports entirely:
+
+```python
+class _Lookup:
+    def __init__(self, samples):
+        self.samples = samples  # pickled directly
+
+    def __call__(self, idx):
+        return self.samples[idx]
+
+class _Tokenize:
+    def __init__(self, tokenizer, max_seq_len):
+        self._tokenizer = tokenizer  # pickled directly — no re-import needed
+        self.max_seq_len = max_seq_len
+        self._tlt = _ThreadLocalTokenizer(tokenizer)
+
+    def __getstate__(self):
+        return {"tokenizer": self._tokenizer, "max_seq_len": self.max_seq_len}
+
+    def __setstate__(self, state):
+        self._tokenizer = state["tokenizer"]
+        self.max_seq_len = state["max_seq_len"]
+        self._tlt = _ThreadLocalTokenizer(self._tokenizer)
+
+    def __call__(self, sample):
+        return tokenize(sample, self._tlt.tokenizer, self.max_seq_len)
+
+pipeline.pipe(_Lookup(samples))
+pipeline.pipe(_Tokenize(tokenizer, 512), concurrency=8)
+```
+
+**When to use Tier 2**: Some libraries (notably HuggingFace `transformers`) can cause unusual errors when imported or when objects are re-created in a subprocess. If a subprocess pipeline crashes silently (0 batches, no error message), the most likely cause is a failed import or object re-creation. Switching to Tier 2 — where objects are pickled from the main process and unpickled in the subprocess — avoids the problematic import entirely.
+
+**Always try Tier 1 first. If the job fails with subprocess-related issues, retry with Tier 2.**
+
+### Thread Safety
+
+**HuggingFace tokenizers are NOT thread-safe.** When using concurrent pipeline stages with HF tokenizers, you MUST use thread-local storage (TLS) to give each thread its own copy:
+
+```python
+class _ThreadLocalTokenizer(threading.local):
+    def __init__(self, source):
+        self._source = source
+        self._tokenizer = None
+
+    @property
+    def tokenizer(self):
+        if self._tokenizer is None:
+            import copy
+            self._tokenizer = copy.deepcopy(self._source)
+        return self._tokenizer
+```
+
+Note: OpenAI's `tiktoken` tokenizers ARE thread-safe and do not need TLS.
+
+### What NOT to do
+
+```python
+# WRONG — all of these fail or cause subtle bugs:
+pipeline.pipe(lambda x: tokenize(x, max_length=512))       # lambda — not picklable
+pipeline.pipe(my_inner_function)                             # inner function — not picklable
+pipeline.pipe(partial(fn, tls=threading.local()))            # non-picklable arg
+pipeline.pipe(partial(tokenize, tokenizer=hf_tokenizer),     # shared HF tokenizer —
+              concurrency=8)                                 #   not thread-safe, will corrupt
+```
+
+## Headspace Analysis
+
+Before optimizing, estimate the maximum possible improvement using `CacheDataLoader`. It caches a small number of batches and returns them repeatedly, eliminating actual data loading overhead. The training accuracy is not meaningful, but the **step time** reflects the best-case performance with zero data loading cost.
+
+```python
+from spdl.dataloader import CacheDataLoader
+dataloader = CacheDataLoader(dataloader, num_caches=10, return_caches_after=100)
+```
+
+**Key properties of CacheDataLoader runs:**
+- The pipeline configuration (concurrency, MTP, batch size, etc.) **does not matter** — after the initial cache fill, all batches come from cache. The result is pure model compute time.
+- The job duration and step time from a CacheDataLoader run represent the **lower bound** of achievable training time — you cannot beat it by optimizing data loading alone.
+
+Compare cached vs uncached `step_time`:
+- **`headspace = (baseline_step_time - cached_step_time) / baseline_step_time`**
+- If headspace is small (<5%), data loading is NOT the bottleneck — focus on model optimization (torch.compile, CUDA graphs, etc.).
+- If headspace is large (>10%), data loading optimization can yield significant gains.
+- The headspace number is the **upper bound** of improvement from data loading optimization alone.
+
+## Distributed Training Considerations
+
+- All ranks synchronize at `nccl:all_reduce`. The slowest rank determines overall speed.
+- Compare data readiness across ranks to find stragglers.
+- Straggler rank can shift between epochs — indicates global data loading insufficiency.
+- Rank 0 is more susceptible (extra work like logging, checkpointing).
+
+## Parameter Tuning Strategy
+
+When tuning parameters like concurrency, num_threads, batch_size:
+1. **Start with exploration**: test a spread of values (e.g., concurrency in {4, 8, 16, 32})
+2. **Model the response**: from results so far, estimate which region of the parameter space yields best metrics
+3. **Exploit the best region**: test values near the current best, with small perturbations
+4. **Balance explore/exploit**: occasionally test values far from the best to avoid local optima
+5. **Consider interactions**: parameters can interact (e.g., high concurrency + high num_threads may exceed CPU budget)
+6. **Respect constraints**: total CPU usage ≤ 40%, concurrency ≤ num_CPU_cores / 8


### PR DESCRIPTION
Add skill MD files for analyzing and optimizing the pipeline performance stats.

These are mostly distilled from our documentation, and tweaked by applying them on the llm_finetune example with autoresearch style agentic optimization.