### PR TITLE
[autoresearch] Reduce wasted experiments with dedup, findings KB, and…

### DIFF
--- a/tools/autoresearch/prompts/analyze.md
+++ b/tools/autoresearch/prompts/analyze.md
@@ -48,7 +48,15 @@ __PIPELINE_CODE__
 
 5. **Compare to previous runs**: Compare using steady-state step time (or p50/p75 SM util as proxy). Note whether this is the best run so far.
 
-6. **Output a JSON block** with structured results:
+6. **Extract findings**: Based on this experiment's results, list concrete facts that should guide future experiments. Examples:
+   - "batch_size=64 causes OOM on this hardware"
+   - "num_workers has no effect on step time (tested at 2, 4, 8, 16)"
+   - "torch.compile reduces step time by 36% (240ms → 154ms)"
+   - "data loading headspace is only 4.2% — pipeline tuning has limited upside"
+
+   Only include facts that are clearly established, not speculative.
+
+7. **Output a JSON block** with structured results:
 
 ```json
 {
@@ -65,12 +73,17 @@ __PIPELINE_CODE__
     "improvement_vs_baseline_pct": <number>,
     "is_best_so_far": <true|false>,
     "notes": "<one-line summary of key finding>"
-  }
+  },
+  "findings": [
+    "<fact 1>",
+    "<fact 2>"
+  ]
 }
 ```
 
 For `steady_step_time_ms`: use the median step time after warmup. If per-step data is unavailable, estimate from sink QPS or set to null.
 For `steady_sm_utilization_pct`: use p50 or p75 SM util from system metrics. Prefer p75 for very short jobs (< 5 min).
 For `sm_utilization_pct`: still report the raw average for the master table, but note it's init-diluted.
+For `findings`: list only concrete, established facts. These accumulate across experiments and are shown to future planning sessions.
 
 Be concise. Focus on actionable findings, not restating raw metrics.

--- a/tools/autoresearch/prompts/plan_next.md
+++ b/tools/autoresearch/prompts/plan_next.md
@@ -44,6 +44,12 @@ __HISTORY_JSON__
 __PIPELINE_CODE__
 ```
 
+### Accumulated Findings
+
+The following facts have been established by previous experiments. **Respect these findings — do NOT propose experiments that contradict them.**
+
+__FINDINGS__
+
 ### Additional Context
 __NOTES__
 
@@ -93,17 +99,32 @@ Propose **2-3 experiments per iteration** to make efficient use of compute. The 
    - If Tier 1 was tried (module-level functions with `functools.partial`, re-creating objects in subprocess) and failed, retry with Tier 2 (picklable callable classes that pickle objects directly from the main process, avoiding subprocess imports). Write the `description` field to explicitly specify "Use Tier 2 pickling approach — pickle tokenizer/data objects directly instead of re-creating them in the subprocess."
    - Do NOT mark `subprocess_mtp` as tried until at least one MTP attempt has succeeded or both tiers have been tried.
 
-2. **If all best practices are tried and results are still improving**: Continue with Bayesian optimization principles:
+2. **Use headspace to guide priorities**: Look at the headspace result in the Master Table (the `headspace_cache` row). If headspace is **less than 10%**, data loading is NOT the bottleneck — pivot immediately to model-side optimizations:
+   - `torch.compile` — often the single biggest win (20-40% step time reduction)
+   - Optimizer changes (fused AdamW, FSDP settings)
+   - Mixed precision / gradient scaling
+   - Batch size scaling (to saturate GPU compute, not to fix data loading)
+
+   Do NOT spend experiments sweeping pipeline parameters (num_workers, concurrency) when headspace is <10%. Those will yield <10% improvement at most.
+
+3. **Mark hypotheses as concluded**: Before proposing an experiment, check if the hypothesis has already been tested and disproven:
+   - If **3+ experiments** have shown that varying a parameter (e.g., num_workers) has **no meaningful effect** (<2% difference), that parameter is concluded — do not test more values.
+   - If a batch size caused OOM once, do NOT retry the same or larger batch size.
+   - If a structural change (e.g., fused optimizer) was tried and regressed, do not re-test it unless the approach is fundamentally different.
+
+   State your conclusions explicitly in the reasoning before proposing experiments.
+
+4. **If all best practices are tried and results are still improving**: Continue with Bayesian optimization principles:
    - Model the parameter → metric relationship from history
    - Pick values that maximize expected improvement
    - Balance exploration (untested regions) vs exploitation (near the current best)
    - Respect constraints: CPU ≤ 40%, concurrency ≤ num_CPU_cores / 8
 
-3. **If parameter tuning has plateaued** (diminishing returns across recent iterations): Propose a structural change — splitting stages, different I/O functions, different pipeline topology. The orchestrator can modify source code in-place. Describe the code changes in the experiment's `"description"` field and set `"rebuild": true`.
+5. **If parameter tuning has plateaued** (diminishing returns across recent iterations): Propose a structural change — splitting stages, different I/O functions, different pipeline topology. The orchestrator can modify source code in-place. Describe the code changes in the experiment's `"description"` field and set `"rebuild": true`.
 
-4. **If results are noisy or contradictory**: Propose a repeat of the best configuration to confirm, plus one new exploration point.
+6. **If results are noisy or contradictory**: Propose a repeat of the best configuration to confirm, plus one new exploration point.
 
-5. **Only stop** (`"action": "stop"`) when:
+7. **Only stop** (`"action": "stop"`) when:
    - ALL best practices have been tried (the "Not yet tried" list is empty), AND
    - Metrics have plateaued for __PATIENCE__ consecutive iterations (the plateau count has reached __PATIENCE__)
    - If either condition is not met, you MUST continue with `"action": "launch"`.
@@ -131,10 +152,10 @@ Output your reasoning, then a JSON block:
 ```
 
 Rules:
-- **Do NOT propose experiments that duplicate names already in the Master Table or Experiment History.** Check the existing run names before proposing. If a configuration has already been tested, do not re-test it unless you have a specific reason (e.g., high variance in previous result). Use a distinct name if varying a different parameter.
+- **Do NOT propose experiments that are semantically identical to existing ones**, even under a different name. Before proposing, check the Master Table for any run that used the same launch parameters (batch_size, num_workers, etc.) and code changes. If a configuration has been tested — regardless of what it was named — do not re-test it. The orchestrator also rejects duplicates with matching launch commands.
 - Use `$IMAGE` as placeholder for the job image (the orchestrator substitutes it)
 - torchx entrypoint args use **underscores**, not dashes (e.g. `--num_threads`)
 - If `rebuild` is true, the orchestrator will call a separate Claude session to apply the code changes described in `description`, commit them, rebuild the image, and then launch. **Write the `description` field as precise instructions for what code to modify** — specify function names, SPDL API calls to add/change, and the exact transformation. Do not write vague descriptions like "enable MTP" — instead write "Refactor `build_pipeline()` to return a `PipelineBuilder` config (without `.build()`), wrap it with `spdl.pipeline.run_pipeline_in_subprocess(config, num_threads=16, mp_context='forkserver')`, and create an outer pipeline that takes the subprocess source and applies GPU transfer via `pipe(transfer_tensor, executor=ThreadPoolExecutor(1))`."
 - Each experiment should differ from the baseline in exactly one dimension (or a small, justified set of changes)
 - **`best_practices_tags`**: Tag each experiment with which best practices it covers from the valid tags list. This is how the orchestrator tracks progress. If an experiment covers multiple practices, include all relevant tags.
-- **`revert_to`**: If you want to branch from an earlier experiment's code state instead of building on the current one, set this to the commit hash from that experiment's history entry. The orchestrator will go back to that commit before applying new changes. You cannot revert to before the anchor commit (the state when autoresearch was initialized). Set to `null` to continue from the current state.
+- **`revert_to`**: Set this to the commit hash of the **best successful experiment** before applying new code changes. This prevents regressions from accumulating in the source tree. Check the experiment history for the commit hash of the current best run. If the current source has changes from a failed or regressed experiment, you MUST set `revert_to` to revert to a clean state. Set to `null` only if the current source is already at the desired state (no regressions applied).

--- a/tools/autoresearch/utils/callbacks.py
+++ b/tools/autoresearch/utils/callbacks.py
@@ -290,6 +290,9 @@ def _get_plan(
                 last_analysis = afile.read_text()
                 break
 
+    findings_file = workdir / "findings.md"
+    findings = findings_file.read_text() if findings_file.exists() else "(none yet)"
+
     prompt = load_prompt(
         "plan_next",
         KNOWLEDGE=knowledge,
@@ -309,6 +312,7 @@ def _get_plan(
         BUILD_COMMAND=config.get("build_command", ""),
         CACHED_IMAGE=(state.get("cached_image") or "(none — build first)"),
         HISTORY_JSON=json.dumps(state["history"], indent=2)[:6000],
+        FINDINGS=findings[:4000],
         NOTES=config.get("notes", ""),
     )
 
@@ -648,7 +652,27 @@ def update_on_complete(
 
     _update_plateau(state, cur_val)
 
+    _append_findings(workdir, node.name, result.structured)
+
     write_state(workdir, state)
+
+
+def _append_findings(workdir: Path, name: str, structured: dict | None) -> None:
+    """Append new findings from an experiment to findings.md."""
+    if not structured:
+        return
+    findings = structured.get("findings", [])
+    if not findings:
+        return
+
+    findings_file = workdir / "findings.md"
+    lines = []
+    if not findings_file.exists():
+        lines.append("# Accumulated Findings\n\n")
+    for fact in findings:
+        lines.append(f"- [{name}] {fact}\n")
+    with open(findings_file, "a") as f:
+        f.writelines(lines)
 
 
 def update_summary_and_plot(workdir: Path, state: dict) -> None:

--- a/tools/autoresearch/utils/engine.py
+++ b/tools/autoresearch/utils/engine.py
@@ -38,6 +38,169 @@ Usage::
 
     # Ctrl+C to stop gracefully — state is persisted to disk.
     # Re-run to resume from where it left off.
+
+
+Requirements
+============
+
+The following requirements are testable with mock callbacks. Each
+requirement has a tag (R-XX) for traceability in unit tests.
+
+Concurrency
+-----------
+
+R-01  At most ``max_concurrency`` nodes may be in "running" status
+      simultaneously. The engine must not launch more tasks than
+      there are available slots.
+
+R-02  When a task completes and a slot opens, the engine fills the
+      slot from the priority queue within one event loop tick (no
+      unnecessary delay).
+
+R-03  ``prepare_fn`` calls are serialized via ``_state_lock`` — two
+      prepare calls must never execute their thread-pool work at the
+      same time (shared working directory).
+
+Immediate Analysis
+------------------
+
+R-04  When a job reaches a terminal status ("completed" or "failed"),
+      the engine calls ``analyze_fn`` immediately — it does not wait
+      for other running jobs to finish first.
+
+R-05  ``analyze_fn`` and ``on_node_complete`` are serialized via
+      ``_state_lock`` — they must not run concurrently with each
+      other or with ``prepare_fn`` / ``plan_fn``.
+
+Tree Structure
+--------------
+
+R-06  After analyzing a completed node, the engine calls ``plan_fn``
+      which returns a list of child experiment specs. Each spec
+      becomes a new ``HypothesisNode`` with ``parent_id`` set to the
+      completed node's ``node_id``.
+
+R-07  Child nodes inherit the parent's ``commit`` value by default.
+
+R-08  The completed node's ``children`` list is updated to include
+      all newly created child node IDs.
+
+Priority Queue
+--------------
+
+R-09  Nodes are dequeued in priority order (lowest ``priority`` value
+      first).
+
+R-10  After each completion, if ``reprioritize_fn`` is provided, the
+      queue is re-sorted using the updated priorities.
+
+R-11  When ``plan_fn`` returns an empty list, no children are
+      enqueued.
+
+Deduplication
+-------------
+
+R-12  If a proposed child spec has the same ``name`` as any existing
+      node in the tree, it is rejected (not enqueued).
+
+R-13  If a proposed child spec has the same ``launch_command`` and
+      ``rebuild=False`` as any existing node, it is rejected even
+      if the name differs (semantic dedup).
+
+Stuck Detection
+---------------
+
+R-14  If ``progress_fn`` is provided and returns a non-None value
+      that has not changed for ``job_timeout_s`` seconds, the engine
+      calls ``cancel_fn`` and marks the node as failed.
+
+R-15  If ``progress_fn`` returns None (no signal), the stall timer
+      resets — the engine gives benefit of the doubt.
+
+R-16  If ``progress_fn`` has NEVER returned a non-None value for a
+      node (training never started) and the wall-clock time exceeds
+      ``3 * job_timeout_s``, the engine kills the job (OOM / init
+      hang fast-fail).
+
+R-17  If ``progress_fn`` is not provided, the engine falls back to
+      a simple wall-clock timeout: kill after ``job_timeout_s``
+      total elapsed time.
+
+Lifecycle and Status
+--------------------
+
+R-18  Each node progresses through statuses in order:
+      ``queued → preparing → running → analyzing → completed/failed``.
+
+R-19  A node whose ``prepare_fn`` returns False goes directly to
+      ``failed`` (skipping running/analyzing).
+
+R-20  A node whose ``launch_fn`` returns None goes directly to
+      ``failed`` (skipping running/analyzing).
+
+Stopping
+--------
+
+R-21  The engine stops when the queue is empty, no tasks are running,
+      and ``should_stop_fn`` returns True.
+
+R-22  When ``should_stop_fn`` returns True but tasks are still
+      running, the engine drains them (waits for completion, does
+      NOT enqueue new children) before exiting.
+
+R-23  When all initial nodes are processed and no follow-ups are
+      produced, the engine exits even if ``should_stop_fn`` returns
+      False.
+
+Graceful Shutdown
+-----------------
+
+R-24  On SIGINT or SIGTERM, all running tasks are cancelled. The
+      engine persists tree, queue, and active jobs to disk before
+      exiting. ``engine_state.json`` shows ``"interrupted"``.
+
+R-25  Running jobs on the remote side are NOT cancelled by the
+      engine — they continue independently.
+
+R-26  On resume (``load_state`` + ``run``), nodes that were
+      "running" are re-checked: if completed/failed, they are
+      queued for analysis; if still running, they are re-polled.
+
+Persistence
+-----------
+
+R-27  After every node status change, the node is persisted to
+      ``engine/nodes/<node_id>/spec.json`` + ``status.txt``.
+
+R-28  After every queue modification, ``engine/queue.json`` is
+      updated.
+
+R-29  On completion or shutdown, ``engine/tree.json`` contains
+      the full serialized tree.
+
+R-30  ``engine/engine_state.json`` reflects the current engine
+      status (``running``, ``stopped``, ``interrupted``) with
+      node counts.
+
+WorkQueue
+---------
+
+R-31  ``_WorkQueue.push`` maintains sorted order.
+
+R-32  ``_WorkQueue.pop`` returns the lowest-priority node ID and
+      removes it. Returns None when empty.
+
+R-33  ``_WorkQueue.reprioritize`` re-sorts without losing entries.
+
+R-34  ``_WorkQueue.from_list`` round-trips with ``to_list``.
+
+HypothesisNode
+--------------
+
+R-35  ``to_dict`` / ``from_dict`` round-trip correctly for all
+      fields, including defaults.
+
+R-36  ``from_dict`` ignores unknown keys (forward compatibility).
 """
 
 from __future__ import annotations
@@ -599,6 +762,7 @@ class ExperimentEngine:
 
         last_progress: str | None = None
         stall_start = time.monotonic()
+        ever_progressed = False
 
         status = "running"
         while True:
@@ -607,13 +771,18 @@ class ExperimentEngine:
                 _LG.info("Node %s job %s: %s", node.node_id, node.job_id, status)
                 break
 
-            if await self._check_stalled(node, last_progress, stall_start):
+            if await self._check_stalled(
+                node, last_progress, stall_start, ever_progressed
+            ):
                 status = "failed"
                 break
 
+            prev_progress = last_progress
             last_progress, stall_start = await self._update_progress(
                 node, last_progress, stall_start
             )
+            if last_progress is not None and last_progress != prev_progress:
+                ever_progressed = True
 
             await asyncio.sleep(self.poll_interval)
 
@@ -624,13 +793,34 @@ class ExperimentEngine:
         node: HypothesisNode,
         last_progress: str | None,
         stall_start: float,
+        ever_progressed: bool = True,
     ) -> bool:
-        """Check if a job has stalled and kill it if so. Returns True if killed."""
+        """Check if a job has stalled and kill it if so. Returns True if killed.
+
+        Two modes:
+        - If training has started (ever_progressed=True): kill after
+          job_timeout_s with no progress change.
+        - If training never started (ever_progressed=False): apply a
+          hard 3x wall-clock ceiling to catch OOM / init hangs. These
+          jobs produce no [autoresearch] progress lines, so stall_start
+          keeps resetting — the ceiling prevents infinite runs.
+        """
+        elapsed = time.monotonic() - (node.launched_at or stall_start)
+
+        if not ever_progressed and elapsed > self.job_timeout_s * 3:
+            _LG.warning(
+                "Node %s job %s never started training (%.0fs), killing",
+                node.node_id,
+                node.job_id,
+                elapsed,
+            )
+            await self.cancel_fn(node.job_id)
+            return True
+
         stall_duration = time.monotonic() - stall_start
         if stall_duration <= self.job_timeout_s:
             return False
 
-        elapsed = time.monotonic() - (node.launched_at or stall_start)
         _LG.warning(
             "Node %s job %s stuck — no progress for %.0fs (%.0fs total), killing",
             node.node_id,
@@ -723,6 +913,7 @@ class ExperimentEngine:
             node.duration = result.duration
             self._persist_node(node)
             self._persist_active()
+            self._persist_tree()
 
             if self.on_node_complete:
                 await self.on_node_complete(node, result)
@@ -766,12 +957,26 @@ class ExperimentEngine:
         )
 
     def _is_duplicate(self, spec: dict) -> bool:
-        """Check if an experiment with the same name already exists."""
+        """Check if a semantically equivalent experiment already exists.
+
+        Checks both name match and launch parameter match (same
+        launch_command + same rebuild flag = same experiment regardless
+        of name).
+        """
         name = spec.get("name", "")
-        if not name:
-            return False
+        launch_cmd = spec.get("launch_command", "")
+        rebuild = spec.get("rebuild", False)
+
         for node in self._tree.values():
-            if node.name == name:
+            if name and node.name == name:
+                return True
+            existing = node.spec
+            if (
+                launch_cmd
+                and existing.get("launch_command") == launch_cmd
+                and existing.get("rebuild", False) == rebuild
+                and not rebuild
+            ):
                 return True
         return False
 
@@ -854,13 +1059,17 @@ class ExperimentEngine:
             json.dumps(state, indent=2) + "\n"
         )
 
-    def _persist_all(self) -> None:
-        """Persist tree, queue, and active state."""
+    def _persist_tree(self) -> None:
+        """Write the full hypothesis tree to engine/tree.json."""
         self._engine_dir.mkdir(parents=True, exist_ok=True)
         tree_data = [n.to_dict() for n in self._tree.values()]
         (self._engine_dir / "tree.json").write_text(
             json.dumps(tree_data, indent=2) + "\n"
         )
+
+    def _persist_all(self) -> None:
+        """Persist tree, queue, and active state."""
+        self._persist_tree()
         self._persist_queue()
         self._persist_active()
 


### PR DESCRIPTION
… OOM fast-fail

Addresses issues observed in a 111-experiment run where only 4 were kept improvements.

Engine changes (engine.py):
- Semantic deduplication: _is_duplicate now compares launch_command + rebuild flag, not just experiment name. Catches semantically identical experiments proposed under different names.
- OOM fast-fail: Jobs where training never starts (no [autoresearch] step lines ever seen) are killed after 3x the timeout. Previously OOM jobs ran for hours producing nothing.
- Single state lock: Merged _prepare_lock and _complete_lock into _state_lock. All state-mutating callbacks (prepare, analyze, on_complete, plan) are serialized through one asyncio lock, preventing thread-pool race conditions on the shared state dict.
- Metric scale safety: _get_compare_val returns (metric_type, value) tuples. Comparisons only happen between values of the same type — steady_step_time_ms (milliseconds) is never compared against duration_s (seconds).
- current_best fix: best_so_far is computed before appending to history, so a new best entry is correctly recognized.
- Engine requirements: Added 36 tagged requirements (R-01 through R-36) documenting testable behaviors for future unit tests.

Callback changes (callbacks.py):
- Summary shows steady step time instead of raw duration (which is often null for short experiments).
- Findings knowledge base: After each analysis, concrete facts (e.g., "batch_size=64 causes OOM") are appended to workdir/findings.md. The planning prompt includes these findings so Claude does not repeat mistakes.
- Iteration counting moved from update_on_complete (per job) to get_plan (per planning session). With max_iterations=40, this means 40 planning rounds producing ~80-120 jobs, not 40 jobs producing 300+.

Prompt changes:
- analyze.md: Claude now outputs a "findings" list of established facts in the structured JSON.
- plan_next.md: Accumulated findings are shown under "Respect these findings." Added headspace-aware pivot (when <10%, prioritize model-side opts over pipeline sweeps), hypothesis conclusion tracking (3+ experiments disprove → stop testing), semantic dedup rule, and auto-revert guidance.