### PR TITLE
[autoresearch] Add platform and infrastructure boundary

### DIFF
--- a/tools/autoresearch/tests/test_platform.py
+++ b/tools/autoresearch/tests/test_platform.py
@@ -1,0 +1,157 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+from spdl.tools.autoresearch.utils.commands import queue as cmd_queue
+from spdl.tools.autoresearch.utils.platform import (
+    _MetricsEvidence,
+    AutoresearchPlatform,
+    create_platform,
+)
+from spdl.tools.autoresearch.utils.platform.agents import (
+    _MockAgent,
+    _parse_agent_result,
+)
+
+__all__: list[str] = []
+
+
+class _PlatformTest(unittest.TestCase):
+    def test_default_platform_has_capability_parts(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            platform = create_platform("auto", Path(tmp))
+
+            self.assertIsInstance(platform, AutoresearchPlatform)
+            self.assertTrue(hasattr(platform, "workspace"))
+            self.assertTrue(hasattr(platform, "artifacts"))
+            self.assertTrue(hasattr(platform, "execution"))
+            self.assertTrue(hasattr(platform, "evidence"))
+            self.assertTrue(hasattr(platform, "agent"))
+
+    def test_local_platform_runs_subprocess_and_collects_log_evidence(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            workdir = Path(tmp)
+            platform = create_platform("local", workdir)
+
+            job_id = platform.execution.launch(
+                "printf '[autoresearch] step=1\\n'",
+                workdir,
+            )
+            self.assertIsNotNone(job_id)
+            assert job_id is not None
+
+            for _ in range(50):
+                status = platform.execution.status(job_id)
+                if status == "SUCCEEDED":
+                    break
+                time.sleep(0.05)
+            self.assertEqual("SUCCEEDED", platform.execution.status(job_id))
+            self.assertEqual(
+                "[autoresearch] step=1", platform.execution.progress(job_id)
+            )
+
+            metrics_dir = workdir / "runs" / "000_baseline" / "metrics"
+            evidence = platform.evidence.collect(job_id, metrics_dir)
+
+            self.assertIsInstance(evidence, _MetricsEvidence)
+            self.assertIn("system metrics unavailable", evidence.system_metrics)
+            self.assertIn("[autoresearch] step=1", evidence.pipeline_stats_log)
+
+    def test_local_dry_run_completes_without_launching_subprocess(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            workdir = Path(tmp)
+            platform = create_platform(
+                {"platform": "local", "local_execution_mode": "dry_run"},
+                workdir,
+            )
+
+            job_id = platform.execution.launch("printf 'not executed\\n'", workdir)
+            self.assertIsNotNone(job_id)
+            assert job_id is not None
+
+            self.assertEqual("SUCCEEDED", platform.execution.status(job_id))
+            self.assertIn("dry_run", platform.execution.progress(job_id) or "")
+
+    def test_local_dataloader_only_uses_dataloader_command(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            workdir = Path(tmp)
+            platform = create_platform(
+                {
+                    "platform": "local",
+                    "local_execution_mode": "dataloader_only",
+                    "local_dataloader_command": "printf '[autoresearch] dataloader\\n'",
+                },
+                workdir,
+            )
+
+            job_id = platform.execution.launch("printf 'training\\n'", workdir)
+            self.assertIsNotNone(job_id)
+            assert job_id is not None
+
+            for _ in range(50):
+                status = platform.execution.status(job_id)
+                if status == "SUCCEEDED":
+                    break
+                time.sleep(0.05)
+
+            self.assertEqual("SUCCEEDED", platform.execution.status(job_id))
+            self.assertEqual(
+                "[autoresearch] dataloader", platform.execution.progress(job_id)
+            )
+
+    def test_mock_agent_is_selected_independently_of_platform(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            platform = create_platform(
+                {"platform": "local", "agent": "mock"},
+                Path(tmp),
+            )
+
+            self.assertEqual("", platform.agent.run("prompt", Path(tmp), "phase"))
+
+    def test_platform_config_validation_rejects_bad_local_mode(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            with self.assertRaisesRegex(ValueError, "local execution mode"):
+                create_platform(
+                    {"platform": "local", "local_execution_mode": "unknown"},
+                    Path(tmp),
+                )
+
+    def test_agent_result_reports_parse_errors_without_llm(self) -> None:
+        agent = _MockAgent()
+
+        parsed = _parse_agent_result(agent, '```json\n{"action": "stop"}\n```')
+        failed = _parse_agent_result(agent, "not json")
+
+        self.assertEqual({"action": "stop"}, parsed.json)
+        self.assertIsNone(parsed.parse_error)
+        self.assertIsNone(failed.json)
+        self.assertEqual("No JSON object found", failed.parse_error)
+
+    def test_queue_command_updates_checkpoint_priority(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            workdir = Path(tmp)
+            engine = workdir / "engine"
+            engine.mkdir(parents=True)
+            (engine / "checkpoint.json").write_text(
+                '{"status": "interrupted", "queued": ['
+                '{"id": "001_a", "priority": 10, "kind": "experiment", '
+                '"payload": {"node": {"node_id": "001_a"}}}], "running": []}\n'
+            )
+
+            cmd_queue._run([str(workdir), "priority", "001_a", "-5"])
+
+            text = (engine / "checkpoint.json").read_text()
+            self.assertIn('"priority": -5.0', text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/autoresearch/utils/claude.py
+++ b/tools/autoresearch/utils/claude.py
@@ -20,12 +20,26 @@ from .state import read_config
 
 _LG: logging.Logger = logging.getLogger(__name__)
 
-SCRIPT_DIR = Path(__file__).resolve().parent.parent
-PROMPTS_DIR = SCRIPT_DIR / "prompts"
+_SCRIPT_DIR = Path(__file__).resolve().parent.parent
+_PROMPTS_DIR = _SCRIPT_DIR / "prompts"
+
+SCRIPT_DIR = _SCRIPT_DIR
+PROMPTS_DIR = _PROMPTS_DIR
+
+__all__ = [
+    "_extract_json_block",
+    "_load_knowledge",
+    "_load_prompt",
+    "_run_claude",
+    "extract_json_block",
+    "load_knowledge",
+    "load_prompt",
+    "run_claude",
+]
 
 
-def load_prompt(name: str, **kwargs: str) -> str:
-    path = PROMPTS_DIR / f"{name}.md"
+def _load_prompt(name: str, **kwargs: str) -> str:
+    path = _PROMPTS_DIR / f"{name}.md"
     if not path.exists():
         print(f"Error: prompt template not found: {path}", file=sys.stderr)
         sys.exit(1)
@@ -33,6 +47,24 @@ def load_prompt(name: str, **kwargs: str) -> str:
     for key, value in kwargs.items():
         template = template.replace(f"__{key.upper()}__", str(value))
     return template
+
+
+load_prompt = _load_prompt
+
+
+def _load_knowledge() -> str:
+    """Load shared skill files and autoresearch-specific knowledge.
+
+    Reads symlinked skill files from prompts/ for shared pipeline
+    optimization knowledge, then appends autoresearch-specific knowledge.
+    """
+    parts: list[str] = []
+    for name in ["optimization_strategies.md", "how_to_interpret_pipeline_stats.md"]:
+        path = _PROMPTS_DIR / name
+        if path.exists():
+            parts.append(path.read_text())
+    parts.append(_load_prompt("knowledge"))
+    return "\n\n".join(parts)
 
 
 def load_knowledge() -> str:
@@ -44,22 +76,22 @@ def load_knowledge() -> str:
     """
     parts: list[str] = []
     for name in ["optimization_strategies.md", "how_to_interpret_pipeline_stats.md"]:
-        path = PROMPTS_DIR / name
+        path = _PROMPTS_DIR / name
         if path.exists():
             parts.append(path.read_text())
-    parts.append(load_prompt("knowledge"))
+    parts.append(_load_prompt("knowledge"))
     for name in [
         "fetching_pipeline_stats.md",
         "mast_job_lifecycle.md",
         "knowledge.md",
     ]:
-        path = PROMPTS_DIR / "fb" / name
+        path = _PROMPTS_DIR / "fb" / name
         if path.exists():
             parts.append(path.read_text())
     return "\n\n".join(parts)
 
 
-def run_claude(prompt: str, workdir: Path, phase: str) -> str:
+def _run_claude(prompt: str, workdir: Path, phase: str) -> str:
     """Run a stateless Claude session and return the text response.
 
     Uses --output-format json to get structured output, then extracts
@@ -129,11 +161,14 @@ def run_claude(prompt: str, workdir: Path, phase: str) -> str:
     return text
 
 
+run_claude = _run_claude
+
+
 def _extract_result_text(raw_stdout: str, phase: str) -> str:
     """Extract the result text from Claude's JSON output.
 
     The JSON line may be preceded by stderr-like banner lines on stdout
-    (e.g. "Claude Code at Meta ..."). We find the JSON object by looking
+    (for example, CLI banner lines). We find the JSON object by looking
     for the last line that starts with '{'.
     """
     json_line = ""
@@ -174,7 +209,7 @@ def _safe_get(raw_stdout: str, key: str, default: object = None) -> object:
     return default
 
 
-def extract_json_block(text: str) -> dict | None:
+def _extract_json_block(text: str) -> dict | None:
     """Extract a ```json ... ``` code block from Claude's text response."""
     matches = list(re.finditer(r"```json\s*\n(.*?)\n```", text, re.DOTALL))
     if not matches:
@@ -185,3 +220,6 @@ def extract_json_block(text: str) -> dict | None:
         except json.JSONDecodeError:
             continue
     return None
+
+
+extract_json_block = _extract_json_block

--- a/tools/autoresearch/utils/infra/__init__.py
+++ b/tools/autoresearch/utils/infra/__init__.py
@@ -1,0 +1,9 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Infrastructure helper modules used by autoresearch platforms."""
+
+__all__: list[str] = []

--- a/tools/autoresearch/utils/infra/jobs.py
+++ b/tools/autoresearch/utils/infra/jobs.py
@@ -1,0 +1,290 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Job launch, monitoring, and metrics collection.
+
+Generic stubs are defined here. Platform implementations can wrap these helpers
+or replace them behind ``utils/platform`` capabilities.
+
+Design note for future agents
+=============================
+
+This module is an infrastructure helper, not part of the generic runner. Keep
+scheduler-neutral job helpers here and keep platform-specific details behind
+``utils/platform`` capabilities. Do not add job-platform behavior to
+``runner.py``.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+_LG: logging.Logger = logging.getLogger(__name__)
+
+__all__ = [
+    "_apply_lint",
+    "_build_image",
+    "_cancel_job",
+    "_check_job_progress",
+    "_check_job_status",
+    "_collect_metrics_summary",
+    "_fetch_pipeline_stats",
+    "_fetch_system_metrics",
+    "_get_job_duration",
+    "_launch_job",
+    "_wait_for_jobs",
+]
+
+
+def _fetch_system_metrics(job_id: str) -> str:
+    """Fetch system metrics (GPU/CPU) for a training job.
+
+    Override this through a platform _Evidence implementation.
+    """
+    return "(system metrics not available — implement _fetch_system_metrics)"
+
+
+def _fetch_pipeline_stats(job_id: str, output_dir: str) -> str:
+    """Fetch SPDL pipeline performance stats for a training job.
+
+    Override this through a platform _Evidence implementation.
+    """
+    return "(pipeline stats not available — implement _fetch_pipeline_stats)"
+
+
+def _check_job_status(job_id: str) -> str:
+    """Check training job status. Override for your infrastructure."""
+    return "UNKNOWN"
+
+
+def _check_job_progress(job_id: str) -> str | None:
+    """Return a progress indicator for a running job.
+
+    Should return a string that changes when the job makes progress,
+    or None if progress checking is not available.
+    Override this through a platform _Execution implementation.
+    """
+    return None
+
+
+def _get_job_duration(job_id: str) -> int | None:
+    """Get the actual runtime of a job in seconds (excludes queue time).
+    Override for your infrastructure."""
+    return None
+
+
+def _cancel_job(job_id: str) -> bool:
+    """Cancel a running job. Returns True on success.
+    Override for your infrastructure."""
+    return False
+
+
+def _apply_lint(source_dir: str) -> None:
+    """Run linter/formatter and fix build deps after code changes.
+    Override for your infrastructure."""
+
+
+def _launch_job(command: str, workdir: Path) -> str | None:
+    """Launch a training job and return its ID."""
+    _LG.info("Launching job: %s", command)
+    result = subprocess.run(
+        command,
+        shell=True,
+        capture_output=True,
+        text=True,
+        cwd=str(workdir),
+    )
+    _LG.debug(
+        "_launch_job returncode=%d stdout=%s stderr=%s",
+        result.returncode,
+        result.stdout[:500],
+        result.stderr[:500],
+    )
+    combined = result.stdout + result.stderr
+    for pattern in [
+        r"Launched app:\s*\S+/(\S+)",
+        r"Job ID:\s*(\S+)",
+        r"job[_-]?id[=: ]+(\S+)",
+    ]:
+        match = re.search(pattern, combined, re.IGNORECASE)
+        if match:
+            job_id = match.group(1)
+            _LG.info("Extracted job ID: %s", job_id)
+            return job_id
+    _LG.error("Could not extract job ID from output:\n%s", combined[:500])
+    return None
+
+
+def _get_check_job_status():
+    """Get the active _check_job_status implementation.
+
+    Platform implementations should call their status capability directly.
+    This lookup remains for older helper-only callers.
+    """
+    pkg = sys.modules.get(__package__)
+    if pkg is not None:
+        fn = getattr(pkg, "_check_job_status", None)
+        if fn is not None:
+            return fn
+    return _check_job_status
+
+
+def _get_check_job_progress():
+    """Get the active _check_job_progress implementation."""
+    pkg = sys.modules.get(__package__)
+    if pkg is not None:
+        fn = getattr(pkg, "_check_job_progress", None)
+        if fn is not None:
+            return fn
+    return _check_job_progress
+
+
+def _get_cancel_job():
+    """Get the active _cancel_job implementation."""
+    pkg = sys.modules.get(__package__)
+    if pkg is not None:
+        fn = getattr(pkg, "_cancel_job", None)
+        if fn is not None:
+            return fn
+    return _cancel_job
+
+
+def _wait_for_jobs(
+    job_ids: list[str],
+    poll_interval: int = 120,
+    max_unknown_polls: int = 5,
+    max_stall_polls: int = 15,
+) -> dict[str, dict[str, object]]:
+    """Wait for jobs to complete. Returns {job_id: {"status": str, "elapsed_s": int}}.
+
+    Kills stuck jobs (no progress for max_stall_polls consecutive polls).
+    """
+    results: dict[str, dict[str, object]] = {}
+    pending = set(job_ids)
+    start_time = time.monotonic()
+    job_start: dict[str, float] = {j: start_time for j in job_ids}
+    unknown_counts: dict[str, int] = dict.fromkeys(job_ids, int())
+    stall_counts: dict[str, int] = dict.fromkeys(job_ids, int())
+    last_progress: dict[str, str | None] = dict.fromkeys(job_ids, None)
+    _check = _get_check_job_status()
+    _progress = _get_check_job_progress()
+    _cancel = _get_cancel_job()
+
+    def _finish(job_id: str, status: str) -> None:
+        elapsed_s = int(time.monotonic() - job_start[job_id])
+        results[job_id] = {"status": status, "elapsed_s": elapsed_s}
+        pending.discard(job_id)
+
+    while pending:
+        for job_id in list(pending):
+            status = _check(job_id)
+            if status in ("SUCCEEDED", "COMPLETE"):
+                _finish(job_id, "completed")
+                print(f"  [{job_id}] COMPLETED")
+            elif status == "FAILED":
+                _finish(job_id, "failed")
+                print(f"  [{job_id}] FAILED")
+            elif status == "UNKNOWN":
+                unknown_counts[job_id] = unknown_counts.get(job_id, 0) + 1
+                if unknown_counts[job_id] >= max_unknown_polls:
+                    _cancel(job_id)
+                    _finish(job_id, "failed")
+                    print(
+                        f"  [{job_id}] UNKNOWN after {max_unknown_polls} polls, killed"
+                    )
+                else:
+                    print(
+                        f"  [{job_id}] UNKNOWN "
+                        f"({unknown_counts[job_id]}/{max_unknown_polls})"
+                    )
+            else:
+                unknown_counts[job_id] = 0
+                progress = _progress(job_id)
+                if progress is not None:
+                    prev = last_progress.get(job_id)
+                    if prev is not None and progress == prev:
+                        stall_counts[job_id] = stall_counts.get(job_id, 0) + 1
+                        if stall_counts[job_id] >= max_stall_polls:
+                            _cancel(job_id)
+                            _finish(job_id, "failed")
+                            print(
+                                f"  [{job_id}] STUCK — no progress for "
+                                f"{max_stall_polls} polls, killed"
+                            )
+                            continue
+                        print(
+                            f"  [{job_id}] {status} "
+                            f"(no progress {stall_counts[job_id]}/{max_stall_polls})"
+                        )
+                    else:
+                        stall_counts[job_id] = 0
+                        last_progress[job_id] = progress
+                        print(f"  [{job_id}] {status}")
+                else:
+                    print(f"  [{job_id}] {status}")
+
+        if pending:
+            print(f"  Waiting {poll_interval}s... ({len(pending)} job(s) pending)")
+            time.sleep(poll_interval)
+
+    return results
+
+
+def _build_image(build_command: str, workdir: Path, cwd: str = "") -> str | None:
+    if not build_command:
+        return None
+    run_cwd = cwd or str(workdir)
+    _LG.info("Building image: %s (cwd=%s)", build_command, run_cwd)
+    result = subprocess.run(
+        build_command,
+        shell=True,
+        capture_output=True,
+        text=True,
+        cwd=run_cwd,
+    )
+    _LG.debug("_build_image returncode=%d", result.returncode)
+    if result.returncode != 0:
+        _LG.error(
+            "Build failed (rc=%d):\n[STDOUT]\n%s\n[STDERR]\n%s",
+            result.returncode,
+            result.stdout[-2000:] if result.stdout else "(empty)",
+            result.stderr[-2000:] if result.stderr else "(empty)",
+        )
+        build_log = workdir / "logs" / "last_build_error.txt"
+        build_log.parent.mkdir(exist_ok=True)
+        build_log.write_text(
+            f"[COMMAND]\n{build_command}\n\n"
+            f"[STDOUT]\n{result.stdout}\n\n"
+            f"[STDERR]\n{result.stderr}\n"
+        )
+        print(f"  Build error details saved to {build_log}")
+        return None
+    lines = result.stdout.strip().splitlines()
+    if not lines:
+        _LG.error("Build produced no output")
+        return None
+    image = lines[-1]
+    _LG.info("Built image: %s", image)
+    return image
+
+
+def _collect_metrics_summary(metrics_dir: Path) -> str:
+    parts = []
+    if not metrics_dir.exists():
+        return "(no metrics files found)"
+    for f in sorted(metrics_dir.iterdir()):
+        if f.suffix == ".tsv":
+            content = f.read_text()
+            lines = content.strip().splitlines()
+            if len(lines) > 52:
+                content = "\n".join(lines[:2] + ["..."] + lines[-50:])
+            parts.append(f"\n### {f.name}\n```\n{content}\n```")
+    return "\n".join(parts) if parts else "(no .tsv files found)"

--- a/tools/autoresearch/utils/infra/scm.py
+++ b/tools/autoresearch/utils/infra/scm.py
@@ -1,0 +1,133 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Source control abstraction for autoresearch.
+
+Detects whether the source directory uses Sapling (sl) or Git, and
+provides commit/goto/_current_commit operations. The autoresearch system
+uses this to commit code changes with descriptive messages and to revert
+to earlier experiment commits when branching out.
+
+An "anchor commit" recorded at init time is the boundary — the system
+must never go back beyond it.
+"""
+
+from __future__ import annotations
+
+import logging
+import shutil
+import subprocess
+
+_LG: logging.Logger = logging.getLogger(__name__)
+
+__all__ = [
+    "_commit",
+    "_current_commit",
+    "_detect_scm",
+    "_goto",
+    "_has_pending_changes",
+]
+
+
+def _run(cmd: list[str], cwd: str) -> subprocess.CompletedProcess:
+    _LG.debug("scm: %s (cwd=%s)", cmd, cwd)
+    result = subprocess.run(cmd, capture_output=True, text=True, cwd=cwd)
+    _LG.debug("scm: rc=%d stdout=%s", result.returncode, result.stdout.strip()[:200])
+    if result.returncode != 0:
+        _LG.debug("scm: stderr=%s", result.stderr.strip()[:500])
+    return result
+
+
+def _detect_scm(source_dir: str) -> str:
+    """Detect which SCM is available. Returns 'sl' or 'git'."""
+    if shutil.which("sl"):
+        result = _run(["sl", "root"], source_dir)
+        if result.returncode == 0:
+            _LG.info("Detected SCM: sl (Sapling)")
+            return "sl"
+    if shutil.which("git"):
+        result = _run(["git", "rev-parse", "--git-dir"], source_dir)
+        if result.returncode == 0:
+            _LG.info("Detected SCM: git")
+            return "git"
+    raise RuntimeError(
+        f"No supported SCM found in {source_dir}. Install sl (Sapling) or git."
+    )
+
+
+def _current_commit(scm: str, source_dir: str) -> str:
+    """Return the current commit hash."""
+    if scm == "sl":
+        result = _run(["sl", "log", "-r", ".", "-T", "{node}"], source_dir)
+    else:
+        result = _run(["git", "rev-parse", "HEAD"], source_dir)
+    if result.returncode != 0:
+        raise RuntimeError(f"Failed to get current commit: {result.stderr}")
+    return result.stdout.strip()
+
+
+def _commit(scm: str, source_dir: str, message: str) -> str:
+    """Commit all pending changes with the given message. Returns commit hash."""
+    if scm == "sl":
+        result = _run(["sl", "commit", "-m", message], source_dir)
+    else:
+        _run(["git", "add", "-A"], source_dir)
+        result = _run(["git", "commit", "-m", message], source_dir)
+
+    if result.returncode != 0:
+        if "nothing changed" in result.stdout or "nothing to commit" in result.stdout:
+            _LG.info("Nothing to commit")
+            return _current_commit(scm, source_dir)
+        raise RuntimeError(f"Commit failed: {result.stderr}")
+
+    new_hash = _current_commit(scm, source_dir)
+    _LG.info("Committed %s: %s", new_hash[:12], message[:80])
+    return new_hash
+
+
+def _goto(scm: str, source_dir: str, target: str, anchor: str) -> None:
+    """Go to a target commit. Refuses to go before the anchor commit."""
+    if not _is_descendant(scm, source_dir, target, anchor):
+        raise ValueError(
+            f"Refusing to go to {target[:12]}: it is not a descendant of "
+            f"anchor commit {anchor[:12]}."
+        )
+
+    _LG.info("Going to commit %s", target[:12])
+    if scm == "sl":
+        result = _run(["sl", "goto", target], source_dir)
+    else:
+        result = _run(["git", "checkout", target], source_dir)
+
+    if result.returncode != 0:
+        raise RuntimeError(f"Failed to go to {target[:12]}: {result.stderr}")
+
+
+def _has_pending_changes(scm: str, source_dir: str) -> bool:
+    """Check if there are uncommitted changes."""
+    if scm == "sl":
+        result = _run(["sl", "status"], source_dir)
+    else:
+        result = _run(["git", "status", "--porcelain"], source_dir)
+    return bool(result.stdout.strip())
+
+
+def _is_descendant(scm: str, source_dir: str, commit_hash: str, ancestor: str) -> bool:
+    """Check if commit_hash is a descendant of (or equal to) ancestor."""
+    if commit_hash == ancestor:
+        return True
+    if scm == "sl":
+        result = _run(
+            ["sl", "log", "-r", f"{ancestor}::{commit_hash}", "-T", "{node}\n"],
+            source_dir,
+        )
+        return ancestor in result.stdout
+    else:
+        result = _run(
+            ["git", "merge-base", "--is-ancestor", ancestor, commit_hash],
+            source_dir,
+        )
+        return result.returncode == 0

--- a/tools/autoresearch/utils/log.py
+++ b/tools/autoresearch/utils/log.py
@@ -11,6 +11,8 @@ from pathlib import Path
 
 _configured = False
 
+__all__ = ["setup_logging"]
+
 
 def setup_logging(workdir: Path) -> None:
     """Configure logging to stderr and workdir/logs/autoresearch.log."""

--- a/tools/autoresearch/utils/platform/__init__.py
+++ b/tools/autoresearch/utils/platform/__init__.py
@@ -1,0 +1,31 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Autoresearch platform boundary."""
+
+from .factory import create_platform
+from .types import (
+    _Artifacts,
+    _CodingAgent,
+    _Evidence,
+    _Execution,
+    _MetricsEvidence,
+    _PlatformError,
+    _Workspace,
+    AutoresearchPlatform,
+)
+
+__all__ = [
+    "_Artifacts",
+    "AutoresearchPlatform",
+    "_CodingAgent",
+    "create_platform",
+    "_Evidence",
+    "_Execution",
+    "_MetricsEvidence",
+    "_PlatformError",
+    "_Workspace",
+]

--- a/tools/autoresearch/utils/platform/agents.py
+++ b/tools/autoresearch/utils/platform/agents.py
@@ -1,0 +1,159 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Coding-agent implementations for autoresearch."""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+import subprocess
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from .. import claude
+from .types import _AgentResult
+
+_LG: logging.Logger = logging.getLogger(__name__)
+
+__all__ = [
+    "_ClaudeAgent",
+    "_CodexAgent",
+    "_MockAgent",
+    "_parse_agent_result",
+    "_create_agent",
+    "_extract_json_block",
+]
+
+
+class _ClaudeAgent:
+    """Stateless Claude-backed coding agent."""
+
+    def _load_prompt(self, name: str, **kwargs: str) -> str:
+        return claude._load_prompt(name, **kwargs)
+
+    def _load_knowledge(self) -> str:
+        return claude._load_knowledge()
+
+    def run(self, prompt: str, workdir: Path, phase: str) -> str:
+        return claude._run_claude(prompt, workdir, phase)
+
+    def _extract_json_block(self, text: str) -> dict | None:
+        return _extract_json_block(text)
+
+
+class _CodexAgent:
+    """Stateless Codex-backed coding agent.
+
+    The interface mirrors ``_ClaudeAgent`` so the workflow can swap agents
+    without changing experiment logic. The command is intentionally configured
+    outside the workflow because different environments expose Codex through
+    different CLIs.
+    """
+
+    def __init__(self, command: list[str] | None = None) -> None:
+        self._command = command or ["codex", "exec", "-"]
+
+    def _load_prompt(self, name: str, **kwargs: str) -> str:
+        return claude._load_prompt(name, **kwargs)
+
+    def _load_knowledge(self) -> str:
+        return claude._load_knowledge()
+
+    def run(self, prompt: str, workdir: Path, phase: str) -> str:
+        log_dir = workdir / "logs"
+        log_dir.mkdir(exist_ok=True)
+        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        prompt_file = log_dir / f"{timestamp}_{phase}_prompt.md"
+        output_file = log_dir / f"{timestamp}_{phase}_output.md"
+        raw_file = log_dir / f"{timestamp}_{phase}_raw.txt"
+        prompt_file.write_text(prompt)
+
+        _LG.info("Running codex [phase=%s] cmd=%s", phase, self._command)
+        result = subprocess.run(
+            self._command,
+            input=prompt,
+            capture_output=True,
+            text=True,
+            cwd=str(workdir),
+            timeout=900,
+        )
+        raw_file.write_text(f"[STDOUT]\n{result.stdout}\n[STDERR]\n{result.stderr}")
+        if result.returncode != 0:
+            raise RuntimeError(
+                f"Codex exited with code {result.returncode} during '{phase}'. "
+                f"See {raw_file} for details.\n"
+                f"stderr: {result.stderr[:500]}"
+            )
+        output_file.write_text(result.stdout)
+        return result.stdout
+
+    def _extract_json_block(self, text: str) -> dict | None:
+        return _extract_json_block(text)
+
+
+class _MockAgent:
+    """Deterministic test agent backed by phase/prompt-name responses."""
+
+    def __init__(self, responses: dict[str, str] | None = None) -> None:
+        self.responses = responses or {}
+        self.calls: list[tuple[str, str]] = []
+
+    def _load_prompt(self, name: str, **kwargs: str) -> str:
+        template = self.responses.get(f"prompt:{name}", f"PROMPT:{name}")
+        for key, value in kwargs.items():
+            template = template.replace(f"__{key.upper()}__", str(value))
+        return template
+
+    def _load_knowledge(self) -> str:
+        return self.responses.get("knowledge", "")
+
+    def run(self, prompt: str, workdir: Path, phase: str) -> str:
+        self.calls.append((phase, prompt))
+        return self.responses.get(phase, self.responses.get("*", ""))
+
+    def _extract_json_block(self, text: str) -> dict | None:
+        return _extract_json_block(text)
+
+
+def _create_agent(kind: str, *, command: list[str] | None = None) -> object:
+    if kind == "claude":
+        return _ClaudeAgent()
+    if kind == "codex":
+        return _CodexAgent(command)
+    if kind == "mock":
+        return _MockAgent()
+    raise ValueError(f"Unknown autoresearch agent: {kind}")
+
+
+def _parse_agent_result(agent: Any, raw_text: str) -> _AgentResult:
+    try:
+        parsed = agent._extract_json_block(raw_text)
+    except Exception as error:
+        return _AgentResult(raw_text=raw_text, parse_error=str(error))
+    if parsed is None:
+        return _AgentResult(raw_text=raw_text, parse_error="No JSON object found")
+    return _AgentResult(raw_text=raw_text, json=parsed)
+
+
+def _extract_json_block(text: str) -> dict | None:
+    """Extract a `````json`` block from an agent response."""
+
+    matches = list(re.finditer(r"```json\s*\n(.*?)\n```", text, re.DOTALL))
+    if not matches:
+        try:
+            parsed = json.loads(text)
+        except json.JSONDecodeError:
+            return None
+        return parsed if isinstance(parsed, dict) else None
+    for match in reversed(matches):
+        try:
+            return json.loads(match.group(1))
+        except json.JSONDecodeError:
+            continue
+    return None

--- a/tools/autoresearch/utils/platform/factory.py
+++ b/tools/autoresearch/utils/platform/factory.py
@@ -1,0 +1,120 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Public platform factory."""
+
+from __future__ import annotations
+
+from importlib import import_module
+from pathlib import Path
+from typing import Any, cast
+
+from .agents import _create_agent
+from .local import (
+    _DefaultArtifacts,
+    _DefaultEvidence,
+    _DefaultExecution,
+    _DefaultWorkspace,
+    _LocalEvidence,
+    _LocalExecution,
+    _LocalWorkspace,
+)
+from .types import _CodingAgent, AutoresearchPlatform
+
+__all__ = ["create_platform"]
+
+_LOCAL_EXECUTION_MODES = frozenset({"full", "dataloader_only", "dry_run"})
+_AGENT_KINDS = frozenset({"claude", "codex", "mock"})
+
+
+def create_platform(
+    config_or_kind: dict[str, Any] | str,
+    workdir: Path | None = None,
+) -> AutoresearchPlatform:
+    """Create a platform from persisted config or a direct platform name."""
+
+    if isinstance(config_or_kind, str):
+        config: dict[str, Any] = {"platform": config_or_kind}
+    else:
+        config = config_or_kind
+
+    kind = str(config.get("platform", "auto"))
+    agent_kind = str(config.get("agent", "claude"))
+    _validate_platform_config(config, workdir)
+    agent = cast(
+        _CodingAgent, _create_agent(agent_kind, command=config.get("agent_command"))
+    )
+
+    if kind == "local":
+        mode = str(config.get("local_execution_mode", "full"))
+        execution = _LocalExecution(mode, config.get("local_dataloader_command"))
+        if workdir is not None:
+            execution.bind_workdir(workdir)
+        return AutoresearchPlatform(
+            workspace=_LocalWorkspace(),
+            artifacts=_DefaultArtifacts(),
+            execution=execution,
+            evidence=_LocalEvidence(),
+            agent=agent,
+        )
+
+    if kind in ("auto", "remote"):
+        fb_platform = _create_fb_platform(config, workdir, agent)
+        if fb_platform is not None:
+            return fb_platform
+        if kind == "remote":
+            raise ValueError("Remote autoresearch platform is not available")
+        return AutoresearchPlatform(
+            workspace=_DefaultWorkspace(),
+            artifacts=_DefaultArtifacts(),
+            execution=_DefaultExecution(),
+            evidence=_DefaultEvidence(),
+            agent=agent,
+        )
+
+    raise ValueError(f"Unknown autoresearch platform: {kind}")
+
+
+def _validate_platform_config(config: dict[str, Any], workdir: Path | None) -> None:
+    kind = str(config.get("platform", "auto"))
+    if kind not in ("auto", "remote", "local"):
+        raise ValueError(f"Unknown autoresearch platform: {kind}")
+
+    agent = str(config.get("agent", "claude"))
+    if agent not in _AGENT_KINDS:
+        raise ValueError(f"Unknown autoresearch agent: {agent}")
+
+    mode = str(config.get("local_execution_mode", "full"))
+    if mode not in _LOCAL_EXECUTION_MODES:
+        raise ValueError(f"Unknown local execution mode: {mode}")
+
+    source_dir = str(config.get("source_dir", ""))
+    if source_dir and not Path(source_dir).exists():
+        raise ValueError(f"Autoresearch source_dir does not exist: {source_dir}")
+
+    pipeline_script = config.get("pipeline_script")
+    if pipeline_script and not Path(str(pipeline_script)).exists():
+        raise ValueError(
+            f"Autoresearch pipeline_script does not exist: {pipeline_script}"
+        )
+
+    if workdir is not None and not workdir.exists():
+        workdir.mkdir(parents=True, exist_ok=True)
+
+
+def _create_fb_platform(
+    config: dict[str, Any],
+    workdir: Path | None,
+    agent: object,
+) -> AutoresearchPlatform | None:
+    try:
+        factory = import_module("spdl.tools.autoresearch.utils.platform.fb.factory")
+    except ImportError:
+        return None
+    create = getattr(factory, "_create_platform", None)
+    if create is None:
+        return None
+    return create(config=config, workdir=workdir, agent=agent)

--- a/tools/autoresearch/utils/platform/local.py
+++ b/tools/autoresearch/utils/platform/local.py
@@ -1,0 +1,341 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Local and generic platform capabilities."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import shlex
+import signal
+import subprocess
+import time
+from pathlib import Path
+
+from ..infra import jobs, scm
+from .types import _MetricsEvidence
+
+_LG: logging.Logger = logging.getLogger(__name__)
+
+__all__ = [
+    "_DefaultArtifacts",
+    "_DefaultEvidence",
+    "_DefaultExecution",
+    "_DefaultWorkspace",
+    "_LocalEvidence",
+    "_LocalExecution",
+    "_LocalWorkspace",
+    "_extract_traceback",
+    "_summarize_error",
+]
+
+
+class _DefaultWorkspace:
+    def detect(self, source_dir: str) -> str:
+        return scm._detect_scm(source_dir)
+
+    def current(self, scm_type: str, source_dir: str) -> str:
+        return scm._current_commit(scm_type, source_dir)
+
+    def commit(self, scm_type: str, source_dir: str, message: str) -> str:
+        return scm._commit(scm_type, source_dir, message)
+
+    def goto(self, scm_type: str, source_dir: str, target: str, anchor: str) -> None:
+        scm._goto(scm_type, source_dir, target, anchor)
+
+    def has_changes(self, scm_type: str, source_dir: str) -> bool:
+        return scm._has_pending_changes(scm_type, source_dir)
+
+    def apply_lint(self, source_dir: str) -> None:
+        jobs._apply_lint(source_dir)
+
+
+class _LocalWorkspace(_DefaultWorkspace):
+    def apply_lint(self, source_dir: str) -> None:
+        _LG.info("Skipping infrastructure lint for local platform: %s", source_dir)
+
+
+class _DefaultArtifacts:
+    def build(self, build_command: str, workdir: Path, cwd: str = "") -> str | None:
+        return jobs._build_image(build_command, workdir, cwd)
+
+
+class _DefaultExecution:
+    def launch(self, command: str, workdir: Path) -> str | None:
+        return jobs._launch_job(command, workdir)
+
+    def status(self, job_id: str) -> str:
+        return jobs._check_job_status(job_id)
+
+    def progress(self, job_id: str) -> str | None:
+        return jobs._check_job_progress(job_id)
+
+    def cancel(self, job_id: str) -> bool:
+        return jobs._cancel_job(job_id)
+
+    def duration(self, job_id: str) -> int | None:
+        return jobs._get_job_duration(job_id)
+
+
+class _DefaultEvidence:
+    def collect(self, job_id: str, metrics_dir: Path) -> _MetricsEvidence:
+        metrics_dir.mkdir(parents=True, exist_ok=True)
+        system_metrics = jobs._fetch_system_metrics(job_id)
+        pipeline_stats_log = jobs._fetch_pipeline_stats(job_id, str(metrics_dir))
+        metrics_summary = jobs._collect_metrics_summary(metrics_dir)
+        return _MetricsEvidence(
+            system_metrics=system_metrics,
+            pipeline_stats_log=pipeline_stats_log,
+            metrics_summary=metrics_summary,
+            error_summary=_summarize_error(
+                "\n".join((system_metrics, pipeline_stats_log, metrics_summary))
+            ),
+        )
+
+
+class _LocalExecution:
+    """Run experiment jobs as local subprocesses."""
+
+    def __init__(
+        self,
+        mode: str = "full",
+        dataloader_command: str | None = None,
+    ) -> None:
+        self._root: Path | None = None
+        self._mode = mode
+        self._dataloader_command = dataloader_command
+
+    def bind_workdir(self, workdir: Path) -> _LocalExecution:
+        self._root = workdir / "local_jobs"
+        return self
+
+    def launch(self, command: str, workdir: Path) -> str | None:
+        self.bind_workdir(workdir)
+        job_id = f"local_{int(time.time() * 1000)}"
+        local_dir = workdir / "local_jobs" / job_id
+        local_dir.mkdir(parents=True, exist_ok=True)
+
+        if self._mode == "dry_run":
+            _write_json(
+                local_dir / "job.json",
+                {
+                    "job_id": job_id,
+                    "command": command,
+                    "started_at": time.time(),
+                    "ended_at": time.time(),
+                    "returncode": 0,
+                    "mode": self._mode,
+                },
+            )
+            (local_dir / "stdout.log").write_text(
+                f"[autoresearch] dry_run command={command}\n"
+            )
+            (local_dir / "stderr.log").write_text("")
+            (local_dir / "returncode.txt").write_text("0\n")
+            return job_id
+
+        run_command = (
+            self._dataloader_command
+            if self._mode == "dataloader_only" and self._dataloader_command
+            else command
+        )
+        stdout = (local_dir / "stdout.log").open("w")
+        stderr = (local_dir / "stderr.log").open("w")
+        rc_file = local_dir / "returncode.txt"
+        wrapped_command = (
+            f"{run_command}; "
+            f"rc=$?; "
+            f"printf '%s\\n' \"$rc\" > {shlex.quote(str(rc_file))}; "
+            "exit $rc"
+        )
+        process = subprocess.Popen(
+            wrapped_command,
+            shell=True,
+            cwd=str(workdir),
+            stdout=stdout,
+            stderr=stderr,
+            text=True,
+        )
+        _write_json(
+            local_dir / "job.json",
+            {
+                "job_id": job_id,
+                "command": run_command,
+                "requested_command": command,
+                "pid": process.pid,
+                "started_at": time.time(),
+                "returncode": None,
+                "mode": self._mode,
+            },
+        )
+        return job_id
+
+    def status(self, job_id: str) -> str:
+        data = self._load(job_id)
+        if not data:
+            return "UNKNOWN"
+        rc_file = self._job_path(job_id).parent / "returncode.txt"
+        if rc_file.exists():
+            try:
+                data["returncode"] = int(rc_file.read_text().strip())
+                data.setdefault("ended_at", time.time())
+                _write_json(self._job_path(job_id), data)
+            except ValueError:
+                _LG.warning("Invalid local return code in %s", rc_file)
+        returncode = data.get("returncode")
+        if isinstance(returncode, int):
+            return "SUCCEEDED" if returncode == 0 else "FAILED"
+        pid = int(data["pid"])
+        if _process_alive(pid):
+            return "RUNNING"
+        data["returncode"] = 1
+        data["ended_at"] = time.time()
+        _write_json(self._job_path(job_id), data)
+        return "FAILED"
+
+    def progress(self, job_id: str) -> str | None:
+        for name in ("stdout.log", "stderr.log"):
+            path = self._job_path(job_id).parent / name
+            if not path.exists():
+                continue
+            for line in reversed(path.read_text(errors="replace").splitlines()):
+                if "[autoresearch]" in line:
+                    return line.strip()
+        return None
+
+    def cancel(self, job_id: str) -> bool:
+        data = self._load(job_id)
+        if not data:
+            return False
+        if isinstance(data.get("returncode"), int):
+            return True
+        pid = int(data["pid"])
+        try:
+            os.kill(pid, signal.SIGTERM)
+            time.sleep(1)
+            if _process_alive(pid):
+                os.kill(pid, signal.SIGKILL)
+            data["returncode"] = data.get("returncode", -signal.SIGTERM)
+            data["ended_at"] = time.time()
+            _write_json(self._job_path(job_id), data)
+            return True
+        except ProcessLookupError:
+            return True
+
+    def duration(self, job_id: str) -> int | None:
+        data = self._load(job_id)
+        if not data:
+            return None
+        started = data.get("started_at")
+        ended = data.get("ended_at", time.time())
+        if not isinstance(started, (int, float)) or not isinstance(ended, (int, float)):
+            return None
+        return int(float(ended) - float(started))
+
+    def _job_path(self, job_id: str) -> Path:
+        if self._root is None:
+            raise RuntimeError("_LocalExecution has no workdir root")
+        return self._root / job_id / "job.json"
+
+    def _load(self, job_id: str) -> dict | None:
+        path = self._job_path(job_id)
+        if not path.exists():
+            return None
+        return json.loads(path.read_text())
+
+
+class _LocalEvidence:
+    def collect(self, job_id: str, metrics_dir: Path) -> _MetricsEvidence:
+        metrics_dir.mkdir(parents=True, exist_ok=True)
+        local_dir = metrics_dir.parents[2] / "local_jobs" / job_id
+        logs = []
+        log_paths = []
+        for name in ("stdout.log", "stderr.log"):
+            path = local_dir / name
+            if path.exists():
+                log_paths.append(str(path))
+                logs.append(f"## {name}\n{path.read_text(errors='replace')[-4000:]}")
+        local_log = "\n\n".join(logs) if logs else "(no local job logs found)"
+        metrics_summary = jobs._collect_metrics_summary(metrics_dir)
+        exit_code = _read_local_exit_code(local_dir)
+        return _MetricsEvidence(
+            system_metrics="(system metrics unavailable for this local platform)",
+            pipeline_stats_log=local_log,
+            metrics_summary=metrics_summary,
+            log_paths=log_paths,
+            exit_code=exit_code,
+            error_summary=_summarize_error(local_log),
+            progress_seen="[autoresearch]" in local_log,
+        )
+
+
+def _summarize_error(text: str) -> str | None:
+    traceback = _extract_traceback(text)
+    if traceback:
+        return traceback
+    for line in reversed(text.splitlines()):
+        stripped = line.strip()
+        if not stripped:
+            continue
+        lower = stripped.lower()
+        if any(
+            marker in lower
+            for marker in (
+                "error",
+                "exception",
+                "traceback",
+                "failed",
+                "cannot pickle",
+                "can't pickle",
+                "out of memory",
+            )
+        ):
+            return stripped[-1000:]
+    return None
+
+
+def _extract_traceback(text: str) -> str | None:
+    lines = text.splitlines()
+    start = None
+    for index, line in enumerate(lines):
+        if line.startswith("Traceback (most recent call last):"):
+            start = index
+    if start is None:
+        return None
+    block = []
+    for line in lines[start:]:
+        block.append(line)
+        if len(block) >= 40:
+            break
+        stripped = line.strip()
+        if block and ":" in stripped and not line.startswith((" ", "\t")):
+            if not stripped.startswith("Traceback"):
+                break
+    return "\n".join(block)[-2000:]
+
+
+def _write_json(path: Path, data: dict) -> None:
+    path.write_text(json.dumps(data, indent=2) + "\n")
+
+
+def _read_local_exit_code(local_dir: Path) -> int | None:
+    path = local_dir / "returncode.txt"
+    if not path.exists():
+        return None
+    try:
+        return int(path.read_text().strip())
+    except ValueError:
+        return None
+
+
+def _process_alive(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+        return True
+    except ProcessLookupError:
+        return False

--- a/tools/autoresearch/utils/platform/types.py
+++ b/tools/autoresearch/utils/platform/types.py
@@ -1,0 +1,218 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Autoresearch platform capability boundary.
+
+Design note for future agents
+=============================
+
+The runner is deliberately simple: it runs coroutine work and persists queued
+or running specs on cancellation. Autoresearch-specific behavior belongs in the
+workflow and in this platform boundary. Keep platform operations grouped by
+capability instead of adding callback arguments, hidden imports, or scheduler
+logic to ``runner.py``.
+
+``AutoresearchPlatform`` is intentionally small and boring. The workflow can
+swap local, remote, Claude, Codex, or test implementations by replacing these
+capability objects without learning any implementation-specific commands.
+
+.. mermaid::
+
+   flowchart LR
+       Workflow["AutoresearchAdapter"]
+       Platform["AutoresearchPlatform"]
+       _Workspace["_Workspace"]
+       _Artifacts["_Artifacts"]
+       _Execution["_Execution"]
+       _Evidence["_Evidence"]
+       Agent["_CodingAgent"]
+       Local["local implementations"]
+       Remote["optional fb implementations"]
+
+       Workflow --> Platform
+       Platform --> _Workspace
+       Platform --> _Artifacts
+       Platform --> _Execution
+       Platform --> _Evidence
+       Platform --> Agent
+       _Workspace --> Local
+       _Artifacts --> Local
+       _Execution --> Local
+       _Evidence --> Local
+       _Workspace --> Remote
+       _Artifacts --> Remote
+       _Execution --> Remote
+       _Evidence --> Remote
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Protocol
+
+__all__ = [
+    "AutoresearchPlatform",
+    "_AgentResult",
+    "_Artifacts",
+    "_CodingAgent",
+    "_Evidence",
+    "_Execution",
+    "_MetricsEvidence",
+    "_PlatformError",
+    "_Workspace",
+]
+
+
+@dataclass(frozen=True)
+class _AgentResult:
+    """Parsed coding-agent response used by workflow code."""
+
+    raw_text: str
+    json: dict | None = None
+    parse_error: str | None = None
+
+
+@dataclass(frozen=True)
+class _MetricsEvidence:
+    """Performance evidence collected for analysis.
+
+    Local execution may still produce meaningful metrics. Treat missing
+    ``system_metrics`` as an evidence limitation, not as proof that local mode
+    is unguided.
+    """
+
+    system_metrics: str
+    pipeline_stats_log: str
+    metrics_summary: str
+    log_paths: list[str] = field(default_factory=list)
+    exit_code: int | None = None
+    error_summary: str | None = None
+    progress_seen: bool | None = None
+
+
+@dataclass(frozen=True)
+class _PlatformError(RuntimeError):
+    """Structured platform failure before workflow classification."""
+
+    capability: str
+    operation: str
+    message: str
+    command: str | None = None
+    returncode: int | None = None
+    stderr_tail: str | None = None
+    log_path: str | None = None
+    retryable: bool = False
+
+    def __str__(self) -> str:
+        return f"{self.capability}.{self.operation}: {self.message}"
+
+
+class _Workspace(Protocol):
+    """Source-control and source-tree operations for workflow code.
+
+    .. mermaid::
+
+       flowchart LR
+           Workflow["workflow/source_ops.py"]
+           _Workspace["_Workspace"]
+           SourceTree["source tree"]
+           SCM["SCM"]
+
+           Workflow --> _Workspace
+           _Workspace --> SourceTree
+           _Workspace --> SCM
+    """
+
+    def detect(self, source_dir: str) -> str: ...
+
+    def current(self, scm_type: str, source_dir: str) -> str: ...
+
+    def commit(self, scm_type: str, source_dir: str, message: str) -> str: ...
+
+    def goto(
+        self, scm_type: str, source_dir: str, target: str, anchor: str
+    ) -> None: ...
+
+    def has_changes(self, scm_type: str, source_dir: str) -> bool: ...
+
+    def apply_lint(self, source_dir: str) -> None: ...
+
+
+class _Artifacts(Protocol):
+    """Build or resolve artifacts consumed by experiment launches."""
+
+    def build(self, build_command: str, workdir: Path, cwd: str = "") -> str | None: ...
+
+
+class _Execution(Protocol):
+    """Launch, poll, and cancel experiment jobs."""
+
+    def launch(self, command: str, workdir: Path) -> str | None: ...
+
+    def status(self, job_id: str) -> str: ...
+
+    def progress(self, job_id: str) -> str | None: ...
+
+    def cancel(self, job_id: str) -> bool: ...
+
+    def duration(self, job_id: str) -> int | None: ...
+
+
+class _Evidence(Protocol):
+    """Collect metrics, logs, and local evidence for completed jobs."""
+
+    def collect(self, job_id: str, metrics_dir: Path) -> _MetricsEvidence: ...
+
+
+class _CodingAgent(Protocol):
+    """Prompt rendering and stateless coding-agent execution.
+
+    Workflow code should depend on this protocol, not on a specific CLI. This
+    keeps Claude, Codex, and deterministic test agents swappable.
+    """
+
+    def _load_prompt(self, name: str, **kwargs: str) -> str: ...
+
+    def _load_knowledge(self) -> str: ...
+
+    def run(self, prompt: str, workdir: Path, phase: str) -> str: ...
+
+    def _extract_json_block(self, text: str) -> dict | None: ...
+
+
+@dataclass(frozen=True)
+class AutoresearchPlatform:
+    """Capability aggregate used by the autoresearch workflow.
+
+    The aggregate is not a service locator. It has exactly the capability
+    groups that the workflow needs, so new implementation-specific behavior has
+    a clear home and does not leak into runner or workflow scheduling logic.
+
+    .. mermaid::
+
+       flowchart TB
+           Adapter["AutoresearchAdapter"]
+           Platform["AutoresearchPlatform"]
+           _Workspace["workspace"]
+           _Artifacts["artifacts"]
+           _Execution["execution"]
+           _Evidence["evidence"]
+           Agent["agent"]
+
+           Adapter --> Platform
+           Platform --> _Workspace
+           Platform --> _Artifacts
+           Platform --> _Execution
+           Platform --> _Evidence
+           Platform --> Agent
+    """
+
+    workspace: _Workspace
+    artifacts: _Artifacts
+    execution: _Execution
+    evidence: _Evidence
+    agent: _CodingAgent


### PR DESCRIPTION
Add the platform abstraction layer that groups workspace, artifact, execution, evidence, and coding-agent capabilities behind explicit protocols. This creates a clear boundary between domain workflow logic and infrastructure-specific implementations.

Architecture: `AutoresearchPlatform` is intentionally small — a frozen dataclass aggregating five capability protocols. The workflow can swap local, remote, Claude, Codex, or test implementations by replacing these capability objects without learning any implementation-specific commands. Platform operations are grouped by capability (workspace, artifacts, execution, evidence, agent) instead of using callback arguments, hidden imports, or scheduler logic in `runner.py`. The infrastructure helpers (`infra/jobs.py`, `infra/scm.py`) are scheduler-neutral stubs; platform implementations wrap or replace them.

Platform capabilities (`utils/platform/`):
- `types.py` — protocol definitions (`_Workspace`, `_Artifacts`, `_Execution`, `_Evidence`, `_CodingAgent`), `AutoresearchPlatform` aggregate dataclass, `_MetricsEvidence`, `_PlatformError`, `_AgentResult`
- `local.py` — local/default implementations: `_DefaultWorkspace`, `_LocalWorkspace`, `_DefaultExecution`, `_LocalExecution` (subprocess-based with dry_run and dataloader_only modes), `_LocalEvidence`, error summarization helpers
- `factory.py` — `create_platform()` factory supporting auto/remote/local modes with config validation
- `agents.py` — `_ClaudeAgent`, `_CodexAgent`, `_MockAgent` implementations with `_parse_agent_result` helper

Infrastructure helpers (`utils/infra/`):
- `jobs.py` — generic job launch/monitor/cancel stubs and `_wait_for_jobs` polling loop
- `scm.py` — Sapling/Git abstraction for commit, goto, and ancestry checks

Also adds `_load_knowledge()` and underscored aliases in `claude.py` for the platform agent interface, `__all__` to `log.py`, and `test_platform.py` covering platform creation, local execution, dry_run, dataloader_only, agent parsing, and queue command.