### PR TITLE
autoresearch: fix engine bugs — CPU cap, plateau tracking, stopping, …

### DIFF
--- a/tools/autoresearch/prompts/analyze.md
+++ b/tools/autoresearch/prompts/analyze.md
@@ -35,7 +35,7 @@ __PIPELINE_CODE__
 
 ## Instructions
 
-1. **Extract key metrics**: SM utilization, CPU utilization, step time, TTFB, and data readiness at the sink. Compare to the baseline (first row in the master table).
+1. **Extract key metrics**: SM utilization, CPU utilization, step time, TTFB, available CPU cores, and data readiness at the sink. Compare to the baseline (first row in the master table).
 
 2. **Separate steady-state from initialization**: Short experiments have a high init-to-steady-state ratio. Raw averages are misleading.
    - **Steady-state step time**: If per-step data is available, take the median after discarding the first 20 steps. If only aggregate data is available, estimate from sink queue QPS (`1000 / sink_qps` = step time in ms).
@@ -45,6 +45,10 @@ __PIPELINE_CODE__
 3. **Evaluate the hypothesis**: Did the change produce the expected improvement? If not, explain why.
 
 4. **Identify remaining bottlenecks**: Even if this run improved, there may be new or remaining bottlenecks. Walk through the pipeline metrics to identify them.
+
+   **CPU utilization and data starvation**: Do NOT flag high CPU utilization as a "noisy neighbor" concern when the pipeline is data-starved. A pipeline is data-starved when the headspace is large (e.g., >50%) or when sink starvation / low data readiness is observed. In data-starved pipelines, the bottleneck is insufficient data processing throughput — the correct response is to use MORE CPU (increase decode/fetch concurrency, add threads), not less. The noisy-neighbor concern only applies when the pipeline is already keeping the GPU well-fed and additional CPU usage would not improve throughput.
+
+   **GPU video decode and SM utilization**: When the experiment uses GPU video decoding (NVDEC / `decode_packets_nvdec`), SM utilization may be lower than CPU-decode runs even though sample throughput is higher. This is expected — NVDEC uses dedicated hardware decoder engines, not SM (shader) cores. Do NOT interpret lower SM utilization as a regression for GPU decode experiments. Compare using **step time** (sample throughput) instead.
 
 5. **Compare to previous runs**: Compare using steady-state step time (or p50/p75 SM util as proxy). Note whether this is the best run so far.
 

--- a/tools/autoresearch/prompts/apply_changes.md
+++ b/tools/autoresearch/prompts/apply_changes.md
@@ -32,6 +32,23 @@ __PIPELINE_CODE__
 5. If the description mentions SPDL APIs (e.g. `run_pipeline_in_subprocess`, `continuous=True`), use them correctly according to the SPDL knowledge above.
 6. **When adding new imports, verify the Buck target exists.** Check the BUCK Dependencies table in the knowledge base for common targets. For modules not listed, look up the target from the module's directory (e.g., `spdl/foo/BUCK` for `import spdl.foo`). Missing Buck deps cause `ModuleNotFoundError` at runtime in the deployed package.
 7. Do NOT truncate the output. Output the ENTIRE file, even if it is long.
+8. **MTP (subprocess) robustness**: When applying MTP changes, carefully inspect the existing pipeline code to understand its return types and structure:
+   - `run_pipeline_in_subprocess()` requires a **`PipelineConfig`** as input (obtained via `builder.get_config()`). It does NOT accept a built `Pipeline` object or an iterator/iterable.
+   - If the existing code has a function that calls `.build()` and/or `.get_iterator()` (returning a `Pipeline` or iterator), you MUST refactor it to return an unbuilt `PipelineBuilder` or `PipelineConfig` instead. Do NOT pass the result of `.build()` to `run_pipeline_in_subprocess`.
+   - **Check type annotations and return statements** to determine what the existing function returns (`PipelineBuilder`, `Pipeline`, `Iterator`, `Iterable`, etc.) and adapt accordingly.
+   - **Separate CPU and GPU stages**: The backend pipeline (running in the subprocess) must contain ONLY CPU-bound stages (fetch, decode, aggregate, collate). GPU stages like `transfer_tensor` require a CUDA context and MUST be in the frontend pipeline (main process). If the existing code includes GPU stages in the pipeline builder, exclude them from the backend config and add them to the frontend pipeline.
+   - The frontend pipeline takes the subprocess iterable as its source and applies GPU transfer: `PipelineBuilder().add_source(subprocess_iterable, continuous=True).pipe(transfer_tensor).add_sink(buffer_size=3).build(num_threads=1)`.
+   - **`Pipeline` is iterable, not iterator**: When iterating a `Pipeline` object, always use `pipeline.get_iterator(timeout=<seconds>)` to get an iterator with a timeout. Do NOT use `iter(pipeline)` or `for batch in pipeline` directly — these lack timeout handling.
+9. **GPU video decode (NVDEC) robustness**: When replacing CPU video decode with GPU decode:
+   - Replace `decode_packets(packets, ...)` + `convert_frames(frames)` + `transfer_buffer(buffer, ...)` with a single `decode_packets_nvdec(packets, device_config=cuda_cfg, pix_fmt="rgb")`. The result is a `CUDABuffer` already on GPU.
+   - Remove the `transfer_buffer` or `transfer_tensor` stage from the pipeline — data is already on GPU after NVDEC decode.
+   - Create `CUDAConfig` with PyTorch's caching allocator: `spdl.io.cuda_config(device_index=..., allocator=(torch.cuda.caching_allocator_alloc, torch.cuda.caching_allocator_delete))`.
+   - The `device_index` must match the current GPU rank. Use `torch.cuda.current_device()` or the rank/local_rank variable from the training setup.
+   - Set decode concurrency based on GPU hardware — H100/B100 have 7 NVDEC instances per GPU (concurrency ~7; higher for sparse decoding patterns). Older GPUs (A100, V100) have 3–5 slots.
+   - If the existing code applies FFmpeg filters for resize/crop, replace them with `scale_width`/`scale_height`/`crop_*` parameters on `decode_packets_nvdec` (dimensions must be even numbers).
+   - `decode_packets_nvdec` auto-applies bitstream filtering — remove any manual `apply_bsf()` calls.
+   - **Use a dedicated `ThreadPoolExecutor` for the NVDEC decode stage.** Do NOT rely on the pipeline's default shared thread pool. Create a separate `ThreadPoolExecutor(max_workers=C)` and pass it as `executor=` to the `.pipe()` call for the decode stage. This prevents NVDEC decode threads from competing with fetch/other CPU threads for the same pool, which is critical because NVDEC decode needs its own CUDA contexts per thread. Example: `.pipe(decode_fn, concurrency=7, executor=ThreadPoolExecutor(7))`.
+   - **NOT compatible with MTP (subprocess mode)** — `VideoPackets` are not picklable. GPU video decode must run as a pure multithreaded pipeline in the main process. Do NOT wrap the pipeline with `run_pipeline_in_subprocess` when using NVDEC. If the existing code uses MTP, remove the subprocess wrapper and use `PipelineBuilder.build(num_threads=N)` instead.
 
 Output the modified file:
 

--- a/tools/autoresearch/prompts/apply_startup_repair.md
+++ b/tools/autoresearch/prompts/apply_startup_repair.md
@@ -1,0 +1,37 @@
+You are an expert in SPDL data loading pipeline optimization for AI training. Your task is to repair an experiment that failed during job startup before meaningful performance metrics were produced.
+
+__KNOWLEDGE__
+
+---
+
+## Startup Failure to Repair
+
+**Experiment**: __EXPERIMENT_NAME__
+**Description**: __EXPERIMENT_DESCRIPTION__
+**Hypothesis**: __EXPERIMENT_HYPOTHESIS__
+**Retry Attempt**: __RETRY_ATTEMPT__
+**Failure Details**:
+
+```json
+__STARTUP_FAILURE_JSON__
+```
+
+## Source Code to Modify
+
+The file to modify is: `__PIPELINE_SCRIPT__`
+
+```python
+__PIPELINE_CODE__
+```
+
+## Instructions
+
+1. Preserve the experiment intent. Do not switch to a different optimization idea.
+2. Focus on startup/init failures: pickling, importability, configuration, function/class placement, subprocess boundaries, and MTP initialization.
+3. If repairing MTP/subprocess mode, make objects passed across process boundaries picklable. Move nested functions/classes to module scope when needed and avoid capturing unpicklable state in closures.
+4. Keep existing instrumentation and logging intact.
+5. Output the complete modified file inside exactly one fenced `python` code block. Do NOT output a diff or partial snippets.
+
+```python
+<full file content here>
+```

--- a/tools/autoresearch/prompts/headspace.md
+++ b/tools/autoresearch/prompts/headspace.md
@@ -39,6 +39,7 @@ dataloader = CacheDataLoader(dataloader, num_caches=10, return_caches_after=100)
   If the code uses nested epoch/batch loops, add the counter and break to the **inner batch loop** and also break out of the outer epoch loop.
 - Keep all other code unchanged — only add the CacheDataLoader import, wrapping, and step limit.
 - Do NOT remove or modify any existing instrumentation (e.g., TTFB logging).
+- **Iterator compatibility**: `CacheDataLoader` is iterable (`for batch in dl:`) but NOT an iterator (`next(dl)` fails). If the training loop uses `next(dataloader)`, you MUST change it to `data_iter = iter(dataloader)` before the loop, then `next(data_iter)` inside the loop. Or simply rewrite to `for batch in dataloader:`.
 
 **CRITICAL**: You MUST output the complete modified file content inside a single fenced code block with the `python` language tag. Do NOT output a diff, do NOT output partial snippets, do NOT describe the changes in prose. The output MUST contain exactly one block in this format:
 

--- a/tools/autoresearch/prompts/instrument.md
+++ b/tools/autoresearch/prompts/instrument.md
@@ -8,10 +8,15 @@ Add logging for the following metrics if not already present:
 
 2. **Step time**: Measure the wall-clock time of each training step (fetch batch + forward + backward + optimizer step). Log a running average every N steps (e.g. every 10 steps).
 
-3. **Data fetch time**: Measure the time spent in `next(dataloader)` separately from the compute time. This helps distinguish data loading bottlenecks from compute bottlenecks — but note that this metric alone can be misleading due to GIL contention (see knowledge base). It is signigicant only when the data fetch time alone is non-trivial. Fast data fetch time does not necessarily mean fast training.
+3. **Data fetch time**: Measure the time spent fetching each batch separately from the compute time. This helps distinguish data loading bottlenecks from compute bottlenecks — but note that this metric alone can be misleading due to GIL contention (see knowledge base). It is significant only when the data fetch time alone is non-trivial. Fast data fetch time does not necessarily mean fast training.
+
+   **Important**: If the code uses `for batch in dataloader:`, keep that pattern — wrap the timing around it. If you need to time fetch separately, create an explicit iterator with `data_iter = iter(dataloader)` before the loop, then use `batch = next(data_iter)`. Do NOT call `next(dataloader)` directly — not all dataloaders are iterators (some are only iterable).
+
+4. **Available CPU cores**: At startup (before the training loop), log the number of CPU cores available to this process. Use `os.sched_getaffinity(0)` (preferred, reflects cgroup/taskset restrictions) with a fallback to `os.cpu_count()`. Log it once.
 
 Use Python's `time.monotonic()` for timing. Print metrics to stdout in a parseable format like:
 ```
+[autoresearch] cpu_cores=32
 [autoresearch] ttfb_s=12.34
 [autoresearch] step=100 step_time_ms=150.2 fetch_time_ms=5.1 compute_time_ms=145.1
 ```

--- a/tools/autoresearch/prompts/knowledge.md
+++ b/tools/autoresearch/prompts/knowledge.md
@@ -4,9 +4,91 @@ This knowledge is assembled from shared skill files. The canonical sources are i
 
 ## Autoresearch-Specific Notes
 
+### MTP — PipelineBuilder vs Pipeline vs PipelineConfig
+
+The SPDL pipeline API has three distinct types:
+
+- **`PipelineBuilder`** — accumulates pipeline configuration in a monad pattern. Chain `.add_source()`, `.pipe()`, `.aggregate()`, `.add_sink()` on it. It does NOT run anything — it only builds up the config.
+- **`PipelineConfig`** — a frozen, picklable dataclass describing the pipeline. Obtained via `builder.get_config()`. This is what `run_pipeline_in_subprocess()` needs.
+- **`Pipeline`** — a facade for the running pipeline. Obtained via `builder.build(num_threads=N)` or `build_pipeline(config, num_threads=N)`. `Pipeline` is an **iterable** (not an iterator) — always use `pipeline.get_iterator(timeout=<seconds>)` to get an iterator with a timeout, rather than calling `iter(pipeline)` or iterating directly with `for batch in pipeline`.
+
+**`run_pipeline_in_subprocess()` accepts ONLY `PipelineConfig`** (from `.get_config()`). It does NOT accept `Pipeline` objects or iterators. If existing code calls `.build()` and returns a `Pipeline` or iterator, it must be refactored to return a `PipelineConfig` instead for MTP to work.
+
+**GPU stages (e.g. `transfer_tensor`) must NOT be in the subprocess pipeline.** They require a CUDA context which is unavailable in the subprocess. Split the pipeline: backend (subprocess) has CPU stages only; frontend (main process) applies GPU transfer.
+
 ### MTP Tier 1/Tier 2 Retry
 
 When implementing MTP, always try Tier 1 (module-level functions with `functools.partial`) first. If the job fails with subprocess-related issues (crashes on startup, silent 0-batch output), retry with Tier 2 (picklable callable classes). The autoresearch loop should attempt both automatically.
+
+### GPU Video Decoding (NVDEC)
+
+When the pipeline bottleneck is CPU video decoding (FFmpeg), GPU video decoding via NVDEC can eliminate the bottleneck entirely by offloading decode to dedicated GPU hardware decoders.
+
+**CPU decode pipeline:** `demux_video → decode_packets → convert_frames → transfer_buffer → to_torch`
+**GPU decode pipeline:** `demux_video → decode_packets_nvdec → to_torch` (much simpler, already on GPU)
+
+#### Key API: `spdl.io.decode_packets_nvdec`
+
+```python
+buffer = spdl.io.decode_packets_nvdec(
+    packets,                    # VideoPackets from demux_video()
+    device_config=spdl.io.cuda_config(
+        device_index=device_index,
+        allocator=(
+            torch.cuda.caching_allocator_alloc,
+            torch.cuda.caching_allocator_delete,
+        ),
+    ),
+    scale_width=width,          # hardware-accelerated resize (must be even)
+    scale_height=height,        # hardware-accelerated resize (must be even)
+    pix_fmt="rgb",              # auto-converts NV12 → RGB
+)
+tensor = spdl.io.to_torch(buffer)  # shape: [N, 3, H, W], already on GPU
+```
+
+#### What it replaces
+
+When refactoring from CPU to GPU decode, replace this pattern:
+```python
+# CPU decode (remove all of this)
+packets = spdl.io.demux_video(src, ...)
+frames = spdl.io.decode_packets(packets, ...)     # CPU FFmpeg decode
+buffer = spdl.io.convert_frames(frames)            # CPU pixel format conversion
+buffer = spdl.io.transfer_buffer(buffer, ...)      # CPU → GPU transfer
+tensor = spdl.io.to_torch(buffer)
+```
+
+With this:
+```python
+# GPU decode (replace with this)
+packets = spdl.io.demux_video(src, ...)
+buffer = spdl.io.decode_packets_nvdec(packets, device_config=cuda_cfg, pix_fmt="rgb")
+tensor = spdl.io.to_torch(buffer)  # already on GPU, no transfer needed
+```
+
+Note: `decode_packets_nvdec` automatically applies bitstream filtering (h264_mp4toannexb / hevc_mp4toannexb), so remove any manual `apply_bsf()` calls if present.
+
+#### Constraints
+
+- **GPU decoder slots are hardware-dependent** — H100 and B100 have 7 NVDEC instances per GPU, so decode concurrency can be set around 7. If the decoding pattern is **sparse** (sampling a few frames from each file rather than decoding many sequential frames), concurrency can exceed 7 since each decode job finishes quickly and doesn't saturate a decoder for long. Older GPUs (A100, V100) have fewer slots (3–5). Do NOT set concurrency equal to CPU thread count.
+- **Even dimensions required** — `scale_width` and `scale_height` must be even numbers.
+- **CUDAConfig must use PyTorch allocator** — always pass `allocator=(torch.cuda.caching_allocator_alloc, torch.cuda.caching_allocator_delete)` to `cuda_config()` so tensors share PyTorch's memory pool.
+- **No FFmpeg filters** — GPU decode does not support FFmpeg filter graphs. Resize/crop is done via NVDEC hardware parameters instead.
+- **Decoder creation is expensive** (~300ms) — SPDL uses thread-local caching to amortize this. Avoid passing crop parameters unless needed (they bypass the cache).
+- **SM utilization may appear lower** — GPU video decode uses dedicated NVDEC hardware engines, not SM (shader) cores. A pipeline using NVDEC may show lower SM utilization than a CPU-decode pipeline even though sample throughput is higher. Do NOT interpret lower SM utilization as a regression when using GPU decode — compare sample throughput (step time) instead.
+
+#### Pipeline integration — multithreading only, no MTP
+
+**GPU video decode is NOT compatible with MTP (subprocess mode)** because `VideoPackets` (the output of `demux_video`) are not picklable and cannot be passed across process boundaries.
+
+Use pure multithreading in the main process instead:
+- Build the entire pipeline (demux → decode_packets_nvdec → to_torch) in the main process using `PipelineBuilder`
+- Use `.build(num_threads=N)` with appropriate thread count
+- GPU decode releases the GIL during hardware decode, so multithreading works well
+- Set decode stage concurrency to match GPU hardware decoder slots (7 for H100/B100; higher for sparse decoding patterns)
+- **Use a dedicated `ThreadPoolExecutor` for the decode stage** — do NOT share the pipeline's default thread pool. Create `ThreadPoolExecutor(max_workers=C)` and pass it via `executor=` to the decode `.pipe()` call. This avoids contention between NVDEC decode threads (which need their own CUDA contexts) and CPU fetch/processing threads
+
+`gpu_video_decode` and `subprocess_mtp` are **independent, mutually exclusive** optimization paths. They cannot be combined. GPU decode experiments must apply changes to the original instrumented pipeline, not on top of MTP changes. Compare their results independently to determine which approach yields better throughput.
 
 ### Headspace Analysis in the Loop
 

--- a/tools/autoresearch/prompts/launch.md
+++ b/tools/autoresearch/prompts/launch.md
@@ -20,6 +20,8 @@ Optional inputs (have sensible defaults):
 - **Max concurrency** — concurrent training jobs, default 3
 - **Job timeout** — wall-clock timeout per job in seconds, default 1800 (30 min)
 - **Poll interval** — seconds between status checks, default 120
+- **Platform** — execution platform, default `auto`; use `local` for local subprocess execution
+- **Agent** — coding agent, default `claude`; use `codex` when that CLI is configured
 
 ## Step 2: Start the Engine
 
@@ -36,7 +38,9 @@ python run.py <workdir> \
   --max-iterations 10 \
   --patience 3 \
   --max-concurrency 3 \
-  --job-timeout 1800
+  --job-timeout 1800 \
+  --platform auto \
+  --agent claude
 ```
 
 Run this command in the background so you can monitor it. The engine handles everything: initialization, pipeline instrumentation, baseline job, headspace analysis, MTP experiment, and iterative optimization.
@@ -65,7 +69,7 @@ The engine runs these fixed initial experiments (skipping any already done):
 2. **Headspace** — wraps pipeline with CacheDataLoader to measure data loading overhead ceiling
 3. **MTP** — runs pipeline in subprocess to test GIL contention elimination
 
-After the fixed experiments, Claude proposes follow-up experiments based on analysis results. The engine:
+After the fixed experiments, the coding agent proposes follow-up experiments based on analysis results. The engine:
 
 - Runs up to `max_concurrency` jobs simultaneously
 - Analyzes each job immediately on completion (no waiting for the batch)
@@ -100,21 +104,23 @@ All files are in `<workdir>/`. Read them periodically to report progress to the 
 - `"interrupted"` — stopped by Ctrl+C, can resume
 - `"stopped"` — finished (stopping conditions met or all work exhausted)
 
+**`engine/checkpoint.json`** — Runner checkpoint containing serialized queued and running `WorkSpec` objects. This is the source of truth for resume after Ctrl+C or a crash.
+
 **`summary.md`** — Human-readable progress summary. Updated after each job completion. Show this to the user when they ask about progress.
 
 **`progress.png`** — Karpathy-style scatter plot showing job duration and SM utilization over time. Green dots are improvements, gray are discarded, red X are failures.
 
 **`hypothesis_tree.png`** — Tree visualization of the experiment hierarchy. Color-coded: green=completed/improved, gray=completed/no improvement, red=failed, blue=running, white dashed=queued. The best path is highlighted with thick green edges.
 
-**`engine/active.json`** — Currently running jobs with node_id, job_id, and launch timestamp.
+**`engine/active.json`** — Currently running jobs with node_id, job_id, and launch timestamp. This is a monitoring view.
 
-**`engine/queue.json`** — Pending experiments in priority order.
+**`engine/queue.json`** — Pending experiments in priority order. This is a monitoring view; do not treat it as the resume source of truth.
 
 **`engine/nodes/<node_id>/`** — Per-experiment details: `spec.json` (what it does), `status.txt` (current state), `result.json` (analysis results after completion).
 
 **`master_table.tsv`** — Tab-separated table of all experiments with metrics.
 
-**`runs/<run_id>/analysis.md`** — Claude's detailed analysis for each completed experiment.
+**`runs/<run_id>/analysis.md`** — Coding-agent detailed analysis for each completed experiment.
 
 ### Reporting Progress
 
@@ -141,9 +147,9 @@ To stop the engine gracefully, send SIGINT to the process. The engine needs time
 4. If still alive after 15 seconds, send `kill -TERM <pid>` and wait another 10 seconds
 5. Verify `engine/engine_state.json` shows `"status": "interrupted"`
 
-Do NOT send SIGKILL — it prevents state persistence and you'll lose the queue.
+Do NOT send SIGKILL — it prevents state persistence and can lose queued or running work that has not reached `engine/checkpoint.json`.
 
-Running jobs on the cluster are NOT cancelled by stopping the engine. They continue independently. The engine re-checks their status on resume.
+Running jobs on the cluster are NOT cancelled by stopping the engine. They continue independently. The engine re-checks their status on resume from `engine/checkpoint.json`.
 
 ### Engine Status: "interrupted"
 
@@ -151,7 +157,7 @@ Normal — the engine was stopped. Resume by re-running the engine with just the
 
 ### Build Failures
 
-Check `<workdir>/logs/last_build_error.txt`. Common causes: dependency issues from code changes, syntax errors in Claude's modifications. To intervene: stop the engine (Ctrl+C), fix the code in the source directory, then resume.
+Check `<workdir>/logs/last_build_error.txt`. Common causes: dependency issues from code changes or syntax errors in agent modifications. To intervene: stop the engine (Ctrl+C), fix the code in the source directory, then resume.
 
 ### All Jobs Failing
 
@@ -171,11 +177,11 @@ Check `hypothesis_tree.png` — are all branches exhausted? Read the latest `run
 
 ### Modifying the Queue
 
-The engine reads `engine/queue.json` on resume. To remove or reorder experiments: stop the engine, edit `engine/queue.json` (remove entries or change priority values — lower = higher priority), then resume.
+The engine reads `engine/checkpoint.json` on resume. To remove or reorder experiments, stop the engine and edit the `queued` list in `engine/checkpoint.json` only if manual queue surgery is required. Remove specs or change their `priority` values; lower priority values run first. `engine/queue.json` is only a monitoring view and is regenerated by the workflow.
 
 ### Log Files
 
 - `<workdir>/logs/autoresearch.log` — full execution log
-- `<workdir>/logs/*_prompt.md` — prompts sent to Claude
-- `<workdir>/logs/*_output.md` — Claude's responses
+- `<workdir>/logs/*_prompt.md` — prompts sent to the coding agent
+- `<workdir>/logs/*_output.md` — Coding-agent responses
 - `<workdir>/logs/*_raw.json` — raw JSON including cost and duration

--- a/tools/autoresearch/prompts/plan_next.md
+++ b/tools/autoresearch/prompts/plan_next.md
@@ -21,7 +21,7 @@ __KNOWLEDGE__
 - **Already tried**: __BEST_PRACTICES_TRIED__
 - **Not yet tried**: __BEST_PRACTICES_REMAINING__
 
-Valid best practice tags: `subprocess_mtp`, `batch_size_tuning`, `concurrency_tuning`
+Valid best practice tags: `subprocess_mtp`, `batch_size_tuning`, `concurrency_tuning`, `gpu_video_decode`
 
 ### Master Table (all runs so far)
 
@@ -70,7 +70,10 @@ Do NOT compare experiments using raw average SM utilization — it is misleading
 
 Before you can consider stopping, ALL of the following must have been attempted (check the "Not yet tried" list above):
 
-1. **`subprocess_mtp`** — Apply the **full MTP pattern** from the knowledge base. This is the highest-impact optimization and includes continuous mode, subprocess isolation, and proper GPU transfer. It requires structural changes — set `"rebuild": true`. **Follow the MTP section in the knowledge base.** Key points:
+1. **`subprocess_mtp`** — Apply the **full MTP pattern** from the knowledge base. This is the highest-impact optimization and includes continuous mode, subprocess isolation, and proper GPU transfer. **Follow the MTP section in the knowledge base.** Key points:
+   - **Critical — understand the existing code first**: Inspect the pipeline builder function's return type and structure. If it calls `.build()` or `.get_iterator()` (returning a `Pipeline` or iterator), the MTP refactor must change it to return a `PipelineConfig` (via `.get_config()`) or an unbuilt `PipelineBuilder` instead. `run_pipeline_in_subprocess()` accepts ONLY `PipelineConfig` — NOT `Pipeline` objects or iterators. Check type annotations and return statements.
+   - **Separate CPU and GPU stages**: The backend pipeline (subprocess) must contain ONLY CPU-bound stages (fetch, decode, aggregate, collate). GPU stages like `transfer_tensor` require a CUDA context and MUST be in the frontend pipeline (main process). If the existing code includes `transfer_tensor` or similar GPU ops in the pipeline, exclude them from the backend config.
+   - **Write the `description` field to explicitly instruct the code modifier** about these structural requirements, e.g.: "Refactor `build_pipeline()` to NOT call `.build()`. Instead, build a `PipelineBuilder` with only CPU stages (no `transfer_tensor`), call `.get_config()`, pass the config to `run_pipeline_in_subprocess(config, num_threads=N)`, then create a frontend `PipelineBuilder` that takes the subprocess iterable as source and applies `transfer_tensor`."
    - Use the **two-tier approach** for pickling: first try module-level functions with `functools.partial` (Tier 1). If the subprocess crashes silently (0 batches), retry with picklable callable classes that pickle objects directly from the main process (Tier 2). See "Pickling Constraints" in the knowledge base.
    - **HuggingFace tokenizers are NOT thread-safe** — use thread-local storage (TLS) when tokenizing with concurrency > 1.
    - Wrap the sampler with **`spdl.source.utils.embed_shuffle()`** for correct sampling behavior.
@@ -85,7 +88,27 @@ Before you can consider stopping, ALL of the following must have been attempted 
 
 3. **`concurrency_tuning`** — Adjust concurrency of the bottleneck stage. Try at least 2 different values.
 
-If the "Not yet tried" list is non-empty, you MUST prioritize those practices. If a practice doesn't apply to this pipeline (e.g., already uses continuous mode), explain why in your reasoning and still tag it so the orchestrator knows it was considered.
+   **Important — threads vs concurrency**:
+   - `PipelineBuilder.build(num_threads=N)` sets the thread pool size for the entire pipeline. Set this mechanically to `num_CPU_cores / num_GPU_workers` (or the number of allocated CPU cores per rank). This is NOT a tuning knob — it's a resource budget.
+   - `.pipe(fn, concurrency=C)` controls how many concurrent tasks run in a specific stage. THIS is the value to tune. The sum of all stage concurrencies should stay within the `num_threads` budget.
+   - For MTP subprocess mode, `run_pipeline_in_subprocess(config, num_threads=N)` — same rule: set `N` to `num_CPU_cores / num_GPU_workers`.
+   - **`spdl.pipeline.PriorityThreadPoolExecutor`** should be tried as part of concurrency tuning. It shares a single thread pool across all pipeline stages but prioritizes downstream stages (closer to output) over upstream ones, reducing end-to-end latency with no expected downside. Try it in at least one standalone experiment (without other changes) to verify the improvement, then combine it with other verified improvements (MTP, torch.compile, etc.) in later experiments. Usage: create one pool (`pool = PriorityThreadPoolExecutor(max_workers=N)`), then pass `executor=pool.get_executor()` to each CPU-bound `.pipe()` call — executors created later automatically get higher priority. It supports pickle for use with `run_pipeline_in_subprocess()`.
+     **Critical PriorityThreadPoolExecutor rules:**
+     - Do NOT pass `executor=` to GPU stages like `transfer_tensor` — GPU transfer must run on the pipeline's own thread, not in the CPU pool.
+     - When using PriorityThreadPoolExecutor, set `.build(num_threads=1)` — the pool handles all CPU threading; the pipeline event loop only needs 1 thread. Using `build(num_threads=N)` with N>1 creates a redundant second thread pool.
+     - Only attach `executor=pool.get_executor()` to CPU-bound stages (fetch, decode, collate). Leave GPU-bound stages (transfer_tensor) without an executor.
+
+4. **`gpu_video_decode`** — If the pipeline decodes video using CPU FFmpeg (`decode_packets` / `decode_packets_ffmpeg` / FFmpeg-based decode functions) and the decode stage is a bottleneck, try replacing it with GPU video decoding via NVDEC (`spdl.io.decode_packets_nvdec`). This offloads decode to dedicated GPU hardware and eliminates the CPU decode bottleneck. **Follow the GPU Video Decoding section in the knowledge base.** Key points:
+   - This practice only applies when the pipeline is doing **video decoding** and the decode stage is identified as a bottleneck. If the pipeline processes images, text, or audio, mark this as "not applicable" and skip.
+   - Replace the CPU decode chain (`decode_packets → convert_frames → transfer_buffer`) with `decode_packets_nvdec(packets, device_config=cuda_cfg, pix_fmt="rgb")` followed by `to_torch()`. The result is already on GPU — no `transfer_buffer` needed.
+   - Create `CUDAConfig` with PyTorch allocator: `spdl.io.cuda_config(device_index=..., allocator=(torch.cuda.caching_allocator_alloc, torch.cuda.caching_allocator_delete))`.
+   - **GPU decoder concurrency** — H100/B100 have 7 NVDEC instances per GPU, so set decode concurrency around 7. For sparse decoding patterns (sampling a few frames per file, not sequential decode), concurrency can exceed 7. Older GPUs (A100, V100) have 3–5 slots.
+   - **Even dimensions required** — `scale_width` and `scale_height` must be even numbers.
+   - **NOT compatible with MTP (subprocess mode)** — `VideoPackets` are not picklable and cannot cross process boundaries. GPU video decode must run as a pure multithreaded pipeline in the main process (using `PipelineBuilder.build(num_threads=N)`). `gpu_video_decode` is an **independent optimization path** from `subprocess_mtp` — they are mutually exclusive alternatives, not stackable. The GPU decode experiment must apply its changes to the original instrumented pipeline (not on top of MTP changes). Do NOT set `goto` to an MTP commit.
+   - **Use a dedicated `ThreadPoolExecutor` for the NVDEC decode stage** — do NOT share the pipeline's default thread pool. Create `ThreadPoolExecutor(max_workers=C)` and pass it via `executor=` to the decode `.pipe()` call. This prevents NVDEC decode threads (which need their own CUDA contexts) from competing with CPU fetch threads.
+   - Write the `description` field with explicit instructions, e.g.: "Replace `spdl.io.decode_packets(packets)` + `convert_frames` + `transfer_buffer` with `spdl.io.decode_packets_nvdec(packets, device_config=cuda_cfg, pix_fmt='rgb')`. Remove the `transfer_buffer`/`transfer_tensor` stage since data is already on GPU. Set decode concurrency to 7. Use a dedicated `ThreadPoolExecutor(7)` for the decode stage via `executor=ThreadPoolExecutor(7)`. Create `cuda_cfg` using `spdl.io.cuda_config(device_index, allocator=(torch.cuda.caching_allocator_alloc, torch.cuda.caching_allocator_delete))`. Use pure multithreading (no subprocess MTP)."
+
+If the "Not yet tried" list is non-empty, you MUST prioritize those practices. If a practice doesn't apply to this pipeline (e.g., already uses continuous mode, or doesn't do video decoding for gpu_video_decode), explain why in your reasoning and still tag it so the orchestrator knows it was considered.
 
 ### Number of Experiments
 
@@ -114,17 +137,21 @@ Propose **2-3 experiments per iteration** to make efficient use of compute. The 
 
    State your conclusions explicitly in the reasoning before proposing experiments.
 
-4. **If all best practices are tried and results are still improving**: Continue with Bayesian optimization principles:
+4. **CPU utilization and data starvation**: Do NOT avoid increasing CPU usage out of "noisy neighbor" concerns when the pipeline is data-starved. A pipeline is data-starved when headspace is large (e.g., >50%) or sink starvation / low data readiness is observed. In data-starved pipelines, the bottleneck is insufficient data processing throughput — increasing concurrency, threads, or decode parallelism is the correct approach even if CPU utilization is already high. The noisy-neighbor concern only applies when the pipeline is already keeping the GPU well-fed and additional CPU usage would not improve throughput. Use the available CPU core count (from `[autoresearch] cpu_cores=N` logs) to set appropriate thread budgets.
+
+5. **If all best practices are tried and results are still improving**: Continue with Bayesian optimization principles:
    - Model the parameter → metric relationship from history
    - Pick values that maximize expected improvement
    - Balance exploration (untested regions) vs exploitation (near the current best)
-   - Respect constraints: CPU ≤ 40%, concurrency ≤ num_CPU_cores / 8
+   - **HARD CONSTRAINT**: Total threads per rank (num_fetch_threads + num_decode_threads) must not exceed the cap stated in Additional Context. Experiments exceeding this are rejected automatically.
 
-5. **If parameter tuning has plateaued** (diminishing returns across recent iterations): Propose a structural change — splitting stages, different I/O functions, different pipeline topology. The orchestrator can modify source code in-place. Describe the code changes in the experiment's `"description"` field and set `"rebuild": true`.
+6. **Combine independently verified improvements**: Scan the Master Table for experiments that each improved over baseline via *different, orthogonal* changes (e.g., MTP improved step time, PriorityThreadPoolExecutor improved scheduling, torch.compile improved compute). When two or more such improvements exist, propose a **combination experiment** that applies all of them together. The combined gain is often larger than the sum of individual gains because the improvements target different bottlenecks. Describe ALL changes in the `"description"` field. Prioritize combinations of the best-performing variant of each independent idea.
 
-6. **If results are noisy or contradictory**: Propose a repeat of the best configuration to confirm, plus one new exploration point.
+7. **If parameter tuning has plateaued** (diminishing returns across recent iterations): Propose a structural change — splitting stages, different I/O functions, different pipeline topology. The orchestrator can modify source code in-place. Describe the code changes in the experiment's `"description"` field.
 
-7. **Only stop** (`"action": "stop"`) when:
+8. **If results are noisy or contradictory**: Propose a repeat of the best configuration to confirm, plus one new exploration point.
+
+9. **Only stop** (`"action": "stop"`) when:
    - ALL best practices have been tried (the "Not yet tried" list is empty), AND
    - Metrics have plateaued for __PATIENCE__ consecutive iterations (the plateau count has reached __PATIENCE__)
    - If either condition is not met, you MUST continue with `"action": "launch"`.
@@ -137,14 +164,15 @@ Output your reasoning, then a JSON block:
 {
   "action": "launch|stop|manual",
   "reasoning": "<2-3 sentence summary of your decision>",
-  "revert_to": "<commit hash to revert to before applying changes, or null>",
+  "goto": "<commit hash to check out before applying changes, or null>",
   "experiments": [
     {
       "name": "<short_snake_case>",
+      "change_summary": "<2-5 word concise label for plots, e.g. raise fetch threads>",
       "description": "<what we are changing>",
       "hypothesis": "<why this should help>",
       "launch_command": "<full command; use $IMAGE for image>",
-      "rebuild": false,
+
       "best_practices_tags": ["<tag1>", "<tag2>"]
     }
   ]
@@ -154,8 +182,9 @@ Output your reasoning, then a JSON block:
 Rules:
 - **Do NOT propose experiments that are semantically identical to existing ones**, even under a different name. Before proposing, check the Master Table for any run that used the same launch parameters (batch_size, num_workers, etc.) and code changes. If a configuration has been tested — regardless of what it was named — do not re-test it. The orchestrator also rejects duplicates with matching launch commands.
 - Use `$IMAGE` as placeholder for the job image (the orchestrator substitutes it)
+- **`change_summary`** must be concise and operator-readable. Use 2-5 words describing the one change being tested. Do not put implementation detail here; keep that in `description`.
 - torchx entrypoint args use **underscores**, not dashes (e.g. `--num_threads`)
-- If `rebuild` is true, the orchestrator will call a separate Claude session to apply the code changes described in `description`, commit them, rebuild the image, and then launch. **Write the `description` field as precise instructions for what code to modify** — specify function names, SPDL API calls to add/change, and the exact transformation. Do not write vague descriptions like "enable MTP" — instead write "Refactor `build_pipeline()` to return a `PipelineBuilder` config (without `.build()`), wrap it with `spdl.pipeline.run_pipeline_in_subprocess(config, num_threads=16, mp_context='forkserver')`, and create an outer pipeline that takes the subprocess source and applies GPU transfer via `pipe(transfer_tensor, executor=ThreadPoolExecutor(1))`."
+- The orchestrator will call a separate Claude session to apply the code changes described in `description`, commit them, rebuild the image, and then launch. **Write the `description` field as precise instructions for what code to modify** — specify function names, SPDL API calls to add/change, and the exact transformation. Do not write vague descriptions like "enable MTP" — instead write "Refactor `build_pipeline()` to return a `PipelineBuilder` config (without `.build()`), wrap it with `spdl.pipeline.run_pipeline_in_subprocess(config, num_threads=16, mp_context='forkserver')`, and create an outer pipeline that takes the subprocess source and applies GPU transfer via `pipe(transfer_tensor, executor=ThreadPoolExecutor(1))`."
 - Each experiment should differ from the baseline in exactly one dimension (or a small, justified set of changes)
 - **`best_practices_tags`**: Tag each experiment with which best practices it covers from the valid tags list. This is how the orchestrator tracks progress. If an experiment covers multiple practices, include all relevant tags.
-- **`revert_to`**: Set this to the commit hash of the **best successful experiment** before applying new code changes. This prevents regressions from accumulating in the source tree. Check the experiment history for the commit hash of the current best run. If the current source has changes from a failed or regressed experiment, you MUST set `revert_to` to revert to a clean state. Set to `null` only if the current source is already at the desired state (no regressions applied).
+- **`goto`**: The orchestrator checks out the instrumentation (anchor) commit before applying each experiment's code changes by default. This ensures every experiment starts from a clean slate. Set `goto` to `null` in most cases. Only set it to a specific commit hash if you want to stack changes on top of a previous successful experiment (e.g., adding batch size tuning on top of an MTP experiment that already improved metrics). Never stack incompatible changes (e.g., GPU decode on top of MTP — they are mutually exclusive).


### PR DESCRIPTION
Improve prompts for the reliablity and

**Iterator safety** (instrument, headspace):
- Fixed `next(dataloader)` guidance to use `iter(dataloader)` + `next(data_iter)` pattern since not all dataloaders are iterators (CacheDataLoader is iterable-only).
- Instrumentation prompt now preserves `for batch in dataloader:` patterns instead of blindly converting to `next()` calls.

**CPU resource awareness** (instrument, plan_next):
- Added CPU core count logging (`os.sched_getaffinity`) to instrumentation so the planner knows the actual thread budget per rank.
- Added hard constraint on total threads per rank, enforced programmatically.
- Distinguished `PipelineBuilder.build(num_threads)` (resource budget, set mechanically) from `.pipe(concurrency)` (the actual tuning knob).
- Added PriorityThreadPoolExecutor usage rules and promotion as a standalone experiment.

**MTP robustness** (apply_changes, plan_next, knowledge):
- Added detailed guidance on PipelineBuilder vs Pipeline vs PipelineConfig type distinctions — `run_pipeline_in_subprocess()` accepts only `PipelineConfig`, not `Pipeline` or iterators.
- Added instructions to separate CPU and GPU stages across subprocess boundary.
- Planner prompt now writes explicit structural instructions in the `description` field instead of vague directives.

**GPU video decode / NVDEC** (plan_next, apply_changes, knowledge, analyze):
- Added `gpu_video_decode` as a new best practice tag, with full NVDEC integration guidance.
- Added knowledge base section covering `decode_packets_nvdec` API, constraints (even dimensions, hardware decoder slots, PyTorch allocator), and pipeline integration (multithreading only, no MTP).
- Analysis prompt updated to not misinterpret lower SM utilization as regression when NVDEC uses dedicated hardware decoders.
- Apply-changes prompt updated with NVDEC-specific code transformation rules.

**CPU utilization / data starvation** (analyze, plan_next):
- Analysis and planner prompts now distinguish data-starved pipelines (where MORE CPU is correct) from GPU-saturated ones (where noisy-neighbor concerns apply).

**Startup repair** (apply_startup_repair — new):
- Added new prompt for repairing experiments that fail during job startup (pickling, importability, MTP initialization) without changing the experiment intent.

**Platform and wording updates** (launch):
- Replaced hardcoded "Claude" references with generic "coding agent" to support multiple agent backends.
- Added `--platform` and `--agent` CLI flags to launch prompt.
- Updated file layout docs to reference `engine/checkpoint.json` as the resume source of truth.

**Planner output schema** (plan_next):
- Renamed `revert_to` → `goto` with updated semantics (orchestrator checks out anchor commit by default; `goto` only needed for stacking on a previous experiment).
- Added `change_summary` field for concise operator-readable plot labels.
- Removed `rebuild` field (orchestrator infers rebuild from description).
- Added combination-experiment step to merge independently verified orthogonal improvements.
- Renumbered decision framework steps for consistency.