### PR TITLE
[spdl] Add priority-queue-based executors for SPDL pipelines

### DIFF
--- a/src/spdl/pipeline/__init__.py
+++ b/src/spdl/pipeline/__init__.py
@@ -38,6 +38,12 @@ from ._pgrp_stats import (
     ProcessGroupStatsMonitor,
 )
 from ._pipeline import Pipeline
+from ._priority_executor import (
+    PriorityExecutorEntrypoint,
+    PriorityProcessPoolExecutor,
+    PriorityThreadPoolExecutor,
+)
+from ._priority_interpreter_executor import PriorityInterpreterPoolExecutor
 from ._profile import profile_pipeline, ProfileHook, ProfileResult
 
 __all__ = [
@@ -63,6 +69,10 @@ __all__ = [
     "StageInfo",
     "StatsQueue",
     "QueuePerfStats",
+    "PriorityExecutorEntrypoint",
+    "PriorityInterpreterPoolExecutor",
+    "PriorityThreadPoolExecutor",
+    "PriorityProcessPoolExecutor",
     "iterate_in_subinterpreter",
     "iterate_in_subprocess",
     "run_pipeline_in_subprocess",

--- a/src/spdl/pipeline/_common/_convert.py
+++ b/src/spdl/pipeline/_common/_convert.py
@@ -25,6 +25,20 @@ T = TypeVar("T")
 U = TypeVar("U")
 
 
+def _is_process_pool(executor: Executor | type[Executor] | None) -> bool:
+    """Check if executor is or wraps a ProcessPoolExecutor."""
+    if isinstance(executor, ProcessPoolExecutor):
+        return True
+    pool_cls = getattr(executor, "_pool_executor_class", None)
+    if pool_cls is not None:
+        return issubclass(pool_cls, ProcessPoolExecutor)
+    # PriorityExecutorEntrypoint: resolve via _owner property
+    owner = getattr(executor, "_owner", None)
+    if owner is not None:
+        return _is_process_pool(owner)
+    return False
+
+
 def _func_in_subprocess(func: Callable[[T], U], item: T) -> U:
     try:
         return func(item)
@@ -45,7 +59,7 @@ def _to_async(
     func: Callable[[T], U],
     executor: type[Executor] | None,
 ) -> Callable[[T], Awaitable[U]]:
-    if isinstance(executor, ProcessPoolExecutor):
+    if _is_process_pool(executor):
 
         async def afunc(item: T) -> U:
             loop = asyncio.get_running_loop()
@@ -66,7 +80,7 @@ def _wrap_gen(generator: Callable[[T], Iterable[U]], item: T) -> list[U]:
 
 def _to_batch_async_gen(
     func: Callable[[T], Iterable[U]],
-    executor: ProcessPoolExecutor,
+    executor: Executor,
 ) -> Callable[[T], AsyncIterable[U]]:
     async def afunc(item: T) -> AsyncIterable[U]:
         loop = asyncio.get_running_loop()
@@ -132,9 +146,10 @@ def convert_to_async(
 
     if inspect.isgeneratorfunction(op):
         # op is sync generator. Convert to async generator.
-        if isinstance(executor, ProcessPoolExecutor):
+        if _is_process_pool(executor):
             # If executing in subprocess, data can be only exchanged at the end
             # of the generator.
+            assert isinstance(executor, Executor)
             return _to_batch_async_gen(op, executor=executor)
         return _to_async_gen(op, executor=executor)
 

--- a/src/spdl/pipeline/_priority_executor.py
+++ b/src/spdl/pipeline/_priority_executor.py
@@ -1,0 +1,475 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""Priority-queue-based executor for SPDL pipelines.
+
+Provides executors that prioritize downstream pipeline stages over upstream ones
+when sharing a thread/process pool. This reduces end-to-end latency by ensuring
+items that are closer to the pipeline output get processed first.
+
+Usage::
+
+    pool = PriorityThreadPoolExecutor(max_workers=4)
+
+    pipeline = (
+        PipelineBuilder()
+        .add_source(range(100))
+        .pipe(load, executor=pool.get_executor(), concurrency=4)
+        .pipe(decode, executor=pool.get_executor(), concurrency=4)
+        .pipe(transform, executor=pool.get_executor(), concurrency=4)
+        .add_sink(3)
+        .build(num_threads=1)
+    )
+
+Executors created later automatically have higher priority. Downstream
+stages should be created after upstream ones. Priority can be overridden
+explicitly via ``get_executor(priority=N)``.
+
+Both the pool executor and ``PriorityExecutorEntrypoint`` support the
+pickle protocol, so they can be used with ``run_pipeline_in_subprocess()``.
+"""
+
+from __future__ import annotations
+
+import itertools
+import sys
+import weakref
+from collections.abc import Callable
+from concurrent.futures import (
+    _base,  # pyre-ignore[21]
+    Executor,
+    Future,
+    process as _process_mod,  # pyre-ignore[21]
+    ProcessPoolExecutor,
+    thread as _thread_mod,  # pyre-ignore[21]
+    ThreadPoolExecutor,
+)
+from concurrent.futures.process import (  # pyre-ignore[21]
+    _WorkItem as _ProcessWorkItem,
+    BrokenProcessPool,
+)
+from concurrent.futures.thread import (  # pyre-ignore[21]
+    _WorkItem as _ThreadWorkItem,
+    BrokenThreadPool,
+)
+from queue import PriorityQueue
+from typing import Any, Self
+
+__all__ = [
+    "PriorityExecutorEntrypoint",
+    "PriorityProcessPoolExecutor",
+    "PriorityThreadPoolExecutor",
+]
+
+# ---------------------------------------------------------------------------
+# Global registry for reconnecting entrypoints to their owner after pickle.
+# Uses weak references so owners can be garbage-collected when no entrypoints
+# or user code reference them. Each process has its own registry.
+# ---------------------------------------------------------------------------
+
+_OWNER_REGISTRY: weakref.WeakValueDictionary[int, Any] = weakref.WeakValueDictionary()
+_next_owner_id = 0
+
+
+def _assign_owner_id() -> int:
+    global _next_owner_id
+    oid = _next_owner_id
+    _next_owner_id += 1
+    return oid
+
+
+class _PriorityQueueAdapter:
+    """Drop-in replacement for SimpleQueue/Queue that orders items by priority.
+
+    When ``put`` is called without a priority (e.g. shutdown sentinels injected
+    by the base executor), items receive the highest priority so they are
+    processed immediately.
+    """
+
+    def __init__(self) -> None:
+        self._queue: PriorityQueue[tuple[tuple[float, ...], int, Any]] = PriorityQueue()
+        self._seq: itertools.count[int] = itertools.count()
+
+    def put(self, item: Any, priority: tuple[int, int] | None = None) -> None:
+        if priority is None:
+            p: tuple[float, ...] = (float("-inf"),)
+        else:
+            p = priority
+        self._queue.put((p, next(self._seq), item))
+
+    def get(self, block: bool = True, timeout: float | None = None) -> Any:
+        _, _, item = self._queue.get(block=block, timeout=timeout)
+        return item
+
+    def get_nowait(self) -> Any:
+        _, _, item = self._queue.get_nowait()
+        return item
+
+    def empty(self) -> bool:
+        return self._queue.empty()
+
+    def qsize(self) -> int:
+        return self._queue.qsize()
+
+
+# ---------------------------------------------------------------------------
+# Base class for priority pool executors
+# ---------------------------------------------------------------------------
+
+
+class _PriorityExecutorBase:
+    """Shared logic for priority-queue pool executors."""
+
+    _kwargs: dict[str, Any]  # pyre-ignore[13]
+    _priority_counter: int  # pyre-ignore[13]
+    _id: int  # pyre-ignore[13]
+
+    @property
+    def _max_workers(self) -> int | None:
+        return self._kwargs["max_workers"]
+
+    def _submit_with_priority(
+        self,
+        priority: tuple[int, int],
+        fn: Callable[..., Any],
+        args: tuple[Any, ...],
+        kwargs: dict[str, Any],
+    ) -> Future[Any]:
+        raise NotImplementedError
+
+    def get_executor(
+        self, *, priority: int | None = None
+    ) -> PriorityExecutorEntrypoint:
+        """Create a child executor for a pipeline stage.
+
+        Args:
+            priority: Priority level. Higher = processed first. When
+                omitted, auto-assigns an incrementing priority so that
+                executors created later have higher priority.
+
+        Returns:
+            A ``PriorityExecutorEntrypoint`` that can be passed to
+            ``PipelineBuilder.pipe()``.
+        """
+        if priority is None:
+            self._priority_counter -= 1
+            internal_priority = self._priority_counter
+        else:
+            internal_priority = -priority
+        return PriorityExecutorEntrypoint(self, internal_priority)
+
+    def shutdown(self, wait: bool = True, cancel_futures: bool = False) -> None:
+        raise NotImplementedError
+
+    def __enter__(self) -> Self:
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        self.shutdown(wait=True)
+
+    def __getstate__(self) -> dict[str, Any]:
+        return {
+            "id": self._id,
+            "kwargs": self._kwargs,
+            "priority_counter": self._priority_counter,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Pool executors — composition-based, picklable
+# ---------------------------------------------------------------------------
+
+
+class PriorityThreadPoolExecutor(_PriorityExecutorBase):
+    """A ``ThreadPoolExecutor`` wrapper whose internal queue is priority-ordered.
+
+    Use ``get_executor()`` to create per-stage executors. Executors
+    created later automatically have higher priority (processed first).
+    Priority can be overridden explicitly via ``get_executor(priority=N)``.
+
+    Supports the pickle protocol for use with ``run_pipeline_in_subprocess()``.
+
+    Example::
+
+        pool = PriorityThreadPoolExecutor(max_workers=4)
+
+        pipeline = (
+            PipelineBuilder()
+            .add_source(range(100))
+            .pipe(load, executor=pool.get_executor(), concurrency=4)
+            .pipe(decode, executor=pool.get_executor(), concurrency=4)
+            .pipe(transform, executor=pool.get_executor(), concurrency=4)
+            .add_sink(3)
+            .build(num_threads=1)
+        )
+
+        with pipeline.auto_stop():
+            for item in pipeline.get_iterator():
+                process(item)
+
+        pool.shutdown()
+    """
+
+    _pool_executor_class: type[ThreadPoolExecutor] = ThreadPoolExecutor
+
+    def __init__(
+        self,
+        max_workers: int | None = None,
+        thread_name_prefix: str = "",
+        initializer: Callable[..., object] | None = None,
+        initargs: tuple[Any, ...] = (),
+    ) -> None:
+        self._kwargs: dict[str, Any] = {
+            "max_workers": max_workers,
+            "thread_name_prefix": thread_name_prefix,
+            "initializer": initializer,
+            "initargs": initargs,
+        }
+        self._pool: ThreadPoolExecutor = ThreadPoolExecutor(**self._kwargs)
+        self._work_queue: _PriorityQueueAdapter = _PriorityQueueAdapter()
+        self._pool._work_queue = self._work_queue  # type: ignore[assignment]
+        self._priority_counter: int = 0
+        self._id: int = _assign_owner_id()
+        _OWNER_REGISTRY[self._id] = self
+
+    def _submit_with_priority(
+        self,
+        priority: tuple[int, int],
+        fn: Callable[..., Any],
+        args: tuple[Any, ...],
+        kwargs: dict[str, Any],
+    ) -> Future[Any]:
+        pool = self._pool
+        with pool._shutdown_lock, _thread_mod._global_shutdown_lock:
+            if pool._broken:
+                raise BrokenThreadPool(pool._broken)
+            if pool._shutdown:
+                raise RuntimeError("cannot schedule new futures after shutdown")
+            if _thread_mod._shutdown:
+                raise RuntimeError(
+                    "cannot schedule new futures after interpreter shutdown"
+                )
+
+            f: Future[Any] = _base.Future()
+            if hasattr(pool, "_resolve_work_item_task"):
+                task = pool._resolve_work_item_task(fn, args, kwargs)  # pyre-ignore[16]
+                w = _ThreadWorkItem(f, task)  # pyre-ignore[20]
+            else:
+                w = _ThreadWorkItem(f, fn, args, kwargs)
+            self._work_queue.put(w, priority=priority)
+            pool._adjust_thread_count()
+            return f
+
+    def shutdown(self, wait: bool = True, cancel_futures: bool = False) -> None:
+        pool = self._pool
+        with pool._shutdown_lock:
+            pool._shutdown = True
+            if cancel_futures:
+                while not self._work_queue.empty():
+                    try:
+                        work_item = self._work_queue.get_nowait()
+                    except Exception:
+                        break
+                    if work_item is not None:
+                        work_item.future.cancel()
+                        work_item.future.set_running_or_notify_cancel()
+            for _ in pool._threads:
+                self._work_queue.put(None, priority=(sys.maxsize, 0))
+        if wait:
+            for t in pool._threads:
+                t.join()
+        _OWNER_REGISTRY.pop(self._id, None)
+
+    def __setstate__(self, state: dict[str, Any]) -> None:
+        existing = _OWNER_REGISTRY.get(state["id"])
+        if existing is not None:
+            self.__dict__.update(existing.__dict__)
+            return
+        self._kwargs = state["kwargs"]
+        self._priority_counter = state["priority_counter"]
+        self._id = state["id"]
+        self._pool = ThreadPoolExecutor(**self._kwargs)
+        self._work_queue = _PriorityQueueAdapter()
+        self._pool._work_queue = self._work_queue  # type: ignore[assignment]
+        _OWNER_REGISTRY[self._id] = self
+
+
+class PriorityProcessPoolExecutor(_PriorityExecutorBase):
+    """A ``ProcessPoolExecutor`` wrapper whose work-ID queue is priority-ordered.
+
+    The ``_work_ids`` queue determines which pending work items are fed
+    to worker processes first. Replacing it with a priority queue ensures
+    higher-priority items are dispatched first.
+
+    Supports the pickle protocol for use with ``run_pipeline_in_subprocess()``.
+
+    Example::
+
+        pool = PriorityProcessPoolExecutor(max_workers=4)
+
+        pipeline = (
+            PipelineBuilder()
+            .add_source(range(100))
+            .pipe(cpu_bound_load, executor=pool.get_executor(), concurrency=4)
+            .pipe(cpu_bound_decode, executor=pool.get_executor(), concurrency=4)
+            .add_sink(3)
+            .build(num_threads=1)
+        )
+
+        with pipeline.auto_stop():
+            for item in pipeline.get_iterator():
+                process(item)
+
+        pool.shutdown()
+    """
+
+    _pool_executor_class: type[ProcessPoolExecutor] = ProcessPoolExecutor
+
+    def __init__(
+        self,
+        max_workers: int | None = None,
+        **kwargs: Any,
+    ) -> None:
+        self._kwargs: dict[str, Any] = {"max_workers": max_workers, **kwargs}
+        self._pool: ProcessPoolExecutor = ProcessPoolExecutor(**self._kwargs)
+        self._work_queue: _PriorityQueueAdapter = _PriorityQueueAdapter()
+        self._pool._work_ids = self._work_queue  # type: ignore[assignment]
+        self._priority_counter: int = 0
+        self._id: int = _assign_owner_id()
+        _OWNER_REGISTRY[self._id] = self
+
+    def _submit_with_priority(
+        self,
+        priority: tuple[int, int],
+        fn: Callable[..., Any],
+        args: tuple[Any, ...],
+        kwargs: dict[str, Any],
+    ) -> Future[Any]:
+        pool = self._pool
+        with pool._shutdown_lock:
+            if pool._broken:
+                raise BrokenProcessPool(pool._broken)
+            if pool._shutdown_thread:
+                raise RuntimeError("cannot schedule new futures after shutdown")
+            if _process_mod._global_shutdown:
+                raise RuntimeError(
+                    "cannot schedule new futures after interpreter shutdown"
+                )
+
+            f: Future[Any] = _base.Future()
+            w = _ProcessWorkItem(f, fn, args, kwargs)
+
+            pool._pending_work_items[pool._queue_count] = w
+            self._work_queue.put(pool._queue_count, priority=priority)
+            pool._queue_count += 1
+            if hasattr(pool, "_executor_manager_thread_wakeup"):
+                pool._executor_manager_thread_wakeup.wakeup()  # pyre-ignore[16]
+            elif hasattr(pool, "_result_queue"):
+                pool._result_queue.put(None)  # pyre-ignore[16]
+
+            if getattr(
+                pool, "_safe_to_dynamically_spawn_children", False
+            ):  # pyre-ignore[16]
+                pool._adjust_process_count()  # pyre-ignore[16]
+            pool._start_executor_manager_thread()
+            return f
+
+    def shutdown(self, wait: bool = True, cancel_futures: bool = False) -> None:
+        self._pool.shutdown(wait=wait, cancel_futures=cancel_futures)
+        _OWNER_REGISTRY.pop(self._id, None)
+
+    def __setstate__(self, state: dict[str, Any]) -> None:
+        existing = _OWNER_REGISTRY.get(state["id"])
+        if existing is not None:
+            self.__dict__.update(existing.__dict__)
+            return
+        self._kwargs = state["kwargs"]
+        self._priority_counter = state["priority_counter"]
+        self._id = state["id"]
+        self._pool = ProcessPoolExecutor(**self._kwargs)
+        self._work_queue = _PriorityQueueAdapter()
+        self._pool._work_ids = self._work_queue  # type: ignore[assignment]
+        _OWNER_REGISTRY[self._id] = self
+
+
+# ---------------------------------------------------------------------------
+# Per-stage entrypoint — picklable, reconnects to owner via registry
+# ---------------------------------------------------------------------------
+
+
+class PriorityExecutorEntrypoint(Executor):
+    """Per-stage executor proxy with a fixed priority.
+
+    Drop-in compatible with ``concurrent.futures.Executor``.
+    Created via ``PriorityThreadPoolExecutor.get_executor()`` or
+    ``PriorityProcessPoolExecutor.get_executor()``.
+
+    Supports the pickle protocol: on deserialization, the first entrypoint
+    with a given owner ID creates the owner; subsequent ones reuse it.
+    """
+
+    def __init__(
+        self,
+        owner: _PriorityExecutorBase,
+        priority: int,
+    ) -> None:
+        self._owner_id: int = owner._id
+        self._owner_class: type[_PriorityExecutorBase] = type(owner)
+        self._owner_kwargs: dict[str, Any] = owner._kwargs
+        self._priority: int = priority
+        self._counter: int = 0
+        self._owner_ref: _PriorityExecutorBase = owner
+
+    @property
+    def _owner(self) -> _PriorityExecutorBase:
+        owner = self.__dict__.get("_owner_ref")
+        if owner is not None:
+            return owner
+        owner = _OWNER_REGISTRY.get(self._owner_id)
+        if owner is None:
+            owner = self._owner_class(**self._owner_kwargs)
+            old_id = owner._id
+            _OWNER_REGISTRY.pop(old_id, None)
+            owner._id = self._owner_id
+            _OWNER_REGISTRY[self._owner_id] = owner
+        self._owner_ref = owner
+        return owner
+
+    def submit(  # pyre-ignore[14]
+        self,
+        fn: Callable[..., Any],
+        /,
+        *args: Any,
+        **kwargs: Any,
+    ) -> Future[Any]:
+        priority = (self._priority, self._counter)
+        self._counter += 1
+        return self._owner._submit_with_priority(
+            priority,
+            fn,
+            args,
+            kwargs,
+        )
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._owner, name)
+
+    def __getstate__(self) -> dict[str, Any]:
+        return {
+            "owner_id": self._owner_id,
+            "owner_class": self._owner_class,
+            "owner_kwargs": self._owner_kwargs,
+            "priority": self._priority,
+        }
+
+    def __setstate__(self, state: dict[str, Any]) -> None:
+        self._owner_id = state["owner_id"]
+        self._owner_class = state["owner_class"]
+        self._owner_kwargs = state["owner_kwargs"]
+        self._priority = state["priority"]
+        self._counter = 0

--- a/src/spdl/pipeline/_priority_interpreter_executor.py
+++ b/src/spdl/pipeline/_priority_interpreter_executor.py
@@ -1,0 +1,193 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""Priority-queue-based InterpreterPoolExecutor for SPDL pipelines.
+
+Python 3.14+ only. Provides an InterpreterPoolExecutor variant that
+prioritizes downstream pipeline stages over upstream ones.
+
+Usage::
+
+    pool = PriorityInterpreterPoolExecutor(max_workers=4)
+
+    pipeline = (
+        PipelineBuilder()
+        .add_source(range(100))
+        .pipe(load, executor=pool.get_executor(), concurrency=4)
+        .pipe(decode, executor=pool.get_executor(), concurrency=4)
+        .pipe(transform, executor=pool.get_executor(), concurrency=4)
+        .add_sink(3)
+        .build(num_threads=1)
+    )
+
+Executors created later automatically have higher priority. Downstream
+stages should be created after upstream ones.
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import Any, Callable
+
+from ._priority_executor import (
+    _assign_owner_id,
+    _OWNER_REGISTRY,
+    _PriorityExecutorBase,
+    _PriorityQueueAdapter,
+    PriorityExecutorEntrypoint,
+)
+
+__all__ = [
+    "PriorityInterpreterPoolExecutor",
+]
+
+
+if sys.version_info < (3, 14):
+    from concurrent.futures import Executor
+
+    class PriorityInterpreterPoolExecutor(Executor):
+        """Stub for Python < 3.14. Raises ``RuntimeError`` on instantiation."""
+
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            raise RuntimeError(
+                f"PriorityInterpreterPoolExecutor requires Python 3.14 or later. "
+                f"Current version: {sys.version_info.major}.{sys.version_info.minor}"
+            )
+
+        def get_executor(
+            self, *, priority: int | None = None
+        ) -> PriorityExecutorEntrypoint:
+            raise RuntimeError(
+                "PriorityInterpreterPoolExecutor requires Python 3.14 or later."
+            )
+
+else:
+    from concurrent.futures import (
+        _base,  # pyre-ignore[21]
+        Future,
+        thread as _thread_mod,  # pyre-ignore[21]
+    )
+    from concurrent.futures.interpreter import (  # pyre-ignore[21]
+        BrokenInterpreterPool,
+        InterpreterPoolExecutor,
+    )
+    from concurrent.futures.thread import _WorkItem  # pyre-ignore[21]
+
+    class PriorityInterpreterPoolExecutor(_PriorityExecutorBase):  # type: ignore[no-redef]
+        """An ``InterpreterPoolExecutor`` wrapper with priority-ordered queue.
+
+        Use ``get_executor()`` to create per-stage executors. Executors
+        created later automatically have higher priority (processed first).
+
+        Supports the pickle protocol for use with
+        ``run_pipeline_in_subprocess()``.
+
+        Python 3.14+ only.
+
+        Example::
+
+            pool = PriorityInterpreterPoolExecutor(max_workers=4)
+
+            pipeline = (
+                PipelineBuilder()
+                .add_source(range(100))
+                .pipe(load, executor=pool.get_executor(), concurrency=4)
+                .pipe(decode, executor=pool.get_executor(), concurrency=4)
+                .pipe(transform, executor=pool.get_executor(), concurrency=4)
+                .add_sink(3)
+                .build(num_threads=1)
+            )
+
+            with pipeline.auto_stop():
+                for item in pipeline.get_iterator():
+                    process(item)
+
+            pool.shutdown()
+        """
+
+        _pool_executor_class: type = InterpreterPoolExecutor
+
+        def __init__(
+            self,
+            max_workers: int | None = None,
+            thread_name_prefix: str = "",
+            initializer: Callable[..., object] | None = None,
+            initargs: tuple[Any, ...] = (),
+        ) -> None:
+            self._kwargs: dict[str, Any] = {
+                "max_workers": max_workers,
+                "thread_name_prefix": thread_name_prefix,
+                "initializer": initializer,
+                "initargs": initargs,
+            }
+            self._pool: InterpreterPoolExecutor = InterpreterPoolExecutor(
+                **self._kwargs
+            )
+            self._work_queue: _PriorityQueueAdapter = _PriorityQueueAdapter()
+            self._pool._work_queue = self._work_queue  # type: ignore[assignment]
+            self._priority_counter: int = 0
+            self._id: int = _assign_owner_id()
+            _OWNER_REGISTRY[self._id] = self
+
+        def _submit_with_priority(
+            self,
+            priority: tuple[int, int],
+            fn: Callable[..., Any],
+            args: tuple[Any, ...],
+            kwargs: dict[str, Any],
+        ) -> Future[Any]:
+            pool = self._pool
+            with pool._shutdown_lock, _thread_mod._global_shutdown_lock:
+                if pool._broken:
+                    raise BrokenInterpreterPool(pool._broken)
+                if pool._shutdown:
+                    raise RuntimeError("cannot schedule new futures after shutdown")
+                if _thread_mod._shutdown:
+                    raise RuntimeError(
+                        "cannot schedule new futures after interpreter shutdown"
+                    )
+
+                f: Future[Any] = _base.Future()
+                task = pool._resolve_work_item_task(fn, args, kwargs)
+                w = _WorkItem(f, task)
+                self._work_queue.put(w, priority=priority)
+                pool._adjust_thread_count()
+                return f
+
+        def shutdown(self, wait: bool = True, cancel_futures: bool = False) -> None:
+            pool = self._pool
+            with pool._shutdown_lock:
+                pool._shutdown = True
+                if cancel_futures:
+                    while not self._work_queue.empty():
+                        try:
+                            work_item = self._work_queue.get_nowait()
+                        except Exception:
+                            break
+                        if work_item is not None:
+                            work_item.future.cancel()
+                            work_item.future.set_running_or_notify_cancel()
+                for _ in pool._threads:
+                    self._work_queue.put(None, priority=(sys.maxsize, 0))
+            if wait:
+                for t in pool._threads:
+                    t.join()
+            _OWNER_REGISTRY.pop(self._id, None)
+
+        def __setstate__(self, state: dict[str, Any]) -> None:
+            existing = _OWNER_REGISTRY.get(state["id"])
+            if existing is not None:
+                self.__dict__.update(existing.__dict__)
+                return
+            self._kwargs = state["kwargs"]
+            self._priority_counter = state["priority_counter"]
+            self._id = state["id"]
+            self._pool = InterpreterPoolExecutor(**self._kwargs)
+            self._work_queue = _PriorityQueueAdapter()
+            self._pool._work_queue = self._work_queue  # type: ignore[assignment]
+            _OWNER_REGISTRY[self._id] = self

--- a/tests/pipeline/priority_executor_test.py
+++ b/tests/pipeline/priority_executor_test.py
@@ -1,0 +1,903 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import gc
+import itertools
+import pickle
+import sys
+import threading
+import time
+import unittest
+import weakref
+from concurrent.futures import Executor, Future, ThreadPoolExecutor
+from queue import Empty
+
+from spdl.pipeline import (
+    PipelineBuilder,
+    PipelineFailure,
+    PriorityExecutorEntrypoint,
+    PriorityProcessPoolExecutor,
+    PriorityThreadPoolExecutor,
+)
+from spdl.pipeline._priority_executor import _OWNER_REGISTRY, _PriorityQueueAdapter
+
+
+def _raise_value_error() -> None:
+    raise ValueError("process boom")
+
+
+# ─── _PriorityQueueAdapter unit tests ───
+
+
+class TestPriorityQueueAdapter(unittest.TestCase):
+    def test_priority_ordering(self) -> None:
+        q = _PriorityQueueAdapter()
+        q.put("low")
+        q.put("high")
+        q.put("mid")
+        # All inserted without priority context → same default → FIFO
+        self.assertEqual(q.get(), "low")
+        self.assertEqual(q.get(), "high")
+        self.assertEqual(q.get(), "mid")
+
+    def test_priority_ordering_with_explicit_priority(self) -> None:
+        q = _PriorityQueueAdapter()
+
+        q.put("low", priority=(10, 0))
+        q.put("high", priority=(0, 0))
+        q.put("mid", priority=(5, 0))
+
+        self.assertEqual(q.get(), "high")
+        self.assertEqual(q.get(), "mid")
+        self.assertEqual(q.get(), "low")
+
+    def test_fifo_within_same_priority(self) -> None:
+        q = _PriorityQueueAdapter()
+        for i in range(5):
+            q.put(f"item_{i}", priority=(1, i))
+
+        for i in range(5):
+            self.assertEqual(q.get(), f"item_{i}")
+
+    def test_sentinel_none_processed_first(self) -> None:
+        q = _PriorityQueueAdapter()
+        q.put("work", priority=(0, 0))
+        q.put(None)  # shutdown sentinel, no priority
+
+        self.assertIsNone(q.get())
+        self.assertEqual(q.get(), "work")
+
+    def test_get_nowait_empty_raises(self) -> None:
+        q = _PriorityQueueAdapter()
+        with self.assertRaises(Empty):
+            q.get_nowait()
+
+    def test_empty_and_qsize(self) -> None:
+        q = _PriorityQueueAdapter()
+        self.assertTrue(q.empty())
+        self.assertEqual(q.qsize(), 0)
+        q.put("x")
+        self.assertFalse(q.empty())
+        self.assertEqual(q.qsize(), 1)
+
+
+# ─── PriorityExecutorEntrypoint unit tests ───
+
+
+class TestPriorityExecutorEntrypoint(unittest.TestCase):
+    def test_submit_returns_future(self) -> None:
+        executor = PriorityThreadPoolExecutor(max_workers=1)
+        stage = executor.get_executor()
+        fut = stage.submit(lambda: 42)
+        self.assertIsInstance(fut, Future)
+        self.assertEqual(fut.result(timeout=5), 42)
+        executor.shutdown()
+
+    def test_is_executor_compatible(self) -> None:
+        executor = PriorityThreadPoolExecutor(max_workers=1)
+        stage = executor.get_executor()
+        self.assertIsInstance(stage, Executor)
+        executor.shutdown()
+
+    def test_shutdown_is_noop(self) -> None:
+        executor = PriorityThreadPoolExecutor(max_workers=1)
+        stage = executor.get_executor()
+        stage.shutdown()  # should not affect the pool
+        fut = stage.submit(lambda: 1)
+        self.assertEqual(fut.result(timeout=5), 1)
+        executor.shutdown()
+
+
+# ─── PriorityThreadPoolExecutor ordering tests ───
+
+
+class TestPriorityThreadPoolExecutorOrdering(unittest.TestCase):
+    def test_downstream_stage_runs_first(self) -> None:
+        """With 1 worker, tasks are executed in priority order."""
+        barrier = threading.Barrier(2)
+        results: list[str] = []
+
+        executor = PriorityThreadPoolExecutor(max_workers=1)
+        upstream = executor.get_executor(priority=0)
+        downstream = executor.get_executor(priority=2)
+
+        # Block the single worker so we can enqueue both tasks
+        executor.get_executor().submit(lambda: barrier.wait(timeout=5))
+
+        # Enqueue upstream first, then downstream
+        upstream.submit(lambda: results.append("upstream"))
+        downstream.submit(lambda: results.append("downstream"))
+
+        # Release the worker
+        barrier.wait(timeout=5)
+        executor.shutdown(wait=True)
+
+        self.assertEqual(results, ["downstream", "upstream"])
+
+    def test_fifo_within_stage(self) -> None:
+        barrier = threading.Barrier(2)
+        results: list[int] = []
+
+        executor = PriorityThreadPoolExecutor(max_workers=1)
+        stage = executor.get_executor()
+
+        executor.get_executor().submit(lambda: barrier.wait(timeout=5))
+
+        for i in range(5):
+            stage.submit(lambda i=i: results.append(i))
+
+        barrier.wait(timeout=5)
+        executor.shutdown(wait=True)
+
+        self.assertEqual(results, [0, 1, 2, 3, 4])
+
+    def test_multiple_stages_interleaved(self) -> None:
+        """3 stages, items interleaved — should sort by priority then FIFO."""
+        barrier = threading.Barrier(2)
+        results: list[tuple[int, int]] = []
+
+        executor = PriorityThreadPoolExecutor(max_workers=1)
+        stages = [executor.get_executor(priority=p) for p in [0, 1, 2]]
+
+        executor.get_executor().submit(lambda: barrier.wait(timeout=5))
+
+        # Submit: stage0, stage1, stage2, stage0, stage1, stage2
+        for round_idx in range(2):
+            for idx, stage in enumerate(stages):
+                stage.submit(lambda i=idx, ri=round_idx: results.append((i, ri)))
+
+        barrier.wait(timeout=5)
+        executor.shutdown(wait=True)
+
+        # priority 2 (highest) first, then priority 1, then priority 0
+        # Within same priority, FIFO by round
+        self.assertEqual(
+            results,
+            [(2, 0), (2, 1), (1, 0), (1, 1), (0, 0), (0, 1)],
+        )
+
+    def test_basic_execution(self) -> None:
+        executor = PriorityThreadPoolExecutor(max_workers=2)
+        stage = executor.get_executor()
+        futs = [stage.submit(lambda x=x: x * 2, x) for x in range(10)]
+        results = {f.result(timeout=5) for f in futs}
+        self.assertEqual(results, {x * 2 for x in range(10)})
+        executor.shutdown()
+
+    def test_exception_propagation(self) -> None:
+        executor = PriorityThreadPoolExecutor(max_workers=1)
+        stage = executor.get_executor()
+
+        def fail() -> None:
+            raise ValueError("boom")
+
+        fut = stage.submit(fail)
+        with self.assertRaises(ValueError):
+            fut.result(timeout=5)
+        executor.shutdown()
+
+    def test_submit_after_shutdown_raises(self) -> None:
+        executor = PriorityThreadPoolExecutor(max_workers=1)
+        stage = executor.get_executor()
+        executor.shutdown()
+        with self.assertRaises(RuntimeError):
+            executor._submit_with_priority((0, 0), lambda: None, (), {})
+
+    def test_multiple_workers_all_complete(self) -> None:
+        """With multiple workers, all tasks must complete."""
+        executor = PriorityThreadPoolExecutor(max_workers=4)
+        stages = [executor.get_executor() for _ in range(3)]
+
+        counter: itertools.count[int] = itertools.count()
+        results: list[int] = []
+        lock: threading.Lock = threading.Lock()
+
+        def work() -> None:
+            val = next(counter)
+            with lock:
+                results.append(val)
+
+        futs = []
+        for stage in stages:
+            for _ in range(10):
+                futs.append(stage.submit(work))
+
+        for f in futs:
+            f.result(timeout=10)
+
+        executor.shutdown()
+        self.assertEqual(len(results), 30)
+
+
+# ─── PriorityProcessPoolExecutor tests ───
+
+
+class TestPriorityProcessPoolExecutor(unittest.TestCase):
+    def test_basic_execution(self) -> None:
+        executor = PriorityProcessPoolExecutor(max_workers=2)
+        stage = executor.get_executor()
+        futs = [stage.submit(pow, 2, x) for x in range(10)]
+        results = {f.result(timeout=10) for f in futs}
+        self.assertEqual(results, {2**x for x in range(10)})
+        executor.shutdown()
+
+    def test_exception_propagation(self) -> None:
+        executor = PriorityProcessPoolExecutor(max_workers=1)
+        stage = executor.get_executor()
+
+        fut = stage.submit(_raise_value_error)
+        with self.assertRaises(ValueError):
+            fut.result(timeout=10)
+        executor.shutdown()
+
+
+# ─── Pipeline integration: correctness ───
+
+
+class TestPriorityExecutorPipelineCorrectness(unittest.TestCase):
+    def test_two_stage_pipeline(self) -> None:
+        """All items flow through correctly with a shared priority executor."""
+        pool = PriorityThreadPoolExecutor(max_workers=4)
+        s1 = pool.get_executor()
+        s2 = pool.get_executor()
+
+        pipeline = (
+            PipelineBuilder()
+            .add_source(range(20))
+            .pipe(lambda x: x * 2, executor=s1, concurrency=4)
+            .pipe(lambda x: x + 1, executor=s2, concurrency=4)
+            .add_sink(3)
+            .build(num_threads=1)
+        )
+
+        with pipeline.auto_stop():
+            results = sorted(pipeline.get_iterator(timeout=10))
+
+        self.assertEqual(results, sorted(x * 2 + 1 for x in range(20)))
+        pool.shutdown()
+
+    def test_three_stage_pipeline(self) -> None:
+        pool = PriorityThreadPoolExecutor(max_workers=4)
+        s1 = pool.get_executor()
+        s2 = pool.get_executor()
+        s3 = pool.get_executor()
+
+        pipeline = (
+            PipelineBuilder()
+            .add_source(range(15))
+            .pipe(lambda x: x + 1, executor=s1, concurrency=2)
+            .pipe(lambda x: x * 3, executor=s2, concurrency=2)
+            .pipe(lambda x: x - 1, executor=s3, concurrency=2)
+            .add_sink(3)
+            .build(num_threads=1)
+        )
+
+        with pipeline.auto_stop():
+            results = sorted(pipeline.get_iterator(timeout=10))
+
+        self.assertEqual(results, sorted((x + 1) * 3 - 1 for x in range(15)))
+        pool.shutdown()
+
+    def test_mixed_priority_and_default_executor(self) -> None:
+        """Some stages use priority executor, others use default."""
+        pool = PriorityThreadPoolExecutor(max_workers=2)
+        s1 = pool.get_executor()
+
+        pipeline = (
+            PipelineBuilder()
+            .add_source(range(10))
+            .pipe(lambda x: x * 2, executor=s1, concurrency=2)
+            .pipe(lambda x: x + 1, concurrency=2)
+            .add_sink(3)
+            .build(num_threads=2)
+        )
+
+        with pipeline.auto_stop():
+            results = sorted(pipeline.get_iterator(timeout=10))
+
+        self.assertEqual(results, sorted(x * 2 + 1 for x in range(10)))
+        pool.shutdown()
+
+    def test_exception_propagates_through_pipeline(self) -> None:
+        pool = PriorityThreadPoolExecutor(max_workers=2)
+        s1 = pool.get_executor()
+        s2 = pool.get_executor()
+
+        def fail_on_five(x: int) -> int:
+            if x == 5:
+                raise ValueError("boom on 5")
+            return x
+
+        pipeline = (
+            PipelineBuilder()
+            .add_source(range(10))
+            .pipe(fail_on_five, executor=s1, concurrency=1, max_failures=0)
+            .pipe(lambda x: x, executor=s2, concurrency=1)
+            .add_sink(3)
+            .build(num_threads=1)
+        )
+
+        with self.assertRaises(PipelineFailure):
+            with pipeline.auto_stop():
+                list(pipeline.get_iterator(timeout=10))
+
+        pool.shutdown()
+
+
+# ─── Pipeline integration: priority ordering ───
+
+
+class TestPriorityExecutorPipelineOrdering(unittest.TestCase):
+    def test_downstream_not_starved(self) -> None:
+        """With 1 shared worker, downstream should interleave with upstream,
+        not wait until all upstream completes."""
+        execution_log: list[tuple[str, int]] = []
+        lock: threading.Lock = threading.Lock()
+
+        pool = PriorityThreadPoolExecutor(max_workers=1)
+        upstream_exec = pool.get_executor()
+        downstream_exec = pool.get_executor()
+
+        def upstream_op(item: int) -> int:
+            with lock:
+                execution_log.append(("up", item))
+            # Sleep so the event loop has time to submit the downstream task
+            # before the worker picks the next item.
+            time.sleep(0.03)
+            return item
+
+        def downstream_op(item: int) -> int:
+            with lock:
+                execution_log.append(("down", item))
+            return item
+
+        pipeline = (
+            PipelineBuilder()
+            .add_source(range(8))
+            .pipe(upstream_op, executor=upstream_exec, concurrency=1)
+            .pipe(downstream_op, executor=downstream_exec, concurrency=1)
+            .add_sink(3)
+            .build(num_threads=1)
+        )
+
+        with pipeline.auto_stop():
+            results = list(pipeline.get_iterator(timeout=30))
+
+        self.assertEqual(len(results), 8)
+        pool.shutdown()
+
+        # With priority: up/down alternate → max consecutive upstream ≤ 2.
+        # Without priority (FIFO): upstream dominates → all upstream first.
+        max_consec_up = 0
+        consec = 0
+        for stage, _ in execution_log:
+            if stage == "up":
+                consec += 1
+                max_consec_up = max(max_consec_up, consec)
+            else:
+                consec = 0
+
+        self.assertLessEqual(
+            max_consec_up,
+            2,
+            f"Upstream ran {max_consec_up} consecutive times — "
+            f"downstream was starved. Full log: {execution_log}",
+        )
+
+    def test_three_stage_priority_order(self) -> None:
+        """With 3 stages sharing 1 worker, the most downstream stage
+        with pending work should run first."""
+        execution_log: list[tuple[str, int]] = []
+        lock: threading.Lock = threading.Lock()
+
+        pool = PriorityThreadPoolExecutor(max_workers=1)
+        s1_exec = pool.get_executor()
+        s2_exec = pool.get_executor()
+        s3_exec = pool.get_executor()
+
+        def make_op(name: str):  # pyre-ignore[3]
+            def op(item: int) -> int:
+                with lock:
+                    execution_log.append((name, item))
+                time.sleep(0.03)
+                return item
+
+            return op
+
+        pipeline = (
+            PipelineBuilder()
+            .add_source(range(6))
+            .pipe(make_op("s1"), executor=s1_exec, concurrency=1)
+            .pipe(make_op("s2"), executor=s2_exec, concurrency=1)
+            .pipe(make_op("s3"), executor=s3_exec, concurrency=1)
+            .add_sink(3)
+            .build(num_threads=1)
+        )
+
+        with pipeline.auto_stop():
+            results = list(pipeline.get_iterator(timeout=30))
+
+        self.assertEqual(len(results), 6)
+        pool.shutdown()
+
+        # After downstream stages have pending work, upstream should not
+        # run consecutively.
+        stages = [stage for stage, _ in execution_log]
+        for i in range(len(stages) - 1):
+            if stages[i] == "s1" and stages[i + 1] == "s1":
+                prior = stages[:i]
+                self.assertNotIn(
+                    "s2",
+                    prior,
+                    f"Consecutive s1 at positions {i},{i + 1} after s2 "
+                    f"already had work. Log: {execution_log}",
+                )
+
+    def test_priority_vs_fifo_comparison(self) -> None:
+        """Priority executor interleaves downstream at least as well as FIFO."""
+
+        def run_pipeline(
+            upstream_exec: Executor,
+            downstream_exec: Executor,
+            num_threads: int,
+        ) -> list[str]:
+            log: list[str] = []
+            lock: threading.Lock = threading.Lock()
+
+            def up_op(item: int) -> int:
+                with lock:
+                    log.append("up")
+                time.sleep(0.03)
+                return item
+
+            def down_op(item: int) -> int:
+                with lock:
+                    log.append("down")
+                return item
+
+            pipeline = (
+                PipelineBuilder()
+                .add_source(range(8))
+                .pipe(up_op, executor=upstream_exec, concurrency=1)
+                .pipe(down_op, executor=downstream_exec, concurrency=1)
+                .add_sink(3)
+                .build(num_threads=num_threads)
+            )
+
+            with pipeline.auto_stop():
+                list(pipeline.get_iterator(timeout=30))
+            return log
+
+        # Priority executor
+        pool = PriorityThreadPoolExecutor(max_workers=1)
+        priority_log = run_pipeline(
+            pool.get_executor(),
+            pool.get_executor(),
+            num_threads=1,
+        )
+        pool.shutdown()
+
+        # Plain FIFO executor
+        plain = ThreadPoolExecutor(max_workers=1)
+        fifo_log = run_pipeline(plain, plain, num_threads=1)
+        plain.shutdown()
+
+        # With priority, downstream entries should appear at least as early.
+        halfway = len(priority_log) // 2
+        priority_down_first_half = priority_log[:halfway].count("down")
+        fifo_down_first_half = fifo_log[:halfway].count("down")
+
+        self.assertGreaterEqual(
+            priority_down_first_half,
+            fifo_down_first_half,
+            f"Priority executor should interleave downstream tasks at least "
+            f"as well as FIFO.\n"
+            f"Priority log: {priority_log}\n"
+            f"FIFO log: {fifo_log}",
+        )
+
+
+# ─── Drop-in compatibility ───
+
+
+class TestDropInCompatibility(unittest.TestCase):
+    def test_stage_executor_with_as_completed(self) -> None:
+        from concurrent.futures import as_completed
+
+        pool = PriorityThreadPoolExecutor(max_workers=2)
+        stage = pool.get_executor()
+        futs = [stage.submit(pow, 2, i) for i in range(5)]
+        results = set()
+        for f in as_completed(futs, timeout=5):
+            results.add(f.result())
+        self.assertEqual(results, {1, 2, 4, 8, 16})
+        pool.shutdown()
+
+    def test_context_manager(self) -> None:
+        with PriorityThreadPoolExecutor(max_workers=2) as executor:
+            stage = executor.get_executor()
+            self.assertEqual(stage.submit(lambda: 99).result(timeout=5), 99)
+
+
+# ─── Mixed priority + regular ThreadPoolExecutor pipelines ───
+
+
+class TestMixedExecutorPipeline(unittest.TestCase):
+    def test_priority_upstream_regular_downstream(self) -> None:
+        """Priority executor on upstream stages, regular ThreadPoolExecutor
+        on downstream stage."""
+        pool = PriorityThreadPoolExecutor(max_workers=2)
+        regular = ThreadPoolExecutor(max_workers=2)
+
+        pipeline = (
+            PipelineBuilder()
+            .add_source(range(20))
+            .pipe(lambda x: x * 2, executor=pool.get_executor(), concurrency=2)
+            .pipe(lambda x: x + 1, executor=regular, concurrency=2)
+            .add_sink(3)
+            .build(num_threads=1)
+        )
+
+        with pipeline.auto_stop():
+            results = sorted(pipeline.get_iterator(timeout=10))
+
+        self.assertEqual(results, sorted(x * 2 + 1 for x in range(20)))
+        pool.shutdown()
+        regular.shutdown()
+
+    def test_regular_upstream_priority_downstream(self) -> None:
+        """Regular ThreadPoolExecutor on upstream, priority executor on
+        downstream."""
+        pool = PriorityThreadPoolExecutor(max_workers=2)
+        regular = ThreadPoolExecutor(max_workers=2)
+
+        pipeline = (
+            PipelineBuilder()
+            .add_source(range(20))
+            .pipe(lambda x: x + 10, executor=regular, concurrency=2)
+            .pipe(lambda x: x * 3, executor=pool.get_executor(), concurrency=2)
+            .add_sink(3)
+            .build(num_threads=1)
+        )
+
+        with pipeline.auto_stop():
+            results = sorted(pipeline.get_iterator(timeout=10))
+
+        self.assertEqual(results, sorted((x + 10) * 3 for x in range(20)))
+        pool.shutdown()
+        regular.shutdown()
+
+    def test_three_stage_alternating_executors(self) -> None:
+        """Three stages: priority, regular, priority — verifying they
+        compose correctly."""
+        pool = PriorityThreadPoolExecutor(max_workers=3)
+        regular = ThreadPoolExecutor(max_workers=2)
+
+        pipeline = (
+            PipelineBuilder()
+            .add_source(range(15))
+            .pipe(lambda x: x + 1, executor=pool.get_executor(), concurrency=2)
+            .pipe(lambda x: x * 2, executor=regular, concurrency=2)
+            .pipe(lambda x: x - 1, executor=pool.get_executor(), concurrency=2)
+            .add_sink(3)
+            .build(num_threads=1)
+        )
+
+        with pipeline.auto_stop():
+            results = sorted(pipeline.get_iterator(timeout=10))
+
+        self.assertEqual(results, sorted((x + 1) * 2 - 1 for x in range(15)))
+        pool.shutdown()
+        regular.shutdown()
+
+    def test_two_priority_pools_and_regular(self) -> None:
+        """Two independent priority pools plus a regular pool, all in one
+        pipeline."""
+        pool_a = PriorityThreadPoolExecutor(max_workers=2)
+        pool_b = PriorityThreadPoolExecutor(max_workers=2)
+        regular = ThreadPoolExecutor(max_workers=2)
+
+        pipeline = (
+            PipelineBuilder()
+            .add_source(range(12))
+            .pipe(lambda x: x + 1, executor=pool_a.get_executor(), concurrency=2)
+            .pipe(lambda x: x * 2, executor=regular, concurrency=2)
+            .pipe(lambda x: x - 1, executor=pool_b.get_executor(), concurrency=2)
+            .add_sink(3)
+            .build(num_threads=1)
+        )
+
+        with pipeline.auto_stop():
+            results = sorted(pipeline.get_iterator(timeout=10))
+
+        self.assertEqual(results, sorted((x + 1) * 2 - 1 for x in range(12)))
+        pool_a.shutdown()
+        pool_b.shutdown()
+        regular.shutdown()
+
+    def test_exception_in_regular_stage(self) -> None:
+        """Exception in the regular executor stage propagates correctly."""
+        pool = PriorityThreadPoolExecutor(max_workers=2)
+        regular = ThreadPoolExecutor(max_workers=2)
+
+        def fail_on_five(x: int) -> int:
+            if x == 5:
+                raise ValueError("mixed boom")
+            return x
+
+        pipeline = (
+            PipelineBuilder()
+            .add_source(range(10))
+            .pipe(lambda x: x, executor=pool.get_executor(), concurrency=2)
+            .pipe(fail_on_five, executor=regular, concurrency=1, max_failures=0)
+            .add_sink(3)
+            .build(num_threads=1)
+        )
+
+        with self.assertRaises(PipelineFailure):
+            with pipeline.auto_stop():
+                list(pipeline.get_iterator(timeout=10))
+
+        pool.shutdown()
+        regular.shutdown()
+
+
+# ─── Pickle support ───
+
+
+class TestPriorityExecutorPickle(unittest.TestCase):
+    def test_thread_executor_round_trip(self) -> None:
+        pool = PriorityThreadPoolExecutor(max_workers=4)
+        data = pickle.dumps(pool)
+        pool.shutdown()
+
+        restored = pickle.loads(data)
+        stage = restored.get_executor()
+        fut = stage.submit(pow, 2, 10)
+        self.assertEqual(fut.result(timeout=5), 1024)
+        restored.shutdown()
+
+    def test_entrypoint_round_trip(self) -> None:
+        pool = PriorityThreadPoolExecutor(max_workers=2)
+        ep = pool.get_executor(priority=5)
+        data = pickle.dumps(ep)
+        pool.shutdown()
+
+        restored_ep = pickle.loads(data)
+        fut = restored_ep.submit(pow, 2, 3)
+        self.assertEqual(fut.result(timeout=5), 8)
+        restored_ep._owner.shutdown()
+
+    def test_multiple_entrypoints_share_master(self) -> None:
+        pool = PriorityThreadPoolExecutor(max_workers=2)
+        ep1 = pool.get_executor(priority=1)
+        ep2 = pool.get_executor(priority=2)
+
+        data1 = pickle.dumps(ep1)
+        data2 = pickle.dumps(ep2)
+
+        # Remove original pool from registry to simulate new process
+        pool_id = pool._id
+        pool.shutdown()
+        _OWNER_REGISTRY.pop(pool_id, None)
+
+        restored1 = pickle.loads(data1)
+        restored2 = pickle.loads(data2)
+
+        self.assertIs(restored1._owner, restored2._owner)
+
+        fut1 = restored1.submit(pow, 2, 3)
+        fut2 = restored2.submit(pow, 3, 2)
+        self.assertEqual(fut1.result(timeout=5), 8)
+        self.assertEqual(fut2.result(timeout=5), 9)
+        restored1._owner.shutdown()
+
+    def test_process_executor_round_trip(self) -> None:
+        pool = PriorityProcessPoolExecutor(max_workers=2)
+        data = pickle.dumps(pool)
+        pool.shutdown()
+
+        restored = pickle.loads(data)
+        stage = restored.get_executor()
+        fut = stage.submit(pow, 2, 10)
+        self.assertEqual(fut.result(timeout=10), 1024)
+        restored.shutdown()
+
+    def test_entrypoint_is_executor_subclass_after_unpickle(self) -> None:
+        pool = PriorityThreadPoolExecutor(max_workers=1)
+        ep = pool.get_executor()
+        data = pickle.dumps(ep)
+        pool.shutdown()
+
+        restored = pickle.loads(data)
+        self.assertIsInstance(restored, Executor)
+        self.assertIsInstance(restored, PriorityExecutorEntrypoint)
+        restored._owner.shutdown()
+
+    def test_entrypoint_priority_preserved(self) -> None:
+        """Priority ordering is preserved across pickle round-trip."""
+        pool = PriorityThreadPoolExecutor(max_workers=1)
+        upstream = pool.get_executor(priority=0)
+        downstream = pool.get_executor(priority=2)
+
+        data_up = pickle.dumps(upstream)
+        data_down = pickle.dumps(downstream)
+        pool.shutdown()
+        _OWNER_REGISTRY.pop(pool._id, None)
+
+        restored_up = pickle.loads(data_down)
+        restored_down = pickle.loads(data_up)
+
+        # Submit and wait for results
+        fut_up = restored_up.submit(pow, 2, 3)
+        fut_down = restored_down.submit(pow, 3, 2)
+        self.assertEqual(fut_up.result(timeout=5), 8)
+        self.assertEqual(fut_down.result(timeout=5), 9)
+
+        # Verify both share the same owner
+        self.assertIs(restored_up._owner, restored_down._owner)
+        # Verify priority values were preserved
+        self.assertEqual(restored_up._priority, -2)
+        self.assertEqual(restored_down._priority, 0)
+        restored_up._owner.shutdown()
+
+
+# ─── Garbage collection ───
+
+
+class TestPriorityExecutorGarbageCollection(unittest.TestCase):
+    def test_owner_gc_after_all_references_dropped(self) -> None:
+        """Owner is garbage-collected once all entrypoints and user refs are gone."""
+        pool = PriorityThreadPoolExecutor(max_workers=1)
+        owner_id = pool._id
+        weak = weakref.ref(pool)
+        stage = pool.get_executor()
+
+        self.assertIn(owner_id, _OWNER_REGISTRY)
+        self.assertIsNotNone(weak())
+
+        # Drop the user reference — entrypoint still holds a strong ref
+        del pool
+        gc.collect()
+        self.assertIsNotNone(weak())
+
+        # Drop the entrypoint — last strong ref gone
+        del stage
+        gc.collect()
+        self.assertIsNone(weak())
+        self.assertNotIn(owner_id, _OWNER_REGISTRY)
+
+    def test_owner_gc_multiple_entrypoints(self) -> None:
+        """Owner survives until ALL entrypoints are dropped."""
+        pool = PriorityThreadPoolExecutor(max_workers=1)
+        weak = weakref.ref(pool)
+        s1 = pool.get_executor()
+        s2 = pool.get_executor()
+        del pool
+        gc.collect()
+
+        self.assertIsNotNone(weak())
+        del s1
+        gc.collect()
+        self.assertIsNotNone(weak())
+        del s2
+        gc.collect()
+        self.assertIsNone(weak())
+
+    def test_owner_gc_after_shutdown(self) -> None:
+        """Shutdown + dropping all refs allows GC."""
+        pool = PriorityThreadPoolExecutor(max_workers=1)
+        weak = weakref.ref(pool)
+        stage = pool.get_executor()
+        fut = stage.submit(lambda: 42)
+        self.assertEqual(fut.result(timeout=5), 42)
+
+        pool.shutdown()
+        del pool
+        gc.collect()
+        # Entrypoint still holds a strong ref
+        self.assertIsNotNone(weak())
+
+        del stage
+        gc.collect()
+        self.assertIsNone(weak())
+
+
+# ─── PriorityInterpreterPoolExecutor tests (Python 3.14+ only) ───
+
+_has_interpreter_pool: bool = sys.version_info >= (3, 14)
+
+
+@unittest.skipUnless(
+    _has_interpreter_pool, "InterpreterPoolExecutor requires Python 3.14+"
+)
+class TestPriorityInterpreterPoolExecutor(unittest.TestCase):
+    def test_basic_execution(self) -> None:
+        from spdl.pipeline import PriorityInterpreterPoolExecutor
+
+        executor = PriorityInterpreterPoolExecutor(max_workers=2)
+        stage = executor.get_executor()
+        futs = [stage.submit(pow, 2, x) for x in range(10)]
+        results = {f.result(timeout=10) for f in futs}
+        self.assertEqual(results, {2**x for x in range(10)})
+        executor.shutdown()
+
+    def test_exception_propagation(self) -> None:
+        from spdl.pipeline import PriorityInterpreterPoolExecutor
+
+        executor = PriorityInterpreterPoolExecutor(max_workers=1)
+        stage = executor.get_executor()
+
+        def fail() -> None:
+            raise ValueError("interpreter boom")
+
+        fut = stage.submit(fail)
+        with self.assertRaises(ValueError):
+            fut.result(timeout=10)
+        executor.shutdown()
+
+    def test_submit_after_shutdown_raises(self) -> None:
+        from spdl.pipeline import PriorityInterpreterPoolExecutor
+
+        executor = PriorityInterpreterPoolExecutor(max_workers=1)
+        stage = executor.get_executor()
+        executor.shutdown()
+        with self.assertRaises(RuntimeError):
+            executor._submit_with_priority(  # pyre-ignore[16]
+                (0, 0), lambda: None, (), {}
+            )
+
+    def test_is_executor_compatible(self) -> None:
+        from spdl.pipeline import PriorityInterpreterPoolExecutor
+
+        executor = PriorityInterpreterPoolExecutor(max_workers=1)
+        stage = executor.get_executor()
+        self.assertIsInstance(stage, Executor)
+        executor.shutdown()
+
+    def test_pipeline_two_stage(self) -> None:
+        from spdl.pipeline import PriorityInterpreterPoolExecutor
+
+        pool = PriorityInterpreterPoolExecutor(max_workers=4)
+        s1 = pool.get_executor()
+        s2 = pool.get_executor()
+
+        pipeline = (
+            PipelineBuilder()
+            .add_source(range(20))
+            .pipe(lambda x: x * 2, executor=s1, concurrency=4)
+            .pipe(lambda x: x + 1, executor=s2, concurrency=4)
+            .add_sink(3)
+            .build(num_threads=1)
+        )
+
+        with pipeline.auto_stop():
+            results = sorted(pipeline.get_iterator(timeout=10))
+
+        self.assertEqual(results, sorted(x * 2 + 1 for x in range(20)))
+        pool.shutdown()


### PR DESCRIPTION
Adds `PriorityThreadPoolExecutor`, `PriorityProcessPoolExecutor`, and `PriorityInterpreterPoolExecutor` (Python 3.14+ only) that share a thread/process pool across pipeline stages while prioritizing downstream stages over upstream ones.

This prevents upstream stages from saturating the pool and starving downstream stages, reducing end-to-end latency and buffered intermediate data.

**Design:**
- Master executors use **composition** (not inheritance) — they wrap the stdlib pool executor as a `_pool` attribute rather than subclassing it. This makes them **picklable** for use with `run_pipeline_in_subprocess()`.
- A **global ID-based registry** (`_MASTER_REGISTRY`) ensures that when multiple `PriorityExecutorEntrypoint` instances sharing the same master are deserialized, they reconnect to the same master instance.
- The internal work queue of the pool executor is replaced with a `_PriorityQueueAdapter` backed by `queue.PriorityQueue`.
- `get_executor()` creates `PriorityExecutorEntrypoint` instances with auto-incrementing priority (later = higher priority). Priority can be overridden explicitly via `get_executor(priority=N)`.
- `PriorityExecutorEntrypoint` implements the `concurrent.futures.Executor` interface so it can be passed directly to `PipelineBuilder.pipe(executor=...)`.
- `_convert.py` updated with duck-typing check (`_is_process_pool`) via `_pool_executor_class` class attribute, so `PriorityExecutorEntrypoint` wrapping a `PriorityProcessPoolExecutor` is correctly detected for subprocess-specific wrapping.
- `PriorityInterpreterPoolExecutor` lives in a separate file and uses a stub class on Python < 3.14 that raises `RuntimeError` at instantiation, so the symbol is always importable.

**Pickle protocol:**
- `__getstate__` on master executors serializes: ID, constructor kwargs, priority counter. The pool itself (threads, locks, queues) is excluded.
- `__setstate__` checks the global registry for an existing master with the same ID; if found, reuses it; otherwise creates a fresh pool and registers.
- `PriorityExecutorEntrypoint.__getstate__` serializes: master ID, master class, master kwargs, priority. On deserialization, the `_master` property lazily resolves the master from the registry.

**Compatibility:**
- Works with Python 3.12, 3.13, and 3.14 (handles `_WorkItem` API differences across versions).
- Stages using priority executors can be freely mixed with stages using regular `ThreadPoolExecutor` in the same pipeline.
- Priority executors can be used in subprocess pipelines via `run_pipeline_in_subprocess()`.
