### PR TITLE
Add example training R3D-18 model on Kinetics dataset

### DIFF
--- a/examples/video_classification/utils/__init__.py
+++ b/examples/video_classification/utils/__init__.py
@@ -1,0 +1,36 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""Compatibility layer: switch between Meta-internal and OSS implementations."""
+
+from __future__ import annotations
+
+from .pipeline import build_pipeline
+
+try:
+    from .fb.dataset import (  # pyre-ignore[21]
+        add_dataset_args,
+        create_dataset,
+        get_label_to_index,
+    )
+    from .fb.helpers import report_progress  # pyre-ignore[21]
+except ImportError:
+    from .dataset import (  # type: ignore[assignment]
+        add_dataset_args,
+        create_dataset,
+        get_label_to_index,
+        report_progress,
+    )
+
+__all__ = [
+    "add_dataset_args",
+    "build_pipeline",
+    "create_dataset",
+    "get_label_to_index",
+    "report_progress",
+]

--- a/examples/video_classification/utils/dataset.py
+++ b/examples/video_classification/utils/dataset.py
@@ -1,0 +1,97 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""OSS video dataset implementation.
+
+Reads videos from a local directory organized as
+``<root>/<split>/<class_name>/<video>.ext``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+from pathlib import Path
+
+_LG: logging.Logger = logging.getLogger(__name__)
+
+_VIDEO_EXTENSIONS: set[str] = {".avi", ".mp4", ".mkv", ".webm", ".mov"}
+
+
+class LocalVideoDataset:
+    """Video dataset backed by local files.
+
+    Each ``__getitem__`` call reads a video file from disk and returns
+    a single-element list of ``{"video_bytes": ..., "label": ...}``.
+    Returning a list aligns the interface with variants that fetch
+    data from a remote source in bulk.
+
+    Expected directory layout::
+
+        root/<split>/<class_name>/<video>.{avi,mp4,mkv,webm,mov}
+    """
+
+    def __init__(self, root: str, split: str = "train") -> None:
+        split_dir = Path(root) / split
+        if not split_dir.is_dir():
+            raise FileNotFoundError(f"Split directory not found: {split_dir}")
+
+        self.samples: list[tuple[str, str]] = []
+        for class_dir in sorted(split_dir.iterdir()):
+            if not class_dir.is_dir():
+                continue
+            label = class_dir.name
+            for video_file in sorted(class_dir.iterdir()):
+                if video_file.suffix.lower() in _VIDEO_EXTENSIONS:
+                    self.samples.append((str(video_file), label))
+
+        if not self.samples:
+            raise RuntimeError(
+                f"No video files found in {split_dir}. "
+                f"Expected layout: {split_dir}/<class_name>/<video>.ext"
+            )
+        _LG.info("Found %d videos in %s", len(self.samples), split_dir)
+
+    def __len__(self) -> int:
+        return len(self.samples)
+
+    def __getitem__(self, index: int) -> list[dict[str, object]]:
+        path, label = self.samples[index]
+        with open(path, "rb") as f:
+            video_bytes = f.read()
+        return [{"video_bytes": video_bytes, "label": label}]
+
+
+def create_dataset(args: argparse.Namespace) -> LocalVideoDataset:
+    return LocalVideoDataset(args.data_dir, args.split)
+
+
+def get_label_to_index(args: argparse.Namespace) -> dict[str, int]:
+    """Derive label-to-index mapping from directory structure."""
+    split_dir = Path(args.data_dir) / args.split
+    labels = sorted(d.name for d in split_dir.iterdir() if d.is_dir())
+    return {label: idx for idx, label in enumerate(labels)}
+
+
+def add_dataset_args(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--data-dir",
+        type=str,
+        required=True,
+        help="Root directory with video files organized as <split>/<class>/<video>.ext",
+    )
+    parser.add_argument(
+        "--split",
+        type=str,
+        default="train",
+        help="Dataset split subdirectory name",
+    )
+
+
+def report_progress(step: int, total_steps: int | None = None) -> None:
+    pass

--- a/examples/video_classification/utils/pipeline.py
+++ b/examples/video_classification/utils/pipeline.py
@@ -1,0 +1,162 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""SPDL pipeline construction for video classification.
+
+Provides the pipeline callables (Decode, collate) and ``build_pipeline``
+which assembles the full SPDL pipeline.  The pipeline is dataset-agnostic:
+any dataset whose ``__getitem__`` returns
+``list[{"video_bytes": bytes, "label": str}]`` can be used.
+"""
+
+from __future__ import annotations
+
+import argparse
+from collections.abc import Iterator
+from typing import Protocol
+
+import spdl.io
+import spdl.source.utils
+import torch
+from spdl.io import transfer_tensor
+from spdl.pipeline import PipelineBuilder
+from spdl.source import DistributedRandomSampler
+
+type _TBatch = dict[str, torch.Tensor]
+
+
+class VideoDataset(Protocol):
+    def __len__(self) -> int: ...
+    def __getitem__(self, index: int) -> list[dict[str, object]]: ...
+
+
+class Decode:
+    """Decode video bytes into a CPU tensor of sampled frames (FFmpeg)."""
+
+    def __init__(
+        self,
+        num_frames: int,
+        filter_desc: str | None,
+        label_to_index: dict[str, int],
+    ) -> None:
+        self.num_frames = num_frames
+        self.filter_desc = filter_desc
+        self.label_to_index = label_to_index
+
+    def __call__(self, item: dict[str, object]) -> dict[str, torch.Tensor] | None:
+        video_bytes = item["video_bytes"]
+        label_str = item["label"]
+        assert isinstance(video_bytes, (bytes, memoryview))
+        assert isinstance(label_str, str)
+
+        try:
+            packets = spdl.io.demux_video(video_bytes)
+            frames = spdl.io.decode_packets(packets, filter_desc=self.filter_desc)
+            buffer = spdl.io.convert_frames(frames)
+            tensor = spdl.io.to_torch(buffer)  # [N, H, W, C]
+        except RuntimeError:
+            return None
+
+        total = tensor.shape[0]
+        if total >= self.num_frames:
+            indices = torch.linspace(0, total - 1, self.num_frames).long()
+            tensor = tensor[indices]
+        else:
+            pad = tensor[-1:].expand(self.num_frames - total, -1, -1, -1)
+            tensor = torch.cat([tensor, pad], dim=0)
+
+        # [T, H, W, C] -> [C, T, H, W] for video models
+        tensor = tensor.permute(3, 0, 1, 2).float() / 255.0
+
+        label_index = self.label_to_index[label_str]
+        return {
+            "video": tensor,
+            "label": torch.tensor(label_index),
+        }
+
+
+def collate(
+    items: list[dict[str, torch.Tensor]],
+) -> _TBatch:
+    return {
+        "video": torch.stack([it["video"] for it in items]),
+        "label": torch.stack([it["label"] for it in items]),
+    }
+
+
+def build_pipeline(
+    *,
+    args: argparse.Namespace,
+    dataset: VideoDataset,
+    label_to_index: dict[str, int],
+    rank: int,
+    world_size: int,
+) -> Iterator[_TBatch]:
+    """Build a multithreaded SPDL pipeline for video classification.
+
+    Constructs the following pipeline stages::
+
+        sample → fetch → disaggregate → decode → aggregate → collate → transfer
+
+    1. **Sample**: ``DistributedRandomSampler`` produces shuffled indices,
+       partitioned across ranks.  The source is continuous (auto-resets
+       each epoch).
+    2. **Fetch** (``num_fetch_threads``): ``dataset.__getitem__`` returns
+       a list of ``{"video_bytes": bytes, "label": str}`` dicts.
+       For local files this is a single-element list; for remote bulk
+       storage each call may return many items.
+    3. **Disaggregate**: Splits each list into individual items.
+    4. **Decode** (``num_decode_threads``): Decodes video bytes with FFmpeg,
+       samples ``num_frames`` evenly, and produces ``[C, T, H, W]`` tensors.
+    5. **Aggregate / collate**: Groups into batches and stacks tensors.
+    6. **Transfer**: Async copy to GPU via ``spdl.io.transfer_tensor``.
+
+    Args:
+        args: CLI args providing ``num_fetch_threads``, ``num_decode_threads``,
+            ``num_frames``, ``frame_width``, ``frame_height``, ``batch_size``.
+        dataset: Any object implementing the ``VideoDataset`` protocol.
+        label_to_index: Mapping from label string to class index.
+        rank: Current distributed rank.
+        world_size: Total number of distributed workers.
+
+    Returns:
+        An iterator yielding ``{"video": Tensor, "label": Tensor}`` batches.
+    """
+    num_fetch_threads: int = args.num_fetch_threads
+    num_decode_threads: int = args.num_decode_threads
+
+    filter_desc: str | None = spdl.io.get_video_filter_desc(
+        scale_width=args.frame_width,
+        scale_height=args.frame_height,
+        pix_fmt="rgb24",
+    )
+
+    source = spdl.source.utils.embed_shuffle(
+        DistributedRandomSampler(
+            len(dataset),
+            rank=rank,
+            world_size=world_size,
+        )
+    )
+
+    pipeline = (
+        PipelineBuilder()
+        .add_source(source, continuous=True)
+        .pipe(dataset.__getitem__, concurrency=num_fetch_threads)
+        .disaggregate()
+        .pipe(
+            Decode(args.num_frames, filter_desc, label_to_index),
+            concurrency=num_decode_threads,
+        )
+        .aggregate(args.batch_size, drop_last=True)
+        .pipe(collate)
+        .pipe(transfer_tensor)
+        .add_sink(buffer_size=3)
+        .build(num_threads=num_fetch_threads + num_decode_threads)
+    )
+    return pipeline.get_iterator(timeout=300)

--- a/examples/video_classification/video_classification.py
+++ b/examples/video_classification/video_classification.py
@@ -1,0 +1,258 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""Video classification training with SPDL data pipeline.
+
+Trains a video classification model (R3D-18) on video data using SPDL
+PipelineBuilder for high-performance concurrent video decoding and GPU
+transfer.
+
+SPDL Data Pipeline
+^^^^^^^^^^^^^^^^^^
+
+Uses a multithreaded pipeline with SPDL PipelineBuilder:
+
+  Sampling → fetch → decode (FFmpeg) → aggregate → collate → GPU transfer.
+
+The data source is pluggable: local video files (OSS) or WarmStorage
+via BulkDataset (Meta-internal), selected automatically via the
+compatibility layer in ``utils/__init__.py``.
+
+Usage
+^^^^^
+
+::
+
+    torchrun \\
+      --nproc_per_node 8 \\
+      -m spdl.examples.video_classification.video_classification \\
+      --data-dir /path/to/kinetics-400 \\
+      --num-classes 400
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import time
+from collections.abc import Callable, Iterator
+from datetime import timedelta
+
+import torch
+import torch.distributed as dist
+from torch.nn.parallel import DistributedDataParallel as DDP
+from torchvision.models.video import r3d_18
+
+try:
+    from examples.video_classification.utils import (  # pyre-ignore[21]
+        add_dataset_args,
+        build_pipeline,
+        create_dataset,
+        get_label_to_index,
+        report_progress,
+    )
+except ImportError:
+    from spdl.examples.video_classification.utils import (
+        add_dataset_args,
+        build_pipeline,
+        create_dataset,
+        get_label_to_index,
+        report_progress,
+    )
+
+_LG: logging.Logger = logging.getLogger(__name__)
+
+type _TBatch = dict[str, torch.Tensor]
+
+
+def train(
+    *,
+    dataloader: Iterator[_TBatch],
+    num_classes: int,
+    batch_size: int,
+    num_epochs: int,
+    lr: float,
+    weight_decay: float,
+    max_grad_norm: float,
+    log_interval: int,
+    max_steps: int | None = None,
+    progress_fn: Callable[[int, int | None], None] | None = None,
+) -> None:
+    """Main training function, called per-rank."""
+    rank: int = dist.get_rank()
+    world_size: int = dist.get_world_size()
+    local_rank: int = int(os.environ.get("LOCAL_RANK", 0))
+    device = torch.device(f"cuda:{local_rank}")
+    torch.cuda.set_device(device)
+
+    _LG.info("Rank %d/%d on device %s", rank, world_size, device)
+
+    # --- Model ---
+    _LG.info("Building R3D-18 model with %d classes", num_classes)
+    model = r3d_18(num_classes=num_classes).to(device=device, dtype=torch.float32)
+    ddp_model = DDP(model, device_ids=[local_rank])
+
+    # --- Optimizer ---
+    optimizer = torch.optim.AdamW(
+        ddp_model.parameters(),
+        lr=lr,
+        weight_decay=weight_decay,
+        foreach=True,
+    )
+
+    if rank == 0 and progress_fn is not None:
+        progress_fn(0, None)
+
+    # --- Training loop ---
+    global_step = 0
+    ddp_model.train()
+    for epoch in range(num_epochs):
+        _LG.info("Epoch %d/%d", epoch + 1, num_epochs)
+
+        t0 = time.monotonic()
+        epoch_loss = 0.0
+        num_batches = 0
+
+        for batch in dataloader:
+            if max_steps is not None and num_batches >= max_steps:
+                break
+
+            outputs = ddp_model(batch["video"])
+            loss = torch.nn.functional.cross_entropy(outputs, batch["label"])
+
+            loss.backward()
+            torch.nn.utils.clip_grad_norm_(ddp_model.parameters(), max_grad_norm)
+            optimizer.step()
+            optimizer.zero_grad()
+
+            epoch_loss += loss.item()
+            num_batches += 1
+            global_step += 1
+
+            if rank == 0:
+                if progress_fn is not None:
+                    progress_fn(global_step, None)
+                if global_step % log_interval == 0:
+                    avg_loss = epoch_loss / num_batches
+                    elapsed = time.monotonic() - t0
+                    _LG.info(
+                        "Step %d | loss=%.4f | %.1f samples/s",
+                        global_step,
+                        avg_loss,
+                        num_batches * batch_size * world_size / elapsed,
+                    )
+
+        elapsed = time.monotonic() - t0
+        if rank == 0:
+            avg_loss = epoch_loss / max(num_batches, 1)
+            _LG.info(
+                "Epoch %d complete | avg_loss=%.4f | %.1fs | %.1f samples/s",
+                epoch + 1,
+                avg_loss,
+                elapsed,
+                num_batches * batch_size * world_size / elapsed,
+            )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    # Model
+    parser.add_argument(
+        "--num-classes", type=int, default=400, help="Number of classification classes"
+    )
+    # Video
+    parser.add_argument(
+        "--num-frames",
+        type=int,
+        default=16,
+        help="Number of frames to sample per video",
+    )
+    parser.add_argument("--frame-height", type=int, default=112)
+    parser.add_argument("--frame-width", type=int, default=112)
+    # Training
+    parser.add_argument("--batch-size", type=int, default=8)
+    parser.add_argument("--num-epochs", type=int, default=1)
+    parser.add_argument("--lr", type=float, default=1e-3)
+    parser.add_argument("--weight-decay", type=float, default=0.01)
+    parser.add_argument("--max-grad-norm", type=float, default=1.0)
+    parser.add_argument("--log-interval", type=int, default=10)
+    parser.add_argument(
+        "--max-steps",
+        type=int,
+        default=None,
+        help="Max training steps per epoch (for benchmarking)",
+    )
+    # Pipeline
+    parser.add_argument(
+        "--num-fetch-threads",
+        type=int,
+        default=8,
+        help="Concurrent data fetch threads",
+    )
+    parser.add_argument(
+        "--num-decode-threads",
+        type=int,
+        default=16,
+        help="Concurrent video decode threads",
+    )
+    # Dataset-specific args (OSS or FB, depending on which module is available)
+    add_dataset_args(parser)
+    return parser.parse_args()
+
+
+def init_logging() -> None:
+    rank = os.environ.get("RANK", "?")
+    logging.basicConfig(
+        level=logging.INFO,
+        format=f"%(asctime)s [%(levelname).1s] [Rank{rank}] %(name)s: %(message)s",
+        force=True,
+    )
+
+
+def main(args: argparse.Namespace) -> None:
+    _LG.info("Building label-to-index mapping ...")
+    label_to_index = get_label_to_index(args)
+    _LG.info("Found %d classes", len(label_to_index))
+
+    dist.init_process_group(backend="nccl", timeout=timedelta(minutes=30))
+    try:
+        rank = dist.get_rank()
+        world_size = dist.get_world_size()
+
+        _LG.info("Creating dataset ...")
+        dataset = create_dataset(args)
+
+        _LG.info("Building data pipeline ...")
+        dataloader = build_pipeline(
+            args=args,
+            dataset=dataset,
+            label_to_index=label_to_index,
+            rank=rank,
+            world_size=world_size,
+        )
+
+        train(
+            dataloader=dataloader,
+            num_classes=args.num_classes,
+            batch_size=args.batch_size,
+            num_epochs=args.num_epochs,
+            lr=args.lr,
+            weight_decay=args.weight_decay,
+            max_grad_norm=args.max_grad_norm,
+            log_interval=args.log_interval,
+            max_steps=args.max_steps,
+            progress_fn=report_progress,
+        )
+    finally:
+        dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    init_logging()
+    main(parse_args())


### PR DESCRIPTION
  Adds an end-to-end video classification example that trains R3D-18 on video data using
SPDL's `PipelineBuilder` for high-performance concurrent video decoding and GPU
transfer.                                                                             
                                                       
### Pipeline architecture                                                             

The example demonstrates a multithreaded SPDL pipeline with six stages:               
                                                       
sample → fetch → disaggregate → decode → aggregate/collate → GPU transfer             

- **Sample**: `DistributedRandomSampler` with per-epoch reshuffling, partitioned      
across ranks                                                                          
- **Fetch**: Concurrent data loading via the dataset's `__getitem__`, which returns a
list of `{"video_bytes", "label"}` dicts                                              
- **Disaggregate**: Splits each list into individual items (supports both single-item
and bulk-fetch datasets)                                                              
- **Decode**: FFmpeg-based video decoding with uniform frame sampling, producing `[C,
T, H, W]` tensors                                                                     
- **Collate**: Batching and tensor stacking               
- **Transfer**: Async GPU copy via `spdl.io.transfer_tensor`                          
                                                                                   
### Pluggable dataset design                                                          
                                                                                   
The pipeline is dataset-agnostic via a `VideoDataset` protocol — any object with      
`__len__` and `__getitem__` returning `list[dict[str, object]]` works. The OSS
implementation (`LocalVideoDataset`) reads videos from a local directory organized as 
`<root>/<split>/<class_name>/<video>.ext`. The single-element list return type aligns
the interface with variants that fetch data from remote sources in bulk.

### Structure
```
examples/video_classification/                                                        
├── video_classification.py          # Training loop, CLI, main()
└── utils/                                                                            
 ├── init.py                  # Compatibility layer (OSS ↔ internal)
 ├── pipeline.py                  # build_pipeline, Decode, collate                
 └── dataset.py                   # LocalVideoDataset, create_dataset              
```
### Usage                                                                             
                                                       
```bash
torchrun \
 --nproc_per_node 8 \                                                                
 -m examples.video_classification.video_classification \
 --data-dir /path/to/kinetics-400 \                                                  
 --num-classes 400                                                                   

The expected data layout is                                                           
<data-dir>/<split>/<class_name>/<video>.{avi,mp4,mkv,webm,mov}, matching the standard
Kinetics directory structure.                                                         
```                    