### PR TITLE
[autoresearch] Add workflow orchestration layer

### DIFF
--- a/tools/autoresearch/tests/test_autoresearch_workflow.py
+++ b/tools/autoresearch/tests/test_autoresearch_workflow.py
@@ -1,0 +1,696 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+import asyncio
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from spdl.tools.autoresearch.plot_progress import (
+    _edge_label,
+    _load_tsv,
+    _tree_font_sizes,
+)
+from spdl.tools.autoresearch.utils.commands.report import _read_failures
+from spdl.tools.autoresearch.utils.commands.status import _failure_summary
+from spdl.tools.autoresearch.utils.platform import _MetricsEvidence, create_platform
+from spdl.tools.autoresearch.utils.platform.agents import _MockAgent
+from spdl.tools.autoresearch.utils.platform.local import _summarize_error
+from spdl.tools.autoresearch.utils.runner import _WorkSpec
+from spdl.tools.autoresearch.utils.state import (
+    _append_master_row,
+    _normalize_config,
+    _normalize_state,
+    MASTER_TABLE_HEADERS,
+    SCHEMA_VERSION,
+    write_state,
+)
+from spdl.tools.autoresearch.utils.types import (
+    _AnalysisResult,
+    _HypothesisNode,
+    FailureKind,
+    FailurePhase,
+    FailureRecord,
+)
+from spdl.tools.autoresearch.utils.workflow import (
+    _AutoresearchStore,
+    AutoresearchAdapter,
+)
+from spdl.tools.autoresearch.utils.workflow.analysis_ops import _update_on_complete
+from spdl.tools.autoresearch.utils.workflow.failures import (
+    _classify_terminal_job_failure,
+    _FAILURE_POLICIES,
+    _make_failure,
+)
+from spdl.tools.autoresearch.utils.workflow.policy import (
+    _change_summary_for_spec,
+    _compare_metric_value,
+    _extract_total_threads,
+    _node_from_spec,
+    _retry_policy_for_failure,
+    _select_planning_node,
+    _spec_from_node,
+    _startup_retry_spec,
+    _validate_thread_budget,
+)
+from spdl.tools.autoresearch.utils.workflow.source_ops import _build_apply_prompt
+from spdl.tools.autoresearch.utils.workflow.store import _write_text_atomic
+
+__all__: list[str] = []
+
+
+def _config() -> dict:
+    return {
+        "pipeline_script": "",
+        "source_dir": "",
+        "scm": "",
+        "build_command": "",
+        "base_launch_command": "torchx run example --num-fetch-threads 8",
+        "stopping_criteria": {
+            "max_iterations": 20,
+            "patience": 5,
+        },
+        "max_concurrency": 4,
+        "job_timeout_s": 600,
+        "poll_interval": 0,
+    }
+
+
+def _state() -> dict:
+    return {
+        "iteration": 0,
+        "status": "looping",
+        "baseline_job": None,
+        "current_best": None,
+        "best_metric": None,
+        "plateau_count": 0,
+        "best_practices_tried": [],
+        "anchor_commit": "",
+        "history": [],
+    }
+
+
+class _AutoresearchWorkflowTest(unittest.TestCase):
+    def test_fresh_load_creates_initial_must_run_specs(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            adapter = self._adapter(Path(tmp))
+
+            specs = adapter.load()
+
+            self.assertEqual(
+                ["000_baseline", "000_headspace", "001_subprocess_mtp"],
+                [spec.id for spec in specs],
+            )
+            self.assertEqual([-1000, -999, -998], [spec.priority for spec in specs])
+
+    def test_checkpoint_writes_compatibility_files(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            workdir = Path(tmp)
+            adapter = self._adapter(workdir)
+            specs = adapter.load()
+
+            adapter.checkpoint(queued=specs[1:], running=specs[:1], status="running")
+
+            engine_state = json.loads(
+                (workdir / "engine" / "engine_state.json").read_text()
+            )
+            queue = json.loads((workdir / "engine" / "queue.json").read_text())
+            active = json.loads((workdir / "engine" / "active.json").read_text())
+            baseline_status = (
+                workdir / "engine" / "nodes" / "000_baseline" / "status.txt"
+            ).read_text()
+
+            self.assertEqual("running", engine_state["status"])
+            self.assertEqual(2, engine_state["queued"])
+            self.assertEqual(1, engine_state["running"])
+            self.assertEqual(
+                ["000_headspace", "001_subprocess_mtp"], [q["node_id"] for q in queue]
+            )
+            self.assertEqual([], active)
+            self.assertEqual("queued\n", baseline_status)
+
+    def test_checkpoint_round_trips_specs(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            workdir = Path(tmp)
+            adapter = self._adapter(workdir)
+            specs = adapter.load()
+            adapter.checkpoint(queued=specs[1:], running=specs[:1], status="running")
+
+            loaded = self._adapter(workdir).load()
+
+            self.assertEqual(
+                ["000_headspace", "001_subprocess_mtp", "000_baseline"],
+                [spec.id for spec in loaded],
+            )
+
+    def test_planning_is_blocked_until_must_run_experiments_finish(self) -> None:
+        baseline = _HypothesisNode(
+            node_id="000_baseline",
+            name="baseline",
+            status="completed",
+        )
+        headspace = _HypothesisNode(
+            node_id="000_headspace",
+            name="headspace_cache",
+            status="queued",
+        )
+        mtp = _HypothesisNode(
+            node_id="001_subprocess_mtp",
+            name="subprocess_mtp",
+            status="completed",
+        )
+
+        selected = _select_planning_node(
+            baseline,
+            {
+                baseline.node_id: baseline,
+                headspace.node_id: headspace,
+                mtp.node_id: mtp,
+            },
+        )
+
+        self.assertIsNone(selected)
+
+    def test_headspace_completion_selects_mtp_after_must_run_finish(self) -> None:
+        baseline = _HypothesisNode(
+            node_id="000_baseline",
+            name="baseline",
+            status="completed",
+        )
+        headspace = _HypothesisNode(
+            node_id="000_headspace",
+            name="headspace_cache",
+            status="completed",
+            spec={"_is_headspace": True},
+        )
+        mtp = _HypothesisNode(
+            node_id="001_subprocess_mtp",
+            name="subprocess_mtp",
+            status="completed",
+        )
+
+        selected = _select_planning_node(
+            headspace,
+            {
+                baseline.node_id: baseline,
+                headspace.node_id: headspace,
+                mtp.node_id: mtp,
+            },
+        )
+
+        self.assertEqual(mtp, selected)
+
+    def test_policy_helpers_cover_metric_and_thread_decisions(self) -> None:
+        self.assertEqual(
+            ("step_ms", 12.5),
+            _compare_metric_value({"steady_step_time_ms": 12.5, "duration_s": 100}),
+        )
+        self.assertEqual(
+            24,
+            _extract_total_threads("--num-fetch-threads 8 --num-decode-threads 16"),
+        )
+        self.assertEqual(
+            ["ok"],
+            [
+                spec["name"]
+                for spec in _validate_thread_budget(
+                    [
+                        {"name": "ok", "launch_command": "--num-threads 8"},
+                        {"name": "too_many", "launch_command": "--num-threads 64"},
+                    ],
+                    16,
+                )
+            ],
+        )
+
+    def test_store_update_spec_refreshes_checkpoint_and_active_view(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            workdir = Path(tmp)
+            self._write_base_files(workdir)
+            store = _AutoresearchStore(workdir, _state())
+            node = _HypothesisNode(
+                node_id="000_baseline",
+                name="baseline",
+                status="queued",
+            )
+            spec = _spec_from_node(node)
+            store.save_scheduler_state(queued=[], running=[spec], status="running")
+
+            node.status = "running"
+            node.job_id = "remote_job"
+            store.update_spec(spec, node)
+
+            checkpoint = json.loads(
+                (workdir / "engine" / "checkpoint.json").read_text()
+            )
+            active = json.loads((workdir / "engine" / "active.json").read_text())
+            running_node = _node_from_spec(
+                _WorkSpec.from_dict(checkpoint["running"][0])
+            )
+
+            self.assertEqual("remote_job", running_node.job_id)
+            self.assertEqual("000_baseline", active[0]["node_id"])
+            self.assertEqual("remote_job", active[0]["job_id"])
+            self.assertIn("launched_at_iso", active[0])
+
+    def test_queue_view_includes_retry_lineage(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            workdir = Path(tmp)
+            self._write_base_files(workdir)
+            store = _AutoresearchStore(workdir, _state())
+            node = _HypothesisNode(
+                node_id="002_retry",
+                name="retry",
+                status="queued",
+                spec={
+                    "_startup_retry_of": "001_subprocess_mtp",
+                    "_startup_retry_attempt": 1,
+                },
+            )
+
+            store.save_scheduler_state(
+                queued=[_spec_from_node(node)],
+                running=[],
+                status="running",
+            )
+
+            queue = json.loads((workdir / "engine" / "queue.json").read_text())
+            self.assertEqual("001_subprocess_mtp", queue[0]["retry_of"])
+            self.assertEqual(1, queue[0]["retry_attempt"])
+
+    def test_store_rejects_malformed_checkpoint(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            workdir = Path(tmp)
+            self._write_base_files(workdir)
+            engine_dir = workdir / "engine"
+            engine_dir.mkdir()
+            (engine_dir / "checkpoint.json").write_text(
+                json.dumps({"queued": [{"id": "bad", "payload": {}}]}) + "\n"
+            )
+            store = _AutoresearchStore(workdir, _state())
+
+            with self.assertRaisesRegex(ValueError, "payload.node"):
+                store.load_checkpoint()
+
+    def test_failure_record_round_trips_with_node(self) -> None:
+        node = _HypothesisNode(
+            node_id="001_bad_mtp",
+            name="bad_mtp",
+            status="failed",
+            failure=FailureRecord(
+                kind=FailureKind.JOB_STARTUP_FAILED,
+                phase=FailurePhase.JOB,
+                message="MTP failed during initialization",
+                details={"component": "mtp"},
+                job_id="job123",
+                created_at="2026-01-01T00:00:00",
+            ),
+        )
+
+        loaded = _HypothesisNode.from_dict(node.to_dict())
+
+        loaded_failure = loaded.failure
+        self.assertIsNotNone(loaded_failure)
+        assert loaded_failure is not None
+        self.assertEqual(FailureKind.JOB_STARTUP_FAILED, loaded_failure.kind)
+        self.assertEqual({"component": "mtp"}, loaded_failure.details)
+
+    def test_store_persists_failure_view(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            workdir = Path(tmp)
+            self._write_base_files(workdir)
+            store = _AutoresearchStore(workdir, _state())
+            node = _HypothesisNode(
+                node_id="001_failed",
+                name="failed",
+                status="failed",
+                failure=_make_failure(
+                    FailureKind.BUILD_FAILED,
+                    FailurePhase.BUILD,
+                    "Build failed",
+                ),
+            )
+
+            store.upsert_node(node)
+            store.write_all()
+
+            failure = json.loads(
+                (
+                    workdir / "engine" / "nodes" / "001_failed" / "failure.json"
+                ).read_text()
+            )
+            engine_state = json.loads(
+                (workdir / "engine" / "engine_state.json").read_text()
+            )
+            self.assertEqual("build_failed", failure["kind"])
+            self.assertEqual({"build_failed": 1}, engine_state["failed_by_kind"])
+            self.assertIn("build_failed", _failure_summary(workdir))
+            self.assertIn("build_failed", _read_failures(workdir))
+
+    def test_adapter_records_structured_failure(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            workdir = Path(tmp)
+            adapter = self._adapter(workdir)
+            node = _HypothesisNode(node_id="001_failed", name="failed")
+            spec = _spec_from_node(node)
+            failure = _make_failure(
+                FailureKind.LAUNCH_FAILED,
+                FailurePhase.LAUNCH,
+                "No launch command configured",
+            )
+
+            asyncio.run(adapter._record_failure(spec, node, failure))
+
+            stored = json.loads(
+                (
+                    workdir / "engine" / "nodes" / "001_failed" / "failure.json"
+                ).read_text()
+            )
+            master_table = (workdir / "master_table.tsv").read_text()
+            self.assertEqual("launch_failed", stored["kind"])
+            self.assertIn("launch_failed: No launch command configured", master_table)
+
+    def test_completed_failure_history_uses_structured_failure(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            workdir = Path(tmp)
+            self._write_base_files(workdir)
+            state = _state()
+            node = _HypothesisNode(
+                node_id="001_failed",
+                name="failed",
+                status="failed",
+                spec={"name": "failed"},
+            )
+            result = _AnalysisResult(
+                structured={"metrics": {}, "findings": []},
+                failure=_make_failure(
+                    FailureKind.JOB_FAILED,
+                    FailurePhase.JOB,
+                    "Job failed",
+                ),
+            )
+
+            _update_on_complete(workdir, _config(), state, node, result)
+
+            entry = state["history"][0]
+            self.assertNotIn("failure", entry)
+            self.assertEqual("job_failed", entry["structured"]["failure"]["kind"])
+
+    def test_job_failure_classifier_splits_startup_runtime_and_unknown(self) -> None:
+        startup = _classify_terminal_job_failure(
+            _MetricsEvidence(
+                system_metrics="",
+                pipeline_stats_log="TypeError: cannot pickle local function for MTP",
+                metrics_summary="",
+            ),
+            job_id="job_startup",
+            progress_seen=False,
+        )
+        runtime = _classify_terminal_job_failure(
+            _MetricsEvidence(
+                system_metrics="",
+                pipeline_stats_log="[autoresearch] step=12\nCUDA out of memory",
+                metrics_summary="steady_step_time_ms: 12",
+            ),
+            job_id="job_runtime",
+            progress_seen=True,
+        )
+        unknown = _classify_terminal_job_failure(
+            _MetricsEvidence(
+                system_metrics="", pipeline_stats_log="", metrics_summary=""
+            ),
+            job_id="job_unknown",
+            progress_seen=False,
+        )
+
+        self.assertEqual(FailureKind.JOB_STARTUP_FAILED, startup.kind)
+        self.assertEqual(FailureKind.JOB_RUNTIME_FAILED, runtime.kind)
+        self.assertEqual(FailureKind.JOB_FAILED, unknown.kind)
+
+    def test_structured_metrics_evidence_guides_failure_classification(self) -> None:
+        startup = _classify_terminal_job_failure(
+            _MetricsEvidence(
+                system_metrics="",
+                pipeline_stats_log="",
+                metrics_summary="",
+                error_summary="TypeError: can't pickle tokenizer",
+                log_paths=["stderr.log"],
+            ),
+            job_id="job_startup",
+            progress_seen=False,
+        )
+        runtime = _classify_terminal_job_failure(
+            _MetricsEvidence(
+                system_metrics="",
+                pipeline_stats_log="",
+                metrics_summary="",
+                progress_seen=True,
+                exit_code=1,
+            ),
+            job_id="job_runtime",
+            progress_seen=False,
+        )
+
+        self.assertEqual(FailureKind.JOB_STARTUP_FAILED, startup.kind)
+        self.assertEqual(["stderr.log"], startup.details["log_paths"])
+        self.assertEqual(FailureKind.JOB_RUNTIME_FAILED, runtime.kind)
+        self.assertEqual(1, runtime.details["exit_code"])
+
+    def test_startup_failure_retry_is_bounded_for_mtp(self) -> None:
+        node = _HypothesisNode(
+            node_id="001_subprocess_mtp",
+            name="subprocess_mtp",
+            status="failed",
+            spec={
+                "name": "subprocess_mtp",
+                "description": "try MTP",
+                "best_practices_tags": ["subprocess_mtp"],
+            },
+            failure=_make_failure(
+                FailureKind.JOB_STARTUP_FAILED,
+                FailurePhase.JOB,
+                "Tokenizer cannot pickle",
+            ),
+        )
+
+        retry = _startup_retry_spec(node, _config())
+        self.assertIsNotNone(retry)
+        assert retry is not None
+        self.assertEqual("subprocess_mtp_startup_retry_1", retry["name"])
+        self.assertEqual(1, retry["_startup_retry_attempt"])
+        self.assertIn("pickling", retry["hypothesis"])
+
+        node.spec["_startup_retry_attempt"] = 2
+        self.assertIsNone(_startup_retry_spec(node, _config()))
+
+    def test_retry_policy_is_kind_specific(self) -> None:
+        node = _HypothesisNode(
+            node_id="001_subprocess_mtp",
+            name="subprocess_mtp",
+            spec={"best_practices_tags": ["subprocess_mtp"]},
+            failure=_make_failure(
+                FailureKind.JOB_STARTUP_FAILED,
+                FailurePhase.JOB,
+                "startup",
+            ),
+        )
+        policy = _retry_policy_for_failure(node, _config())
+        self.assertIsNotNone(policy)
+        assert policy is not None
+        self.assertEqual(2, policy["max_attempts"])
+
+        node.failure = _make_failure(
+            FailureKind.BUILD_FAILED,
+            FailurePhase.BUILD,
+            "build",
+        )
+        self.assertIsNone(_retry_policy_for_failure(node, _config()))
+
+    def test_planning_prefers_non_startup_failed_retry(self) -> None:
+        baseline = _HypothesisNode(
+            node_id="000_baseline",
+            name="baseline",
+            status="completed",
+        )
+        headspace = _HypothesisNode(
+            node_id="000_headspace",
+            name="headspace_cache",
+            status="completed",
+            spec={"_is_headspace": True},
+        )
+        mtp = _HypothesisNode(
+            node_id="001_subprocess_mtp",
+            name="subprocess_mtp",
+            status="failed",
+            failure=_make_failure(
+                FailureKind.JOB_STARTUP_FAILED,
+                FailurePhase.JOB,
+                "startup",
+            ),
+        )
+        retry = _HypothesisNode(
+            node_id="002_subprocess_mtp_startup_retry_1",
+            name="subprocess_mtp_startup_retry_1",
+            status="failed",
+            spec={"_startup_retry_of": "001_subprocess_mtp"},
+            failure=_make_failure(
+                FailureKind.JOB_STARTUP_FAILED,
+                FailurePhase.JOB,
+                "startup",
+            ),
+        )
+        better_candidate = _HypothesisNode(
+            node_id="003_threads",
+            name="threads",
+            status="completed",
+        )
+
+        selected = _select_planning_node(
+            retry,
+            {
+                node.node_id: node
+                for node in [baseline, headspace, mtp, retry, better_candidate]
+            },
+        )
+
+        self.assertEqual(better_candidate, selected)
+
+    def test_startup_retry_uses_repair_prompt(self) -> None:
+        platform = create_platform({"platform": "local", "agent": "mock"})
+        assert isinstance(platform.agent, _MockAgent)
+        platform.agent.responses["prompt:apply_startup_repair"] = (
+            "failed during job startup __STARTUP_FAILURE_JSON__"
+        )
+        prompt = _build_apply_prompt(
+            platform,
+            {
+                "name": "subprocess_mtp_startup_retry_1",
+                "description": "repair",
+                "hypothesis": "fix startup",
+                "_startup_retry_attempt": 1,
+                "_startup_failure": {"kind": "job_startup_failed"},
+            },
+            "002_subprocess_mtp_startup_retry_1",
+            "knowledge",
+            "/tmp/pipeline.py",
+            "def main():\n    pass\n",
+        )
+
+        self.assertIn("failed during job startup", prompt)
+        self.assertIn("job_startup_failed", prompt)
+
+    def test_tree_edge_label_describes_experiment_evolution(self) -> None:
+        parent = {"node_id": "001_parent", "name": "parent", "spec": {}}
+        child = {
+            "node_id": "002_child",
+            "name": "child",
+            "spec": {
+                "change_summary": "raise decode threads",
+                "description": "increase decode thread count",
+            },
+        }
+        retry = {
+            "node_id": "003_retry",
+            "name": "retry",
+            "spec": {"_startup_retry_attempt": 2, "description": "repair"},
+        }
+
+        self.assertEqual("raise decode threads", _edge_label(parent, child))
+        self.assertEqual("startup repair #2", _edge_label(parent, retry))
+
+    def test_change_summary_is_concise_and_persisted_in_master_table(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            workdir = Path(tmp)
+            (workdir / "master_table.tsv").write_text(
+                "\t".join(MASTER_TABLE_HEADERS) + "\n"
+            )
+
+            summary = _change_summary_for_spec(
+                {
+                    "description": (
+                        "Increase decode thread count while preserving the rest "
+                        "of the pipeline"
+                    )
+                }
+            )
+            _append_master_row(
+                workdir,
+                {
+                    "run_id": "001_threads",
+                    "name": "threads",
+                    "status": "completed",
+                    "change_summary": summary,
+                    "sm_util_pct": "50",
+                },
+            )
+
+            rows = _load_tsv(workdir / "master_table.tsv")
+
+            self.assertEqual("Increase decode thread count while", summary)
+            self.assertEqual(summary, rows[0]["change_summary"])
+
+    def test_tree_font_sizes_grow_with_tree_size(self) -> None:
+        small = _tree_font_sizes(4, 1)
+        large = _tree_font_sizes(120, 10)
+
+        self.assertGreater(large["title"], small["title"])
+        self.assertGreater(large["legend"], small["legend"])
+
+    def test_schema_normalizers_add_versions_and_defaults(self) -> None:
+        config = _normalize_config({})
+        state = _normalize_state({})
+
+        self.assertEqual(SCHEMA_VERSION, config["schema_version"])
+        self.assertEqual(SCHEMA_VERSION, state["schema_version"])
+        self.assertEqual("auto", config["platform"])
+        self.assertEqual([], state["history"])
+
+    def test_every_failure_kind_has_policy(self) -> None:
+        self.assertEqual(set(FailureKind.__members__.values()), set(_FAILURE_POLICIES))
+        self.assertTrue(_FAILURE_POLICIES[FailureKind.JOB_STARTUP_FAILED].retryable)
+
+    def test_error_summary_prefers_traceback_block(self) -> None:
+        summary = _summarize_error(
+            "before\n"
+            "Traceback (most recent call last):\n"
+            '  File "x.py", line 1, in <module>\n'
+            "TypeError: cannot pickle tokenizer\n"
+            "after\n"
+        )
+
+        self.assertIsNotNone(summary)
+        assert summary is not None
+        self.assertIn("Traceback", summary)
+        self.assertIn("cannot pickle", summary)
+
+    def test_atomic_write_replaces_json(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "data.json"
+
+            _write_text_atomic(path, '{"a": 1}\n')
+            _write_text_atomic(path, '{"a": 2}\n')
+
+            self.assertEqual({"a": 2}, json.loads(path.read_text()))
+
+    def _adapter(self, workdir: Path) -> AutoresearchAdapter:
+        self._write_base_files(workdir)
+        return AutoresearchAdapter(
+            workdir=workdir,
+            config=_config(),
+            state=_state(),
+            platform=create_platform({"platform": "auto", "agent": "mock"}, workdir),
+        )
+
+    def _write_base_files(self, workdir: Path) -> None:
+        workdir.mkdir(parents=True, exist_ok=True)
+        (workdir / "config.json").write_text(json.dumps(_config()) + "\n")
+        write_state(workdir, _state())
+        (workdir / "master_table.tsv").write_text(
+            "\t".join(MASTER_TABLE_HEADERS) + "\n"
+        )

--- a/tools/autoresearch/utils/state.py
+++ b/tools/autoresearch/utils/state.py
@@ -11,6 +11,8 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+SCHEMA_VERSION = 2
+
 MASTER_TABLE_HEADERS = [
     "run_id",
     "name",
@@ -24,31 +26,82 @@ MASTER_TABLE_HEADERS = [
     "data_readiness_pct",
     "duration_s",
     "changes",
+    "change_summary",
     "notes",
+]
+
+__all__ = [
+    "MASTER_TABLE_HEADERS",
+    "SCHEMA_VERSION",
+    "_append_master_row",
+    "_normalize_config",
+    "_normalize_state",
+    "_read_master_table",
+    "append_master_row",
+    "read_config",
+    "read_master_table",
+    "read_state",
+    "write_state",
 ]
 
 
 def read_state(workdir: Path) -> dict:
-    return json.loads((workdir / "state.json").read_text())
+    return _normalize_state(json.loads((workdir / "state.json").read_text()))
 
 
 def write_state(workdir: Path, state: dict) -> None:
+    state = _normalize_state(state)
     (workdir / "state.json").write_text(json.dumps(state, indent=2) + "\n")
 
 
 def read_config(workdir: Path) -> dict:
-    return json.loads((workdir / "config.json").read_text())
+    return _normalize_config(json.loads((workdir / "config.json").read_text()))
 
 
-def read_master_table(workdir: Path) -> str:
+def _read_master_table(workdir: Path) -> str:
     return (workdir / "master_table.tsv").read_text()
+
+
+read_master_table = _read_master_table
 
 
 def _escape_tsv(value: str) -> str:
     return value.replace("\\", "\\\\").replace("\n", "\\n").replace("\t", "\\t")
 
 
-def append_master_row(workdir: Path, row: dict) -> None:
+def _append_master_row(workdir: Path, row: dict) -> None:
     with open(workdir / "master_table.tsv", "a") as f:
         values = [_escape_tsv(str(row.get(h, ""))) for h in MASTER_TABLE_HEADERS]
         f.write("\t".join(values) + "\n")
+
+
+append_master_row = _append_master_row
+
+
+def _normalize_config(config: dict) -> dict:
+    normalized = dict(config)
+    normalized.setdefault("schema_version", SCHEMA_VERSION)
+    normalized.setdefault("stopping_criteria", {})
+    normalized["stopping_criteria"].setdefault("max_iterations", 10)
+    normalized["stopping_criteria"].setdefault("patience", 3)
+    normalized.setdefault("platform", "auto")
+    normalized.setdefault("agent", "claude")
+    normalized.setdefault("local_execution_mode", "full")
+    normalized.setdefault("startup_failure_retries", 2)
+    normalized.setdefault("startup_retryable_experiments", ["subprocess_mtp"])
+    return normalized
+
+
+def _normalize_state(state: dict) -> dict:
+    normalized = dict(state)
+    normalized.setdefault("schema_version", SCHEMA_VERSION)
+    normalized.setdefault("iteration", 0)
+    normalized.setdefault("status", "initialized")
+    normalized.setdefault("baseline_job", None)
+    normalized.setdefault("current_best", None)
+    normalized.setdefault("best_metric", None)
+    normalized.setdefault("plateau_count", 0)
+    normalized.setdefault("best_practices_tried", [])
+    normalized.setdefault("anchor_commit", "")
+    normalized.setdefault("history", [])
+    return normalized

--- a/tools/autoresearch/utils/types.py
+++ b/tools/autoresearch/utils/types.py
@@ -1,0 +1,207 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Shared autoresearch domain types."""
+
+from __future__ import annotations
+
+import dataclasses
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import NotRequired, TypedDict
+
+_TERMINAL_STATUSES = frozenset({"completed", "failed"})
+
+__all__ = [
+    "FailureKind",
+    "FailurePhase",
+    "FailureRecord",
+    "_AnalysisResult",
+    "_AutoresearchConfig",
+    "_AutoresearchError",
+    "_AutoresearchState",
+    "_HypothesisNode",
+    "_StoppingCriteriaConfig",
+    "_TERMINAL_STATUSES",
+]
+
+
+class FailureKind(str, Enum):
+    """Stable workflow failure categories.
+
+    These values are part of the autoresearch persistence contract. Future
+    agents should add a new kind when a failure needs different retry,
+    triage, or reporting behavior; do not collapse domain failures back into
+    free-form strings in the runner.
+
+    .. mermaid::
+
+       flowchart LR
+           Status["status = failed"]
+           Record["FailureRecord"]
+           Kind["FailureKind"]
+           Reports["failure.json / history / engine_state"]
+
+           Status --> Record
+           Record --> Kind
+           Record --> Reports
+    """
+
+    CODE_CHANGE_FAILED = "code_change_failed"
+    SOURCE_RESTORE_FAILED = "source_restore_failed"
+    BUILD_FAILED = "build_failed"
+    LAUNCH_FAILED = "launch_failed"
+    JOB_STARTUP_FAILED = "job_startup_failed"
+    JOB_RUNTIME_FAILED = "job_runtime_failed"
+    JOB_FAILED = "job_failed"
+    JOB_STALLED = "job_stalled"
+    METRICS_COLLECTION_FAILED = "metrics_collection_failed"
+    ANALYSIS_FAILED = "analysis_failed"
+    PLANNING_FAILED = "planning_failed"
+    SETUP_INSTRUMENTATION_FAILED = "setup_instrumentation_failed"
+    SETUP_SOURCE_FAILED = "setup_source_failed"
+    UNEXPECTED_EXCEPTION = "unexpected_exception"
+    INTERRUPTED = "interrupted"
+
+
+class FailurePhase(str, Enum):
+    """Workflow phase where a failure was detected."""
+
+    PREPARE = "prepare"
+    SOURCE = "source"
+    CODE_CHANGE = "code_change"
+    BUILD = "build"
+    LAUNCH = "launch"
+    JOB = "job"
+    METRICS = "metrics"
+    ANALYSIS = "analysis"
+    PLANNING = "planning"
+    SETUP = "setup"
+    INSTRUMENTATION = "instrumentation"
+    RUNNER = "runner"
+
+
+@dataclass(frozen=True)
+class FailureRecord:
+    """Machine-readable failure attached to a failed hypothesis node."""
+
+    kind: FailureKind
+    phase: FailurePhase
+    message: str
+    retryable: bool = False
+    details: dict = field(default_factory=dict)
+    exception_type: str | None = None
+    job_id: str | None = None
+    created_at: str | None = None
+
+    def to_dict(self) -> dict:
+        data = dataclasses.asdict(self)
+        data["kind"] = self.kind.value
+        data["phase"] = self.phase.value
+        return data
+
+    @classmethod
+    def from_dict(cls, data: dict) -> FailureRecord:
+        return cls(
+            kind=FailureKind(data["kind"]),
+            phase=FailurePhase(data["phase"]),
+            message=str(data.get("message", "")),
+            retryable=bool(data.get("retryable", False)),
+            details=dict(data.get("details", {})),
+            exception_type=data.get("exception_type"),
+            job_id=data.get("job_id"),
+            created_at=data.get("created_at"),
+        )
+
+
+class _AutoresearchError(RuntimeError):
+    """Expected workflow failure carrying a structured failure record."""
+
+    def __init__(self, failure: FailureRecord) -> None:
+        super().__init__(failure.message)
+        self.failure = failure
+
+
+class _StoppingCriteriaConfig(TypedDict, total=False):
+    max_iterations: int
+    patience: int
+
+
+class _AutoresearchConfig(TypedDict, total=False):
+    schema_version: int
+    pipeline_script: str | None
+    source_dir: str
+    scm: str
+    build_command: str
+    base_launch_command: str
+    notes: str
+    platform: str
+    agent: str
+    local_execution_mode: str
+    stopping_criteria: _StoppingCriteriaConfig
+    max_concurrency: int
+    job_timeout_s: int
+    poll_interval: int
+    startup_failure_retries: int
+    startup_retryable_experiments: list[str]
+    claude_flags: list[str]
+
+
+class _AutoresearchState(TypedDict):
+    schema_version: int
+    iteration: int
+    status: str
+    baseline_job: str | None
+    current_best: str | None
+    best_metric: float | None
+    plateau_count: int
+    best_practices_tried: list[str]
+    anchor_commit: str
+    history: list[dict]
+    cached_image: NotRequired[str]
+
+
+@dataclass
+class _HypothesisNode:
+    """A node in the autoresearch hypothesis tree."""
+
+    node_id: str
+    name: str
+    parent_id: str | None = None
+    commit: str | None = None
+    spec: dict = field(default_factory=dict)
+    status: str = "queued"
+    job_id: str | None = None
+    launched_at: float | None = None
+    result: dict | None = None
+    children: list[str] = field(default_factory=list)
+    priority: float = 0.0
+    duration: float | None = None
+    failure: FailureRecord | None = None
+
+    def to_dict(self) -> dict:
+        data = dataclasses.asdict(self)
+        if self.failure is not None:
+            data["failure"] = self.failure.to_dict()
+        return data
+
+    @classmethod
+    def from_dict(cls, data: dict) -> _HypothesisNode:
+        field_names = {field.name for field in dataclasses.fields(cls)}
+        values = {k: v for k, v in data.items() if k in field_names}
+        if isinstance(values.get("failure"), dict):
+            values["failure"] = FailureRecord.from_dict(values["failure"])
+        return cls(**values)
+
+
+@dataclass
+class _AnalysisResult:
+    """Structured analysis returned after an experiment finishes."""
+
+    structured: dict | None = None
+    duration: float | None = None
+    improved: bool = False
+    failure: FailureRecord | None = None

--- a/tools/autoresearch/utils/workflow/__init__.py
+++ b/tools/autoresearch/utils/workflow/__init__.py
@@ -1,0 +1,15 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Autoresearch workflow layer."""
+
+from .adapter import AutoresearchAdapter
+from .store import _AutoresearchStore
+
+__all__ = [
+    "AutoresearchAdapter",
+    "_AutoresearchStore",
+]

--- a/tools/autoresearch/utils/workflow/adapter.py
+++ b/tools/autoresearch/utils/workflow/adapter.py
@@ -1,0 +1,489 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Autoresearch workflow adapter for the generic async runner.
+
+Design note for future agents
+=============================
+
+This module is the domain side of the runner/adapter boundary. It orchestrates
+experiment coroutines, but durable state lives in ``store.py`` and deterministic
+policy lives in ``policy.py``. Keep SPDL, coding-agent, source-control, metric,
+and hypothesis-planning decisions out of ``runner.py``.
+
+The workflow is the right place to sequence domain operations: restore source,
+apply experiment changes, build, launch, poll, collect metrics, analyze, update
+state, and produce child ``_WorkSpec`` objects. Infrastructure-specific work
+should sit behind ``AutoresearchPlatform`` capability objects. Do not turn the
+runner adapter boundary back into a large flat callback interface.
+
+Workflow failures are structured domain data. Expected failures should carry a
+``FailureRecord`` through ``_AutoresearchError`` or ``_AnalysisResult.failure``;
+the runner should never learn autoresearch failure kinds, and workflow code
+should not record durable failures as bare strings.
+
+.. mermaid::
+
+   flowchart TB
+       Run["run.py"]
+       Runner["AsyncWorkEngine"]
+       Adapter["AutoresearchAdapter"]
+       Store["_AutoresearchStore"]
+       Policy["autoresearch_policy"]
+       Platform["AutoresearchPlatform"]
+       Agent["_CodingAgent"]
+
+       Run --> Runner
+       Run --> Adapter
+       Runner -->|"_WorkSpec coroutine"| Adapter
+       Adapter --> Store
+       Adapter --> Policy
+       Adapter --> Platform
+       Platform --> Agent
+       Adapter -->|"_WorkResult(children)"| Runner
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from collections.abc import Coroutine
+from pathlib import Path
+from typing import Any
+
+from ..platform import AutoresearchPlatform
+from ..runner import _WorkResult, _WorkSpec
+from ..state import _append_master_row
+from ..types import (
+    _AnalysisResult,
+    _AutoresearchError,
+    _HypothesisNode,
+    _TERMINAL_STATUSES,
+    FailureKind,
+    FailurePhase,
+    FailureRecord,
+)
+from .analysis_ops import (
+    _analyze_job,
+    _update_on_complete,
+    _update_summary_and_plot,
+)
+from .failures import _failure_note, _make_failure, _unexpected_failure
+from .planning_ops import _build_initial_nodes, _plan_followups
+from .policy import (
+    _change_summary_for_spec,
+    _is_duplicate_spec,
+    _node_from_spec,
+    _normalize_status,
+    _record_failed_best_practice_attempt,
+    _select_planning_node,
+    _should_cancel_for_stall,
+    _spec_from_node,
+    _startup_retry_spec,
+)
+from .source_ops import _launch_node, _prepare_node
+from .store import _AutoresearchStore
+
+_LG: logging.Logger = logging.getLogger(__name__)
+
+__all__ = ["AutoresearchAdapter"]
+
+
+class AutoresearchAdapter:
+    """Bridge autoresearch domain logic into the simple work scheduler.
+
+    The adapter contract is intentionally small: load specs, checkpoint specs,
+    build a coroutine for a spec, and translate a completed result into child
+    specs. New autoresearch behavior should usually be implemented in this
+    workflow, in the store, in deterministic policy helpers, or behind the
+    platform capability boundary.
+
+    .. mermaid::
+
+       flowchart LR
+           Spec["_WorkSpec"]
+           Node["_HypothesisNode"]
+           Prepare["prepare source/build"]
+           Launch["launch or resume job"]
+           Poll["poll status/progress"]
+           Failure["FailureRecord"]
+           Analyze["collect metrics + analyze"]
+           Store["update store/views"]
+           Children["child WorkSpecs"]
+
+           Spec --> Node
+           Node --> Prepare
+           Prepare --> Launch
+           Launch --> Poll
+           Poll --> Failure
+           Poll --> Analyze
+           Analyze --> Failure
+           Analyze --> Store
+           Analyze --> Children
+    """
+
+    def __init__(
+        self,
+        *,
+        workdir: Path,
+        config: dict,
+        state: dict,
+        platform: AutoresearchPlatform,
+    ) -> None:
+        self.workdir = workdir
+        self.config = config
+        self.state = state
+        self.platform = platform
+        self.poll_interval = int(config.get("poll_interval", 120))
+        self.job_timeout_s = float(config.get("job_timeout_s", 1800))
+
+        self._state_lock = asyncio.Lock()
+        self._store = _AutoresearchStore(workdir, state)
+
+    def load(self) -> list[_WorkSpec]:
+        specs = self._store.load_checkpoint()
+        if specs is not None:
+            _LG.info("Loaded %d work specs from checkpoint", len(specs))
+            return specs
+
+        specs = [_spec_from_node(node) for node in self._initial_nodes()]
+        _LG.info("Created %d initial work specs", len(specs))
+        return specs
+
+    def checkpoint(
+        self,
+        queued: list[_WorkSpec],
+        running: list[_WorkSpec],
+        status: str,
+    ) -> None:
+        self._store.save_scheduler_state(queued, running, status)
+
+    def make_coro(self, spec: _WorkSpec) -> Coroutine[Any, Any, _WorkResult]:
+        return self.run_experiment(spec)
+
+    async def on_result(self, spec: _WorkSpec, result: _WorkResult) -> list[_WorkSpec]:
+        children = []
+        for child in result.children:
+            node = _node_from_spec(child)
+            if _is_duplicate_spec(node.spec, self._store.tree.values()):
+                _LG.info("Skipping duplicate experiment: %s", node.name)
+                continue
+            parent = self._store.tree.get(node.parent_id) if node.parent_id else None
+            if parent is not None:
+                self._store.add_child(parent, child)
+            else:
+                self._store.upsert_node(node)
+                self._store.write_all()
+            children.append(child)
+        return children
+
+    async def run_experiment(self, spec: _WorkSpec) -> _WorkResult:
+        node = _node_from_spec(spec)
+        self._store.upsert_node(node)
+        try:
+            return await self._run_experiment_inner(spec, node)
+        except asyncio.CancelledError:
+            self._store.update_spec(spec, node)
+            raise
+        except _AutoresearchError as error:
+            await self._record_failure(spec, node, error.failure)
+            return _WorkResult()
+        except Exception as error:
+            _LG.exception("Experiment %s failed unexpectedly", node.node_id)
+            await self._record_failure(
+                spec,
+                node,
+                _unexpected_failure(error, job_id=node.job_id),
+            )
+            return _WorkResult()
+
+    async def _run_experiment_inner(
+        self,
+        spec: _WorkSpec,
+        node: _HypothesisNode,
+    ) -> _WorkResult:
+        if node.status == "analyzing" and node.job_id:
+            status = str(spec.payload.get("terminal_status", "completed"))
+            return await self._analyze_record_and_plan(spec, node, status)
+
+        if node.status == "running" and node.job_id:
+            status = await self._poll_until_terminal(spec, node)
+            return await self._analyze_record_and_plan(spec, node, status)
+
+        prepared = await self._prepare(spec, node)
+        if not prepared:
+            await self._record_failure(
+                spec,
+                node,
+                _make_failure(
+                    FailureKind.CODE_CHANGE_FAILED,
+                    FailurePhase.PREPARE,
+                    "Prepare step failed",
+                ),
+            )
+            return _WorkResult()
+
+        node.job_id = await asyncio.to_thread(
+            _launch_node,
+            self.config,
+            self.state,
+            self.platform,
+            node,
+            self.workdir,
+        )
+        if not node.job_id:
+            await self._record_failure(
+                spec,
+                node,
+                _make_failure(
+                    FailureKind.LAUNCH_FAILED,
+                    FailurePhase.LAUNCH,
+                    "Launch step returned no job id",
+                ),
+            )
+            return _WorkResult()
+
+        node.status = "running"
+        node.launched_at = time.monotonic()
+        self._store.update_spec(spec, node)
+
+        status = await self._poll_until_terminal(spec, node)
+        return await self._analyze_record_and_plan(spec, node, status)
+
+    async def _prepare(self, spec: _WorkSpec, node: _HypothesisNode) -> bool:
+        async with self._state_lock:
+            node.status = "preparing"
+            self._store.update_spec(spec, node)
+            parent = self._store.tree.get(node.parent_id) if node.parent_id else None
+            prepared = await asyncio.to_thread(
+                _prepare_node,
+                self.workdir,
+                self.config,
+                self.state,
+                self.platform,
+                node,
+                parent,
+            )
+            self._store.update_spec(spec, node)
+            return prepared
+
+    async def _poll_until_terminal(self, spec: _WorkSpec, node: _HypothesisNode) -> str:
+        if node.launched_at is None:
+            node.launched_at = time.monotonic()
+
+        last_progress: str | None = None
+        stall_start = time.monotonic()
+        ever_progressed = False
+
+        while True:
+            raw_status = await asyncio.to_thread(
+                self.platform.execution.status,
+                node.job_id or "",
+            )
+            status = _normalize_status(raw_status)
+            if status in _TERMINAL_STATUSES:
+                spec.payload["terminal_status"] = status
+                spec.payload["progress_seen"] = ever_progressed
+                self._store.update_spec(spec, node)
+                return status
+
+            if await self._is_stalled(node, stall_start, ever_progressed):
+                spec.payload["terminal_status"] = "failed"
+                spec.payload["progress_seen"] = ever_progressed
+                node.failure = _make_failure(
+                    FailureKind.JOB_STALLED,
+                    FailurePhase.JOB,
+                    "Job stalled and was cancelled",
+                    details={"progress_seen": ever_progressed},
+                    job_id=node.job_id,
+                )
+                self._store.update_spec(spec, node)
+                return "failed"
+
+            progress = await asyncio.to_thread(
+                self.platform.execution.progress,
+                node.job_id or "",
+            )
+            if progress is None:
+                last_progress = None
+                stall_start = time.monotonic()
+            elif progress != last_progress:
+                last_progress = progress
+                stall_start = time.monotonic()
+                ever_progressed = True
+
+            self._store.update_spec(spec, node)
+            await asyncio.sleep(self.poll_interval)
+
+    async def _is_stalled(
+        self,
+        node: _HypothesisNode,
+        stall_start: float,
+        ever_progressed: bool,
+    ) -> bool:
+        now = time.monotonic()
+        if not _should_cancel_for_stall(
+            now=now,
+            launched_at=node.launched_at or now,
+            stall_start=stall_start,
+            ever_progressed=ever_progressed,
+            timeout_s=self.job_timeout_s,
+        ):
+            return False
+        await asyncio.to_thread(self.platform.execution.cancel, node.job_id or "")
+        return True
+
+    async def _analyze_record_and_plan(
+        self,
+        spec: _WorkSpec,
+        node: _HypothesisNode,
+        status: str,
+    ) -> _WorkResult:
+        async with self._state_lock:
+            node.status = "analyzing"
+            self._store.update_spec(spec, node)
+
+            result = await asyncio.to_thread(
+                _analyze_job,
+                self.workdir,
+                self.config,
+                self.state,
+                self.platform,
+                node,
+                status,
+                bool(spec.payload.get("progress_seen", False)),
+            )
+            if not isinstance(result, _AnalysisResult):
+                raise TypeError(f"Expected _AnalysisResult, got {type(result)}")
+
+            node.status = "completed" if status == "completed" else "failed"
+            node.result = result.structured
+            node.duration = result.duration
+            if node.failure is None:
+                node.failure = result.failure
+            self._store.update_spec(spec, node)
+
+            await asyncio.to_thread(
+                _update_on_complete,
+                self.workdir,
+                self.config,
+                self.state,
+                node,
+                result,
+            )
+            await asyncio.to_thread(_update_summary_and_plot, self.workdir, self.state)
+
+            retry_spec = _startup_retry_spec(node, self.config)
+            if retry_spec is not None:
+                self._store.write_all()
+                return _WorkResult(children=[self._create_child_spec(node, retry_spec)])
+
+            planning_node = _select_planning_node(node, self._store.tree)
+            if planning_node is None:
+                return _WorkResult()
+
+            planning_result = result
+            if planning_node.node_id != node.node_id:
+                planning_result = _AnalysisResult(structured=planning_node.result)
+
+            try:
+                followups = await asyncio.to_thread(
+                    _plan_followups,
+                    self.workdir,
+                    self.config,
+                    self.state,
+                    self.platform,
+                    planning_node,
+                    planning_result,
+                    self._store.tree_dict(),
+                )
+            except _AutoresearchError:
+                raise
+            except Exception as error:
+                raise _AutoresearchError(
+                    _make_failure(
+                        FailureKind.PLANNING_FAILED,
+                        FailurePhase.PLANNING,
+                        "Failed to plan follow-up experiments",
+                        exception=error,
+                    )
+                )
+            children = [
+                self._create_child_spec(planning_node, child) for child in followups
+            ]
+            self._store.write_all()
+            return _WorkResult(children=children)
+
+    async def _record_failure(
+        self,
+        spec: _WorkSpec,
+        node: _HypothesisNode,
+        failure: FailureRecord,
+    ) -> None:
+        async with self._state_lock:
+            node.status = "failed"
+            node.failure = failure
+            self._store.update_spec(spec, node)
+            note = _failure_note(failure)
+            _append_master_row(
+                self.workdir,
+                {
+                    "run_id": node.node_id,
+                    "name": node.name,
+                    "job_id": node.job_id or "",
+                    "status": "failed",
+                    "changes": node.spec.get("description", ""),
+                    "change_summary": _change_summary_for_spec(node.spec),
+                    "notes": note,
+                },
+            )
+            self.state.setdefault("history", []).append(
+                {
+                    "iteration": self.state.get("iteration", 0),
+                    "run_id": node.node_id,
+                    "name": node.name,
+                    "job_id": node.job_id or "",
+                    "commit": node.commit or "",
+                    "completed_at": _timestamp(),
+                    "structured": {
+                        "metrics": {},
+                        "findings": [note],
+                        "failure": failure.to_dict(),
+                    },
+                }
+            )
+            _record_failed_best_practice_attempt(self.state, node)
+            self._store.write_all()
+            await asyncio.to_thread(_update_summary_and_plot, self.workdir, self.state)
+
+    def _initial_nodes(self) -> list[_HypothesisNode]:
+        nodes = _build_initial_nodes(self.workdir, self.config, self.state)
+        for node in nodes:
+            self._store.upsert_node(node)
+        self._store.write_all()
+        return nodes
+
+    def _create_child_spec(
+        self, parent: _HypothesisNode, child_spec: dict
+    ) -> _WorkSpec:
+        name = child_spec.get("name", f"exp_{self._store.node_counter}")
+        child_spec["change_summary"] = _change_summary_for_spec(child_spec)
+        node = _HypothesisNode(
+            node_id=f"{self._store.node_counter:03d}_{name}",
+            name=name,
+            parent_id=parent.node_id,
+            commit=parent.commit,
+            spec=child_spec,
+            status="queued",
+            priority=child_spec.get("priority", 0.0),
+        )
+        self._store.node_counter += 1
+        return _spec_from_node(node)
+
+
+def _timestamp() -> str:
+    return time.strftime("%Y-%m-%dT%H:%M:%S")

--- a/tools/autoresearch/utils/workflow/analysis_ops.py
+++ b/tools/autoresearch/utils/workflow/analysis_ops.py
@@ -1,0 +1,325 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Metrics analysis and result recording operations for autoresearch."""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime
+from pathlib import Path
+
+from spdl.tools.autoresearch.plot_progress import (
+    _load_tsv,
+    _plot_hypothesis_tree,
+    _plot_progress,
+)
+
+from ..platform import AutoresearchPlatform
+from ..platform.agents import _parse_agent_result
+from ..state import _append_master_row, _read_master_table, write_state
+from ..types import (
+    _AnalysisResult,
+    _AutoresearchError,
+    _HypothesisNode,
+    FailureKind,
+    FailurePhase,
+)
+from .common import (
+    _compare_value,
+    _current_best_metric,
+    _is_headspace_entry,
+    _read_pipeline_code,
+)
+from .failures import _classify_terminal_job_failure, _failure_note, _make_failure
+from .policy import _change_summary_for_spec
+
+_LG: logging.Logger = logging.getLogger(__name__)
+
+_STRUCTURAL_PRACTICES = {"subprocess_mtp"}
+_STRUCTURAL_ATTEMPT_THRESHOLD = 3
+
+
+def _analyze_job(
+    workdir: Path,
+    config: dict,
+    state: dict,
+    platform: AutoresearchPlatform,
+    node: object,
+    status: str,
+    progress_seen: bool = False,
+) -> object:
+    """Analyze a completed job. Returns _AnalysisResult."""
+    assert isinstance(node, _HypothesisNode)
+
+    knowledge = platform.agent._load_knowledge()
+    pipeline_code = _read_pipeline_code(config, workdir)
+    exp = node.spec
+    run_id = node.node_id
+
+    run_dir = workdir / "runs" / run_id
+    run_dir.mkdir(parents=True, exist_ok=True)
+    metrics_dir = run_dir / "metrics"
+    metrics_dir.mkdir(exist_ok=True)
+
+    job_id = node.job_id or ""
+    print(f"\nCollecting metrics for {node.name} ({job_id})...")
+
+    try:
+        evidence = platform.evidence.collect(job_id, metrics_dir)
+    except Exception as error:
+        raise _AutoresearchError(
+            _make_failure(
+                FailureKind.METRICS_COLLECTION_FAILED,
+                FailurePhase.METRICS,
+                "Failed to collect job metrics",
+                exception=error,
+                job_id=job_id,
+            )
+        ) from error
+    (run_dir / "system_metrics.txt").write_text(evidence.system_metrics)
+    (run_dir / "pipeline_stats_log.txt").write_text(evidence.pipeline_stats_log)
+
+    prompt = platform.agent._load_prompt(
+        "analyze",
+        KNOWLEDGE=knowledge,
+        JOB_ID=job_id,
+        RUN_NAME=node.name,
+        CHANGES=exp.get("description", ""),
+        HYPOTHESIS=exp.get("hypothesis", ""),
+        SYSTEM_METRICS=evidence.system_metrics,
+        PIPELINE_STATS=evidence.metrics_summary,
+        MASTER_TABLE=_read_master_table(workdir),
+        PIPELINE_CODE=pipeline_code or "(not provided)",
+    )
+
+    print(f"Running agent analysis for {node.name}...")
+    try:
+        analysis = platform.agent.run(prompt, workdir, f"analyze_{run_id}")
+    except Exception as error:
+        raise _AutoresearchError(
+            _make_failure(
+                FailureKind.ANALYSIS_FAILED,
+                FailurePhase.ANALYSIS,
+                "Coding-agent analysis failed",
+                exception=error,
+                job_id=job_id,
+            )
+        ) from error
+    (run_dir / "analysis.md").write_text(analysis)
+
+    structured = _parse_agent_result(platform.agent, analysis).json
+    duration = platform.execution.duration(job_id) if job_id else None
+    if duration is None:
+        duration = node.duration
+
+    terminal_failure = (
+        _classify_terminal_job_failure(
+            evidence, job_id=job_id, progress_seen=progress_seen
+        )
+        if status == "failed"
+        else None
+    )
+    _append_master_result_row(
+        workdir, node, status, duration, structured, terminal_failure
+    )
+
+    cur_type, cur_val = _compare_value(
+        structured.get("metrics", {}) if structured else {}
+    )
+    best_type, best_val = _current_best_metric(state)
+    improved = cur_type != "none" and (
+        best_type == "none" or (cur_type == best_type and cur_val < best_val)
+    )
+
+    return _AnalysisResult(
+        structured=structured,
+        duration=float(duration)
+        if isinstance(duration, (int, float)) and duration > 0
+        else None,
+        improved=improved,
+        failure=terminal_failure,
+    )
+
+
+def _append_master_result_row(
+    workdir: Path,
+    node: _HypothesisNode,
+    status: str,
+    duration: object,
+    structured: dict | None,
+    terminal_failure,
+) -> None:
+    row: dict[str, str | float] = {
+        "run_id": node.node_id,
+        "name": node.name,
+        "job_id": node.job_id or "",
+        "status": status,
+        "changes": node.spec.get("description", ""),
+        "change_summary": _change_summary_for_spec(node.spec),
+        "duration_s": duration or "",
+    }
+    if structured and "metrics" in structured:
+        metrics = structured["metrics"]
+        row["step_time_ms"] = metrics.get("step_time_ms", "")
+        row["steady_step_time_ms"] = metrics.get("steady_step_time_ms", "")
+        row["ttfb_s"] = metrics.get("ttfb_s", "")
+        row["sm_util_pct"] = metrics.get("sm_utilization_pct", "")
+        row["steady_sm_util_pct"] = metrics.get("steady_sm_utilization_pct", "")
+        row["data_readiness_pct"] = metrics.get("data_readiness_pct", "")
+        row["notes"] = metrics.get("notes", "")
+    if terminal_failure is not None and not row.get("notes"):
+        row["notes"] = _failure_note(terminal_failure)
+    _append_master_row(workdir, row)
+
+
+def _update_on_complete(
+    workdir: Path,
+    config: dict,
+    state: dict,
+    node: object,
+    result: object,
+) -> None:
+    """Update autoresearch state after a node completes."""
+    assert isinstance(node, _HypothesisNode)
+    assert isinstance(result, _AnalysisResult)
+
+    exp = node.spec
+    best_type, best_val = _current_best_metric(state)
+    structured = result.structured or {}
+    failure = result.failure
+    if failure is not None:
+        structured = dict(structured)
+        structured["failure"] = failure.to_dict()
+
+    state["history"].append(
+        {
+            "iteration": state.get("iteration", 0),
+            "run_id": node.node_id,
+            "name": node.name,
+            "job_id": node.job_id or "",
+            "commit": node.commit or "",
+            "completed_at": datetime.now().isoformat(),
+            "structured": structured,
+        }
+    )
+
+    cur_type, cur_val = _compare_value(
+        result.structured.get("metrics", {}) if result.structured else {}
+    )
+    if (
+        not _is_headspace_entry({"name": node.name})
+        and cur_type != "none"
+        and (best_type == "none" or (cur_type == best_type and cur_val < best_val))
+    ):
+        state["current_best"] = node.node_id
+
+    _record_successful_structural_practices(state, [exp], result.structured)
+    _append_findings(workdir, node.name, result.structured)
+    write_state(workdir, state)
+
+
+def _record_successful_structural_practices(
+    state: dict,
+    experiments: list[dict],
+    result_structured: dict | None,
+) -> None:
+    tried = set(state.get("best_practices_tried", []))
+    attempts: dict[str, int] = state.get("_structural_attempts", {})
+
+    for exp in experiments:
+        structural_tags = [
+            tag
+            for tag in exp.get("best_practices_tags", [])
+            if tag in _STRUCTURAL_PRACTICES
+        ]
+        if not structural_tags:
+            continue
+
+        metrics = (result_structured or {}).get("metrics", {})
+        dur = metrics.get("duration_s")
+        sm = metrics.get("sm_utilization_pct")
+        succeeded = (isinstance(dur, (int, float)) and dur > 0) or (
+            isinstance(sm, (int, float)) and sm > 0
+        )
+        for tag in structural_tags:
+            attempts[tag] = attempts.get(tag, 0) + 1
+            if succeeded or attempts[tag] >= _STRUCTURAL_ATTEMPT_THRESHOLD:
+                tried.add(tag)
+
+    state["_structural_attempts"] = attempts
+    state["best_practices_tried"] = sorted(tried)
+
+
+def _append_findings(workdir: Path, name: str, structured: dict | None) -> None:
+    if not structured:
+        return
+    findings = structured.get("findings", [])
+    if not findings:
+        return
+
+    findings_file = workdir / "findings.md"
+    lines = []
+    if not findings_file.exists():
+        lines.append("# Accumulated Findings\n\n")
+    for fact in findings:
+        lines.append(f"- [{name}] {fact}\n")
+    with open(findings_file, "a") as f:
+        f.writelines(lines)
+
+
+def _update_summary_and_plot(workdir: Path, state: dict) -> None:
+    """Regenerate summary.md, progress.png, and hypothesis_tree.png."""
+    history = state.get("history", [])
+    best = state.get("current_best", "N/A")
+    best_metric = state.get("best_metric")
+    plateau = state.get("plateau_count", 0)
+
+    best_str = f"{best_metric:.0f}ms" if best_metric else "N/A"
+    lines = [
+        "# Autoresearch Progress\n",
+        f"**Total experiments**: {len(history)}",
+        f"**Current best**: {best}",
+        f"**Best steady step time**: {best_str}",
+        f"**Plateau count**: {plateau}\n",
+        "## Recent Results\n",
+    ]
+    for entry in history[-5:]:
+        metrics = (entry.get("structured") or {}).get("metrics", {})
+        step = metrics.get("steady_step_time_ms") or metrics.get("step_time_ms")
+        dur = metrics.get("duration_s")
+        metric_parts = []
+        if step is not None:
+            metric_parts.append(f"step={step}ms")
+        if dur is not None:
+            metric_parts.append(f"dur={dur:.0f}s")
+        name = entry.get("name", entry.get("run_id", "?"))
+        metric_str = ", ".join(metric_parts) if metric_parts else "N/A"
+        lines.append(f"- **{name}**: {metric_str}")
+    (workdir / "summary.md").write_text("\n".join(lines) + "\n")
+
+    try:
+        tsv_path = workdir / "master_table.tsv"
+        if tsv_path.exists():
+            experiments = _load_tsv(tsv_path)
+            if experiments:
+                _plot_progress(experiments, str(workdir / "progress.png"))
+    except Exception as error:
+        _LG.warning("Failed to regenerate progress plot: %s", error)
+
+    try:
+        tree_file = workdir / "engine" / "tree.json"
+        if tree_file.exists():
+            _plot_hypothesis_tree(
+                json.loads(tree_file.read_text()),
+                str(workdir / "hypothesis_tree.png"),
+            )
+    except Exception as error:
+        _LG.warning("Failed to regenerate hypothesis tree plot: %s", error)
+
+
+__all__ = ["_analyze_job", "_update_on_complete", "_update_summary_and_plot"]

--- a/tools/autoresearch/utils/workflow/common.py
+++ b/tools/autoresearch/utils/workflow/common.py
@@ -1,0 +1,60 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Small shared helpers for autoresearch workflow modules."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from .policy import _compare_metric_value
+
+__all__ = [
+    "_compare_value",
+    "_current_best_metric",
+    "_is_headspace_entry",
+    "_read_pipeline_code",
+]
+
+
+def _read_pipeline_code(config: dict, workdir: Path) -> str:
+    pipeline_script = config.get("pipeline_script", "")
+    if pipeline_script and Path(pipeline_script).exists():
+        return Path(pipeline_script).read_text()
+    if (workdir / "pipeline.py").exists():
+        return (workdir / "pipeline.py").read_text()
+    return ""
+
+
+def _compare_value(metrics: dict) -> tuple[str, float]:
+    return _compare_metric_value(metrics)
+
+
+def _is_headspace_entry(entry: dict) -> bool:
+    name = entry.get("name", "")
+    return "headspace" in name or "cache" in name
+
+
+def _current_best_metric(state: dict) -> tuple[str, float]:
+    best_step = float("inf")
+    best_dur = float("inf")
+    for entry in state.get("history", []):
+        if _is_headspace_entry(entry):
+            continue
+        structured = entry.get("structured") or {}
+        metrics = structured.get("metrics", {})
+        step = metrics.get("steady_step_time_ms")
+        if isinstance(step, (int, float)) and step > 0:
+            best_step = min(best_step, float(step))
+        dur = metrics.get("duration_s")
+        if isinstance(dur, (int, float)) and dur > 0:
+            best_dur = min(best_dur, float(dur))
+
+    if best_step < float("inf"):
+        return ("step_ms", best_step)
+    if best_dur < float("inf"):
+        return ("duration_s", best_dur)
+    return ("none", float("inf"))

--- a/tools/autoresearch/utils/workflow/failures.py
+++ b/tools/autoresearch/utils/workflow/failures.py
@@ -1,0 +1,328 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Failure construction and classification for autoresearch workflow code.
+
+The runner intentionally treats coroutine errors generically. Autoresearch
+needs richer semantics because a failed source edit, a failed build, a job that
+dies before training starts, and a job that crashes after producing metrics all
+need different triage. Keep those domain decisions here and persist the
+resulting ``FailureRecord`` on the node.
+
+.. mermaid::
+
+   flowchart LR
+       Operation["workflow operation"]
+       Error["_AutoresearchError"]
+       Adapter["AutoresearchAdapter"]
+       Node["_HypothesisNode.failure"]
+       Store["failure.json / history"]
+
+       Operation -->|"expected failure"| Error
+       Error --> Adapter
+       Adapter --> Node
+       Node --> Store
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import NoReturn
+
+from ..platform import _MetricsEvidence
+from ..types import (
+    _AutoresearchError,
+    FailureKind,
+    FailurePhase,
+    FailureRecord,
+)
+
+__all__ = [
+    "_FAILURE_POLICIES",
+    "_FailurePolicy",
+    "_make_failure",
+    "_classify_terminal_job_failure",
+    "_failure_note",
+    "_raise_failure",
+    "_unexpected_failure",
+]
+
+
+@dataclass(frozen=True)
+class _FailurePolicy:
+    phase: FailurePhase
+    retryable: bool
+    retry_strategy: str
+    action: str
+
+
+_FAILURE_POLICIES = {
+    FailureKind.CODE_CHANGE_FAILED: _FailurePolicy(
+        FailurePhase.CODE_CHANGE,
+        False,
+        "none",
+        "Inspect the coding-agent output and source patch.",
+    ),
+    FailureKind.SOURCE_RESTORE_FAILED: _FailurePolicy(
+        FailurePhase.SOURCE,
+        False,
+        "none",
+        "Inspect source-control state before retrying.",
+    ),
+    FailureKind.BUILD_FAILED: _FailurePolicy(
+        FailurePhase.BUILD,
+        False,
+        "none",
+        "Inspect the build log and generated source patch.",
+    ),
+    FailureKind.LAUNCH_FAILED: _FailurePolicy(
+        FailurePhase.LAUNCH,
+        False,
+        "none",
+        "Inspect the launch command and platform configuration.",
+    ),
+    FailureKind.JOB_STARTUP_FAILED: _FailurePolicy(
+        FailurePhase.JOB,
+        True,
+        "repair_source_then_retry",
+        "Repair initialization, import, or pickling issues before measuring.",
+    ),
+    FailureKind.JOB_RUNTIME_FAILED: _FailurePolicy(
+        FailurePhase.JOB,
+        False,
+        "none",
+        "Inspect runtime logs and metrics from the failed workload.",
+    ),
+    FailureKind.JOB_FAILED: _FailurePolicy(
+        FailurePhase.JOB,
+        False,
+        "none",
+        "Inspect job logs to classify the failure more specifically.",
+    ),
+    FailureKind.JOB_STALLED: _FailurePolicy(
+        FailurePhase.JOB,
+        False,
+        "none",
+        "Inspect progress logs and timeout settings.",
+    ),
+    FailureKind.METRICS_COLLECTION_FAILED: _FailurePolicy(
+        FailurePhase.METRICS,
+        False,
+        "none",
+        "Inspect evidence collection logs and platform metrics availability.",
+    ),
+    FailureKind.ANALYSIS_FAILED: _FailurePolicy(
+        FailurePhase.ANALYSIS,
+        False,
+        "none",
+        "Inspect coding-agent analysis output.",
+    ),
+    FailureKind.PLANNING_FAILED: _FailurePolicy(
+        FailurePhase.PLANNING,
+        False,
+        "none",
+        "Inspect coding-agent planning output.",
+    ),
+    FailureKind.SETUP_INSTRUMENTATION_FAILED: _FailurePolicy(
+        FailurePhase.INSTRUMENTATION,
+        False,
+        "none",
+        "Inspect instrumentation prompt output.",
+    ),
+    FailureKind.SETUP_SOURCE_FAILED: _FailurePolicy(
+        FailurePhase.SETUP,
+        False,
+        "none",
+        "Inspect source-control access and source directory.",
+    ),
+    FailureKind.UNEXPECTED_EXCEPTION: _FailurePolicy(
+        FailurePhase.RUNNER,
+        False,
+        "none",
+        "Inspect the exception and add a structured failure kind if needed.",
+    ),
+    FailureKind.INTERRUPTED: _FailurePolicy(
+        FailurePhase.RUNNER,
+        True,
+        "resume",
+        "Resume from the engine checkpoint.",
+    ),
+}
+
+_STARTUP_PATTERNS = (
+    "can't pickle",
+    "cannot pickle",
+    "pickle",
+    "modulenotfounderror",
+    "importerror",
+    "syntaxerror",
+    "configuration",
+    "config error",
+    "initialization",
+    "initialize",
+    "startup",
+    "mtp",
+)
+
+_RUNTIME_PATTERNS = (
+    "cuda out of memory",
+    "outofmemory",
+    "oom",
+    "dataloader",
+    "data loader",
+    "training step",
+    "iteration",
+    "epoch",
+)
+
+_METRIC_MARKERS = (
+    "step_time",
+    "steady_step_time",
+    "ttfb",
+    "data_readiness",
+    "sm_util",
+    "[autoresearch]",
+)
+
+
+def _make_failure(
+    kind: FailureKind,
+    phase: FailurePhase,
+    message: str,
+    *,
+    retryable: bool = False,
+    details: Mapping[str, object] | None = None,
+    exception: BaseException | None = None,
+    job_id: str | None = None,
+) -> FailureRecord:
+    policy = _FAILURE_POLICIES[kind]
+    return FailureRecord(
+        kind=kind,
+        phase=phase,
+        message=message,
+        retryable=retryable or policy.retryable,
+        details=dict(details or {}),
+        exception_type=type(exception).__name__ if exception is not None else None,
+        job_id=job_id,
+        created_at=_timestamp(),
+    )
+
+
+def _raise_failure(
+    kind: FailureKind,
+    phase: FailurePhase,
+    message: str,
+    *,
+    retryable: bool = False,
+    details: Mapping[str, object] | None = None,
+    exception: BaseException | None = None,
+    job_id: str | None = None,
+) -> NoReturn:
+    raise _AutoresearchError(
+        _make_failure(
+            kind,
+            phase,
+            message,
+            retryable=retryable,
+            details=details,
+            exception=exception,
+            job_id=job_id,
+        )
+    )
+
+
+def _unexpected_failure(
+    error: BaseException, *, job_id: str | None = None
+) -> FailureRecord:
+    return _make_failure(
+        FailureKind.UNEXPECTED_EXCEPTION,
+        FailurePhase.RUNNER,
+        str(error) or type(error).__name__,
+        exception=error,
+        job_id=job_id,
+    )
+
+
+def _failure_note(failure: FailureRecord) -> str:
+    policy = _FAILURE_POLICIES.get(failure.kind)
+    action = f" Action: {policy.action}" if policy is not None else ""
+    return f"{failure.kind.value}: {failure.message}{action}"
+
+
+def _classify_terminal_job_failure(
+    evidence: _MetricsEvidence,
+    *,
+    job_id: str,
+    progress_seen: bool,
+) -> FailureRecord:
+    """Classify a terminal failed job from logs and metric evidence.
+
+    Platform status only says that a job failed. The workflow owns this
+    classifier because it can combine evidence with SPDL conventions:
+    no metrics plus pickle/import/init errors means startup; metrics or
+    progress before the crash means runtime; otherwise keep the conservative
+    ``JOB_FAILED`` fallback.
+    """
+
+    text = "\n".join(
+        (
+            evidence.system_metrics,
+            evidence.pipeline_stats_log,
+            evidence.metrics_summary,
+            evidence.error_summary or "",
+        )
+    ).lower()
+    has_metrics = _has_metric_evidence(text)
+    progress_observed = progress_seen or bool(evidence.progress_seen)
+    details = {
+        "progress_seen": progress_observed,
+        "has_metric_evidence": has_metrics,
+        "exit_code": evidence.exit_code,
+        "error_summary": evidence.error_summary,
+        "log_paths": evidence.log_paths,
+    }
+
+    if not has_metrics and any(pattern in text for pattern in _STARTUP_PATTERNS):
+        return _make_failure(
+            FailureKind.JOB_STARTUP_FAILED,
+            FailurePhase.JOB,
+            "Job failed during startup before measured workload began",
+            details=details,
+            job_id=job_id,
+        )
+
+    if (
+        progress_observed
+        or has_metrics
+        or any(pattern in text for pattern in _RUNTIME_PATTERNS)
+    ):
+        return _make_failure(
+            FailureKind.JOB_RUNTIME_FAILED,
+            FailurePhase.JOB,
+            "Job failed after the workload started",
+            details=details,
+            job_id=job_id,
+        )
+
+    return _make_failure(
+        FailureKind.JOB_FAILED,
+        FailurePhase.JOB,
+        "Job reached terminal failed status",
+        details=details,
+        job_id=job_id,
+    )
+
+
+def _has_metric_evidence(text: str) -> bool:
+    if "unavailable" in text and not any(marker in text for marker in _METRIC_MARKERS):
+        return False
+    return any(marker in text for marker in _METRIC_MARKERS)
+
+
+def _timestamp() -> str:
+    return time.strftime("%Y-%m-%dT%H:%M:%S")

--- a/tools/autoresearch/utils/workflow/operations.py
+++ b/tools/autoresearch/utils/workflow/operations.py
@@ -1,0 +1,31 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Compatibility imports for autoresearch workflow operations.
+
+Implementation lives in cohesive modules:
+``source_ops`` for source/build/launch, ``analysis_ops`` for metrics and
+result recording, and ``planning_ops`` for initial/follow-up experiment
+planning. Keep new code in those modules so future agents do not recreate a
+large flat operations file.
+"""
+
+from __future__ import annotations
+
+from .analysis_ops import _analyze_job, _update_on_complete, _update_summary_and_plot
+from .planning_ops import _build_initial_nodes, _plan_followups, _should_stop
+from .source_ops import _launch_node, _prepare_node
+
+__all__ = [
+    "_analyze_job",
+    "_build_initial_nodes",
+    "_plan_followups",
+    "_launch_node",
+    "_prepare_node",
+    "_should_stop",
+    "_update_on_complete",
+    "_update_summary_and_plot",
+]

--- a/tools/autoresearch/utils/workflow/planning_ops.py
+++ b/tools/autoresearch/utils/workflow/planning_ops.py
@@ -1,0 +1,361 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Initial experiment and follow-up planning operations for autoresearch."""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from pathlib import Path
+
+from ..platform import AutoresearchPlatform
+from ..platform.agents import _parse_agent_result
+from ..state import _read_master_table, write_state
+from ..types import _AnalysisResult, _HypothesisNode
+from .common import _current_best_metric, _read_pipeline_code
+from .policy import (
+    _change_summary_for_spec,
+    _extract_total_threads,
+    _validate_thread_budget as _policy_validate_thread_budget,
+)
+
+_LG: logging.Logger = logging.getLogger(__name__)
+
+_BEST_PRACTICES = [
+    "subprocess_mtp",
+    "batch_size_tuning",
+    "concurrency_tuning",
+]
+_STRUCTURAL_PRACTICES = {"subprocess_mtp"}
+_MAX_THREADS_PER_RANK_DEFAULT = 16
+_MAX_THREADS_PER_RANK_EXTENDED = 32
+_HISTORY_JSON_MAX_CHARS = 12000
+
+
+def _truncate_history_json(history: list[dict]) -> str:
+    for start in range(len(history)):
+        text = json.dumps(history[start:], indent=2)
+        if len(text) <= _HISTORY_JSON_MAX_CHARS:
+            if start > 0:
+                return f"[... {start} earlier entries omitted ...]\n{text}"
+            return text
+    return "[]"
+
+
+def _untried_best_practices(state: dict) -> list[str]:
+    tried = set(state.get("best_practices_tried", []))
+    return [bp for bp in _BEST_PRACTICES if bp not in tried]
+
+
+def _thread_cap_for_experiment(state: dict, config: dict) -> int:
+    base_cmd = config.get("base_launch_command", "")
+    match = re.search(r"-j\s+\d+x(\d+)", base_cmd)
+    num_gpus = int(match.group(1)) if match else 8
+    if num_gpus <= 1:
+        return _MAX_THREADS_PER_RANK_EXTENDED
+
+    results_at_cap = []
+    results_below_cap = []
+    for entry in state.get("history", []):
+        metrics = (entry.get("structured") or {}).get("metrics", {})
+        step = metrics.get("steady_step_time_ms")
+        if not isinstance(step, (int, float)) or step <= 0:
+            continue
+        run_id = entry.get("run_id", "")
+        name = entry.get("name", "")
+        if run_id.startswith("000") or "headspace" in name or "cache" in name:
+            continue
+
+        spec = (entry.get("structured") or {}).get("experiment", {})
+        command = spec.get("launch_command", "") or config.get(
+            "base_launch_command", ""
+        )
+        total = _extract_total_threads(command)
+        if total is None:
+            continue
+        if total >= _MAX_THREADS_PER_RANK_DEFAULT:
+            results_at_cap.append(step)
+        else:
+            results_below_cap.append(step)
+
+    if not results_at_cap:
+        return _MAX_THREADS_PER_RANK_DEFAULT
+    best_at_cap = min(results_at_cap)
+    if results_below_cap and best_at_cap < min(results_below_cap):
+        return _MAX_THREADS_PER_RANK_EXTENDED
+    return _MAX_THREADS_PER_RANK_DEFAULT
+
+
+def _validate_thread_budget(experiments: list[dict], cap: int) -> list[dict]:
+    valid = _policy_validate_thread_budget(experiments, cap)
+    valid_ids = {id(exp) for exp in valid}
+    for exp in experiments:
+        if id(exp) not in valid_ids:
+            total = _extract_total_threads(exp.get("launch_command", ""))
+            _LG.warning(
+                "Rejecting %s: %d threads exceeds cap of %d",
+                exp.get("name", "?"),
+                total or 0,
+                cap,
+            )
+    return valid
+
+
+def _record_best_practices(state: dict, plan: dict) -> None:
+    tried = set(state.get("best_practices_tried", []))
+    for exp in plan.get("experiments", []):
+        for tag in exp.get("best_practices_tags", []):
+            if tag not in _STRUCTURAL_PRACTICES:
+                tried.add(tag)
+    state["best_practices_tried"] = sorted(tried)
+
+
+def _get_plan(
+    workdir: Path,
+    config: dict,
+    state: dict,
+    platform: AutoresearchPlatform,
+    knowledge: str,
+    pipeline_code: str,
+    iteration: int,
+) -> dict | None:
+    max_iter = config["stopping_criteria"]["max_iterations"]
+    patience = config["stopping_criteria"].get("patience", 3)
+    untried = _untried_best_practices(state)
+    plateau_count = state.get("plateau_count", 0)
+
+    last_analysis = ""
+    if state["history"]:
+        last = state["history"][-1]
+        for directory in [
+            workdir / "runs" / last["run_id"],
+            workdir / "runs" / f"{last['run_id']}_{last['name']}",
+            workdir / "runs" / "000_baseline",
+        ]:
+            analysis_file = directory / "analysis.md"
+            if analysis_file.exists():
+                last_analysis = analysis_file.read_text()
+                break
+
+    findings_file = workdir / "findings.md"
+    findings = findings_file.read_text() if findings_file.exists() else "(none yet)"
+    cap = _thread_cap_for_experiment(state, config)
+    notes = config.get("notes", "") + (
+        f"\n\n**CPU THREAD BUDGET (HARD LIMIT):** Total threads per rank "
+        f"(num_fetch_threads + num_decode_threads) must not exceed {cap}. "
+        f"Experiments exceeding this will be rejected automatically."
+    )
+
+    prompt = platform.agent._load_prompt(
+        "plan_next",
+        KNOWLEDGE=knowledge,
+        MASTER_TABLE=_read_master_table(workdir),
+        LAST_ANALYSIS=last_analysis[:8000],
+        PIPELINE_CODE=pipeline_code or "(not provided)",
+        ITERATION=str(iteration),
+        MAX_ITERATIONS=str(max_iter),
+        PATIENCE=str(patience),
+        PLATEAU_COUNT=str(plateau_count),
+        BEST_METRIC=str(state.get("best_metric") or "N/A"),
+        BEST_PRACTICES_TRIED=", ".join(state.get("best_practices_tried", [])) or "none",
+        BEST_PRACTICES_REMAINING=", ".join(untried) or "none",
+        BASE_LAUNCH_COMMAND=config.get("base_launch_command", ""),
+        BUILD_COMMAND=config.get("build_command", ""),
+        CACHED_IMAGE="(always rebuilt)",
+        HISTORY_JSON=_truncate_history_json(state["history"]),
+        FINDINGS=findings[:4000],
+        NOTES=notes,
+    )
+
+    print("Asking coding agent to plan next experiments...")
+    plan_output = platform.agent.run(prompt, workdir, f"plan_{iteration:03d}")
+    result = _parse_agent_result(platform.agent, plan_output)
+    plan = result.json
+    if not plan:
+        print("Could not parse plan from agent output.")
+        print(plan_output[:2000])
+        return None
+    if plan.get("action") != "stop":
+        return plan
+
+    can_stop = plateau_count >= patience and not untried
+    if can_stop:
+        return plan
+
+    overrides_attempted = state.get("_stop_overrides", 0)
+    if overrides_attempted >= 2:
+        _LG.warning(
+            "Coding agent insisted on stopping %d times at iteration %d; respecting it",
+            overrides_attempted + 1,
+            iteration,
+        )
+        return plan
+
+    reasons = []
+    if untried:
+        reasons.append(f"best practices not yet tried: {', '.join(untried)}")
+    if plateau_count < patience:
+        reasons.append(f"plateau count {plateau_count}/{patience} not reached")
+    _LG.info(
+        "Coding agent suggested stop at iteration %d, overriding: %s",
+        iteration,
+        "; ".join(reasons),
+    )
+    print(f"Coding agent suggested stopping, but: {'; '.join(reasons)}")
+    print("Re-planning with instruction to continue...")
+    state["_stop_overrides"] = overrides_attempted + 1
+
+    override = "\n\n**OVERRIDE: You MUST propose experiments. Do NOT stop.**\n"
+    if untried:
+        override += (
+            "The following best practices have NOT been tried yet: "
+            f"{', '.join(untried)}. Prioritize these.\n"
+        )
+    if plateau_count < patience:
+        override += (
+            f"Only {plateau_count} consecutive non-improving iterations "
+            f"(need {patience} to stop). Keep exploring.\n"
+        )
+    plan_output = platform.agent.run(
+        prompt + override, workdir, f"plan_{iteration:03d}_retry"
+    )
+    return _parse_agent_result(platform.agent, plan_output).json
+
+
+def _plan_followups(
+    workdir: Path,
+    config: dict,
+    state: dict,
+    platform: AutoresearchPlatform,
+    parent_node: object,
+    result: object,
+    tree: dict,
+) -> list[dict]:
+    """Plan follow-up experiments. Returns experiment spec dicts."""
+    assert isinstance(parent_node, _HypothesisNode)
+    assert isinstance(result, _AnalysisResult)
+
+    if parent_node.spec.get("_is_headspace"):
+        return []
+
+    knowledge = platform.agent._load_knowledge()
+    pipeline_code = _read_pipeline_code(config, workdir)
+    iteration = state.get("iteration", 0) + 1
+
+    _, cur_best = _current_best_metric(state)
+    prev_best_at_last_plan = state.get("_best_at_last_plan", float("inf"))
+    if cur_best < prev_best_at_last_plan:
+        state["plateau_count"] = 0
+        state["best_metric"] = cur_best
+    else:
+        state["plateau_count"] = state.get("plateau_count", 0) + 1
+    state["_best_at_last_plan"] = cur_best
+
+    plan = _get_plan(
+        workdir, config, state, platform, knowledge, pipeline_code, iteration
+    )
+    if not plan or plan.get("action") in ("stop", "manual"):
+        return []
+
+    experiments = _validate_thread_budget(
+        plan.get("experiments", []),
+        _thread_cap_for_experiment(state, config),
+    )
+    for experiment in experiments:
+        experiment["change_summary"] = _change_summary_for_spec(experiment)
+    _record_best_practices(state, {"experiments": experiments})
+    state["_stop_overrides"] = 0
+    state["iteration"] = iteration
+    write_state(workdir, state)
+    return experiments
+
+
+def _should_stop(config: dict, state: dict, tree: dict) -> bool:
+    max_iter = config["stopping_criteria"]["max_iterations"]
+    patience = config["stopping_criteria"].get("patience", 3)
+    return state.get("iteration", 0) >= max_iter or (
+        state.get("plateau_count", 0) >= patience and not _untried_best_practices(state)
+    )
+
+
+def _build_initial_nodes(workdir: Path, config: dict, state: dict) -> list:
+    """Create initial _HypothesisNode objects for baseline, headspace, and MTP."""
+    nodes: list[_HypothesisNode] = []
+    history_names = {entry.get("name") for entry in state.get("history", [])}
+    tried_practices = set(state.get("best_practices_tried", []))
+    base_launch = config.get("base_launch_command", "")
+
+    if "baseline" not in history_names:
+        nodes.append(
+            _HypothesisNode(
+                node_id="000_baseline",
+                name="baseline",
+                spec={
+                    "name": "baseline",
+                    "description": "Run the unchanged pipeline to establish baseline metrics",
+                    "change_summary": "baseline",
+                    "hypothesis": "Baseline measurement",
+                    "launch_command": base_launch,
+                    "best_practices_tags": [],
+                },
+                priority=-1000,
+            )
+        )
+
+    headspace_succeeded = any(
+        entry.get("name") == "headspace_cache"
+        and (entry.get("structured") or {})
+        .get("metrics", {})
+        .get("steady_step_time_ms")
+        for entry in state.get("history", [])
+    )
+    if not headspace_succeeded:
+        nodes.append(
+            _HypothesisNode(
+                node_id="000_headspace",
+                name="headspace_cache",
+                spec={
+                    "name": "headspace_cache",
+                    "description": "Wrap with CacheDataLoader for headspace analysis",
+                    "change_summary": "headspace",
+                    "hypothesis": (
+                        "Measures upper bound of improvement "
+                        "from data loading optimization"
+                    ),
+                    "launch_command": base_launch,
+                    "best_practices_tags": [],
+                    "_is_headspace": True,
+                },
+                priority=-999,
+            )
+        )
+
+    if "subprocess_mtp" not in tried_practices:
+        nodes.append(
+            _HypothesisNode(
+                node_id="001_subprocess_mtp",
+                name="subprocess_mtp",
+                spec={
+                    "name": "subprocess_mtp",
+                    "description": "Run pipeline in subprocess to avoid GIL contention",
+                    "change_summary": "subprocess MTP",
+                    "hypothesis": (
+                        "Subprocess isolation eliminates "
+                        "GIL contention and improves throughput"
+                    ),
+                    "launch_command": base_launch,
+                    "best_practices_tags": ["subprocess_mtp"],
+                },
+                priority=-998,
+            )
+        )
+
+    return nodes
+
+
+__all__ = ["_build_initial_nodes", "_plan_followups", "_should_stop"]

--- a/tools/autoresearch/utils/workflow/policy.py
+++ b/tools/autoresearch/utils/workflow/policy.py
@@ -1,0 +1,365 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Deterministic autoresearch workflow policies.
+
+This module intentionally contains no coding-agent calls, subprocess execution,
+or filesystem writes. Keep predictable decisions here so they can be unit tested
+without infrastructure.
+
+Design note for future agents
+=============================
+
+If a behavior is deterministic and can be expressed from specs, nodes, state,
+or metrics already in memory, prefer adding it here instead of burying it in
+workflow orchestration or agent prompts. This keeps the workflow simple and
+makes core autoresearch behavior testable without source control, subprocesses,
+or LLM calls.
+
+.. mermaid::
+
+   flowchart LR
+       Inputs["_WorkSpec / _HypothesisNode / state"]
+       Policy["pure policy helpers"]
+       Decisions["workflow decisions"]
+       Tests["unit tests"]
+
+       Inputs --> Policy
+       Policy -->|"planning gate"| Decisions
+       Policy -->|"duplicate filter"| Decisions
+       Policy -->|"stall policy"| Decisions
+       Policy -->|"spec/node conversion"| Decisions
+       Tests --> Policy
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable, Mapping
+
+from ..runner import _WorkSpec
+from ..types import _HypothesisNode, _TERMINAL_STATUSES, FailureKind
+
+__all__ = [
+    "_change_summary_for_spec",
+    "_compare_metric_value",
+    "_extract_counter",
+    "_extract_total_threads",
+    "_initial_experiments_finished",
+    "_is_duplicate_spec",
+    "_is_headspace_node",
+    "_is_startup_failed_retry",
+    "_node_from_spec",
+    "_normalize_status",
+    "_record_failed_best_practice_attempt",
+    "_retry_policy_for_failure",
+    "_select_planning_node",
+    "_should_cancel_for_stall",
+    "_spec_from_node",
+    "_startup_retry_spec",
+    "_update_spec_from_node",
+    "_validate_thread_budget",
+]
+
+_KIND_EXPERIMENT = "experiment"
+_REQUIRED_INITIAL_EXPERIMENTS = frozenset(
+    {"baseline", "headspace_cache", "subprocess_mtp"}
+)
+_STRUCTURAL_ATTEMPT_THRESHOLD = 3
+_MAX_THREADS_PER_RANK_DEFAULT = 16
+_MAX_THREADS_PER_RANK_EXTENDED = 32
+_STARTUP_FAILURE_RETRIES_DEFAULT = 2
+_STARTUP_RETRYABLE_EXPERIMENTS_DEFAULT = ("subprocess_mtp",)
+_NON_RETRYABLE_FAILURES = frozenset(
+    {
+        FailureKind.JOB_RUNTIME_FAILED,
+        FailureKind.JOB_FAILED,
+        FailureKind.BUILD_FAILED,
+        FailureKind.LAUNCH_FAILED,
+    }
+)
+_SUMMARY_LIMIT = 34
+
+
+def _normalize_status(status: str) -> str:
+    if status in ("SUCCEEDED", "COMPLETE", "completed"):
+        return "completed"
+    if status in ("FAILED", "failed"):
+        return "failed"
+    return "running"
+
+
+def _is_headspace_node(node: _HypothesisNode) -> bool:
+    return bool(node.spec.get("_is_headspace")) or "headspace" in node.name
+
+
+def _initial_experiments_finished(
+    tree: Mapping[str, _HypothesisNode],
+    required_names: frozenset[str] = _REQUIRED_INITIAL_EXPERIMENTS,
+) -> bool:
+    by_name = {node.name: node for node in tree.values()}
+    return all(
+        (node := by_name.get(name)) is not None and node.status in _TERMINAL_STATUSES
+        for name in required_names
+    )
+
+
+def _select_planning_node(
+    completed_node: _HypothesisNode,
+    tree: Mapping[str, _HypothesisNode],
+) -> _HypothesisNode | None:
+    """Pick the non-headspace completed node that should trigger planning."""
+    if not _initial_experiments_finished(tree):
+        return None
+    if not _is_headspace_node(completed_node):
+        if not _is_startup_failed_retry(completed_node):
+            return completed_node
+
+    candidates = [
+        node
+        for node in tree.values()
+        if node.status in _TERMINAL_STATUSES and not _is_headspace_node(node)
+    ]
+    if not candidates:
+        return None
+    preferred = [node for node in candidates if not _is_startup_failed_retry(node)]
+    return max(preferred or candidates, key=lambda node: _extract_counter(node.node_id))
+
+
+def _is_duplicate_spec(spec: dict, nodes: Iterable[_HypothesisNode]) -> bool:
+    name = spec.get("name", "")
+    launch_cmd = spec.get("launch_command", "")
+    for node in nodes:
+        if node.status == "failed":
+            continue
+        if name and node.name == name:
+            return True
+        existing = node.spec
+        if launch_cmd and existing.get("launch_command") == launch_cmd:
+            return True
+    return False
+
+
+def _should_cancel_for_stall(
+    *,
+    now: float,
+    launched_at: float,
+    stall_start: float,
+    ever_progressed: bool,
+    timeout_s: float,
+) -> bool:
+    elapsed = now - launched_at
+    stall_duration = now - stall_start
+    if not ever_progressed:
+        return elapsed > timeout_s * 3
+    return stall_duration > timeout_s
+
+
+def _compare_metric_value(metrics: Mapping[str, object]) -> tuple[str, float]:
+    step = metrics.get("steady_step_time_ms")
+    if isinstance(step, (int, float)) and step > 0:
+        return ("step_ms", float(step))
+    duration = metrics.get("duration_s")
+    if isinstance(duration, (int, float)) and duration > 0:
+        return ("duration_s", float(duration))
+    return ("none", float("inf"))
+
+
+def _extract_total_threads(launch_cmd: str) -> int | None:
+    fetch = 8
+    decode = 16
+    match = re.search(r"--num[_-]fetch[_-]threads?\s+(\d+)", launch_cmd)
+    if match:
+        fetch = int(match.group(1))
+    match = re.search(r"--num[_-]decode[_-]threads?\s+(\d+)", launch_cmd)
+    if match:
+        decode = int(match.group(1))
+    match = re.search(r"--num[_-]threads?\s+(\d+)", launch_cmd)
+    if match:
+        return int(match.group(1))
+    return fetch + decode
+
+
+def _validate_thread_budget(experiments: list[dict], cap: int) -> list[dict]:
+    valid = []
+    for experiment in experiments:
+        command = experiment.get("launch_command", "")
+        total = _extract_total_threads(command) if command else None
+        if total is not None and total > cap:
+            continue
+        valid.append(experiment)
+    return valid
+
+
+def _change_summary_for_spec(spec: dict) -> str:
+    """Return a concise, stable label for plots and tables."""
+    explicit = str(spec.get("change_summary", "")).strip()
+    if explicit:
+        return _short_change_label(explicit)
+
+    retry_attempt = spec.get("_startup_retry_attempt")
+    if retry_attempt:
+        return f"startup repair {retry_attempt}"
+
+    tags = spec.get("best_practices_tags", [])
+    if isinstance(tags, list) and tags:
+        return _short_change_label(str(tags[0]).replace("_", " "))
+
+    command = str(spec.get("launch_command", ""))
+    flag = _first_interesting_flag(command)
+    if flag:
+        return _short_change_label(flag)
+
+    description = str(spec.get("description", "")).strip()
+    if description:
+        return _short_change_label(description)
+
+    return _short_change_label(str(spec.get("name", "experiment")))
+
+
+def _short_change_label(text: str) -> str:
+    words = [word.strip(".,;:()[]{}") for word in text.replace("_", " ").split()]
+    words = [word for word in words if word]
+    if not words:
+        return "experiment"
+    label = " ".join(words[:5])
+    if len(label) <= _SUMMARY_LIMIT:
+        return label
+    return label[: _SUMMARY_LIMIT - 3].rstrip() + "..."
+
+
+def _first_interesting_flag(command: str) -> str | None:
+    tokens = command.split()
+    for index, token in enumerate(tokens):
+        if not token.startswith("--"):
+            continue
+        name = token.lstrip("-").replace("_", " ").replace("-", " ")
+        if index + 1 < len(tokens) and not tokens[index + 1].startswith("-"):
+            return f"{name} {tokens[index + 1]}"
+        return name
+    return None
+
+
+def _record_failed_best_practice_attempt(state: dict, node: _HypothesisNode) -> None:
+    tags = node.spec.get("best_practices_tags", [])
+    if not tags:
+        return
+    tried = set(state.get("best_practices_tried", []))
+    attempts: dict[str, int] = state.get("_structural_attempts", {})
+    for tag in tags:
+        if tag == "subprocess_mtp":
+            attempts[tag] = attempts.get(tag, 0) + 1
+            if attempts[tag] >= _STRUCTURAL_ATTEMPT_THRESHOLD:
+                tried.add(tag)
+        else:
+            tried.add(tag)
+    state["_structural_attempts"] = attempts
+    state["best_practices_tried"] = sorted(tried)
+
+
+def _retry_policy_for_failure(node: _HypothesisNode, config: dict) -> dict | None:
+    failure = node.failure
+    if failure is None:
+        return None
+    if failure.kind in _NON_RETRYABLE_FAILURES:
+        return None
+    if failure.kind != FailureKind.JOB_STARTUP_FAILED:
+        return None
+
+    retryable = set(
+        config.get(
+            "startup_retryable_experiments",
+            list(_STARTUP_RETRYABLE_EXPERIMENTS_DEFAULT),
+        )
+    )
+    tags = set(node.spec.get("best_practices_tags", []))
+    if node.name not in retryable and not tags.intersection(retryable):
+        return None
+
+    return {
+        "max_attempts": int(
+            config.get("startup_failure_retries", _STARTUP_FAILURE_RETRIES_DEFAULT)
+        ),
+        "reason": "startup_failure",
+    }
+
+
+def _is_startup_failed_retry(node: _HypothesisNode) -> bool:
+    failure = node.failure
+    return bool(
+        node.spec.get("_startup_retry_of")
+        and failure is not None
+        and failure.kind == FailureKind.JOB_STARTUP_FAILED
+    )
+
+
+def _startup_retry_spec(node: _HypothesisNode, config: dict) -> dict | None:
+    """Return a repair experiment for retryable startup failures.
+
+    Failed must-run experiments still count as terminal once attempts are
+    exhausted. Startup failures are special because they often indicate
+    pickling/import/init problems that the code-changing path can repair.
+    """
+
+    failure = node.failure
+    policy = _retry_policy_for_failure(node, config)
+    if failure is None or policy is None:
+        return None
+
+    limit = int(policy["max_attempts"])
+    attempt = int(node.spec.get("_startup_retry_attempt", 0))
+    if attempt >= limit:
+        return None
+
+    next_attempt = attempt + 1
+    retry = dict(node.spec)
+    retry["name"] = f"{node.name}_startup_retry_{next_attempt}"
+    retry["_startup_retry_attempt"] = next_attempt
+    retry["_startup_retry_of"] = node.spec.get("_startup_retry_of", node.node_id)
+    retry["_startup_failure"] = failure.to_dict()
+    retry["description"] = (
+        f"Repair startup failure from {node.name}: {failure.message}. "
+        f"{node.spec.get('description', '')}"
+    ).strip()
+    retry["change_summary"] = f"startup repair {next_attempt}"
+    retry["hypothesis"] = (
+        "Make the experiment initialize successfully before measuring "
+        "performance. Focus on pickling/import/configuration/startup issues. "
+        f"Previous failure: {failure.message}"
+    )
+    retry["priority"] = float(node.priority) - 0.01
+    return retry
+
+
+def _spec_from_node(node: _HypothesisNode) -> _WorkSpec:
+    node.spec["change_summary"] = _change_summary_for_spec(node.spec)
+    return _WorkSpec(
+        id=node.node_id,
+        priority=node.priority,
+        kind=_KIND_EXPERIMENT,
+        payload={"node": node.to_dict()},
+    )
+
+
+def _node_from_spec(spec: _WorkSpec) -> _HypothesisNode:
+    node_data = spec.payload.get("node", {})
+    if not isinstance(node_data, dict):
+        raise ValueError(f"Work spec {spec.id} has no node payload")
+    return _HypothesisNode.from_dict(node_data)
+
+
+def _update_spec_from_node(spec: _WorkSpec, node: _HypothesisNode) -> None:
+    spec.id = node.node_id
+    spec.priority = node.priority
+    spec.kind = _KIND_EXPERIMENT
+    spec.payload["node"] = node.to_dict()
+
+
+def _extract_counter(node_id: str) -> int:
+    try:
+        return int(node_id.split("_", 1)[0])
+    except (IndexError, ValueError):
+        return 0

--- a/tools/autoresearch/utils/workflow/source_ops.py
+++ b/tools/autoresearch/utils/workflow/source_ops.py
@@ -1,0 +1,304 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Source mutation, build, and launch operations for workflow experiments."""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from pathlib import Path
+
+from ..platform import AutoresearchPlatform
+from ..types import _AutoresearchError, _HypothesisNode, FailureKind, FailurePhase
+from .common import _read_pipeline_code
+from .failures import _make_failure, _raise_failure
+
+_LG: logging.Logger = logging.getLogger(__name__)
+
+
+def _extract_code_block(text: str) -> str | None:
+    for pattern in [
+        r"```python\s*\n(.*?)\n```",
+        r"```\s*\n(.*?)\n```",
+    ]:
+        matches = list(re.finditer(pattern, text, re.DOTALL))
+        if matches:
+            candidate = matches[-1].group(1)
+            if "import " in candidate or "def " in candidate or "class " in candidate:
+                return candidate
+    return None
+
+
+def _build_apply_prompt(
+    platform: AutoresearchPlatform,
+    exp: dict,
+    run_id: str,
+    knowledge: str,
+    pipeline_script: str,
+    pipeline_code: str,
+) -> str:
+    if exp.get("_startup_retry_attempt"):
+        return platform.agent._load_prompt(
+            "apply_startup_repair",
+            KNOWLEDGE=knowledge,
+            EXPERIMENT_NAME=exp.get("name", run_id),
+            EXPERIMENT_DESCRIPTION=exp.get("description", ""),
+            EXPERIMENT_HYPOTHESIS=exp.get("hypothesis", ""),
+            RETRY_ATTEMPT=str(exp.get("_startup_retry_attempt", "")),
+            STARTUP_FAILURE_JSON=json.dumps(
+                exp.get("_startup_failure", {}),
+                indent=2,
+            ),
+            PIPELINE_SCRIPT=pipeline_script,
+            PIPELINE_CODE=pipeline_code,
+        )
+    return platform.agent._load_prompt(
+        "apply_changes",
+        KNOWLEDGE=knowledge,
+        EXPERIMENT_NAME=exp.get("name", run_id),
+        EXPERIMENT_DESCRIPTION=exp.get("description", ""),
+        EXPERIMENT_HYPOTHESIS=exp.get("hypothesis", ""),
+        PIPELINE_SCRIPT=pipeline_script,
+        PIPELINE_CODE=pipeline_code,
+    )
+
+
+def _apply_code_changes(
+    workdir: Path,
+    config: dict,
+    state: dict,
+    platform: AutoresearchPlatform,
+    exp: dict,
+    run_id: str,
+    knowledge: str,
+    pipeline_code: str,
+) -> bool:
+    pipeline_script = config.get("pipeline_script", "")
+    if not pipeline_script or not pipeline_code:
+        _LG.warning("No pipeline script configured; cannot apply code changes")
+        _raise_failure(
+            FailureKind.CODE_CHANGE_FAILED,
+            FailurePhase.CODE_CHANGE,
+            "No pipeline script configured for source-changing experiment",
+        )
+
+    _LG.info("Applying code changes for %s: %s", run_id, exp.get("description", ""))
+    print(f"  Applying code changes for {exp['name']}...")
+
+    prompt = _build_apply_prompt(
+        platform, exp, run_id, knowledge, pipeline_script, pipeline_code
+    )
+    try:
+        output = platform.agent.run(prompt, workdir, f"apply_{run_id}")
+    except Exception as error:
+        raise _AutoresearchError(
+            _make_failure(
+                FailureKind.CODE_CHANGE_FAILED,
+                FailurePhase.CODE_CHANGE,
+                "Coding agent failed while applying experiment source changes",
+                exception=error,
+            )
+        ) from error
+    modified_code = _extract_code_block(output)
+
+    if not modified_code:
+        _LG.warning(
+            "First apply attempt returned no code block for %s, retrying", run_id
+        )
+        retry_prompt = (
+            prompt + "\n\n**You MUST output the ENTIRE modified file in a single "
+            "```python code block. Do NOT describe changes in prose.**\n"
+        )
+        try:
+            output = platform.agent.run(retry_prompt, workdir, f"apply_{run_id}_retry")
+        except Exception as error:
+            raise _AutoresearchError(
+                _make_failure(
+                    FailureKind.CODE_CHANGE_FAILED,
+                    FailurePhase.CODE_CHANGE,
+                    "Coding agent failed while retrying experiment source changes",
+                    exception=error,
+                )
+            ) from error
+        modified_code = _extract_code_block(output)
+
+    if not modified_code:
+        _LG.warning("Could not extract modified code from agent output for %s", run_id)
+        _LG.debug("Agent output (first 2000 chars): %s", output[:2000])
+        print("  Warning: code change failed - no code block in response")
+        failed_log = workdir / "logs" / f"apply_{run_id}_failed.md"
+        failed_log.write_text(output)
+        print(f"  Full output saved to {failed_log}")
+        _raise_failure(
+            FailureKind.CODE_CHANGE_FAILED,
+            FailurePhase.CODE_CHANGE,
+            "Coding agent did not return a Python code block for experiment changes",
+            details={"log": str(failed_log)},
+        )
+
+    target = Path(pipeline_script)
+    target.write_text(modified_code)
+    _LG.info("Wrote modified code to %s", target)
+    print(f"  Wrote modified code to {target}")
+
+    source_dir = config.get("source_dir", "")
+    if source_dir:
+        platform.workspace.apply_lint(source_dir)
+
+    scm = config.get("scm", "")
+    if scm and source_dir and platform.workspace.has_changes(scm, source_dir):
+        msg = f"[autoresearch] {run_id}: {exp.get('description', exp['name'])}"
+        commit_hash = platform.workspace.commit(scm, source_dir, msg)
+        exp["commit"] = commit_hash
+        run_dir = workdir / "runs" / run_id
+        run_dir.mkdir(parents=True, exist_ok=True)
+        (run_dir / "commit.txt").write_text(commit_hash + "\n")
+        _LG.info("Committed code changes: %s", commit_hash[:12])
+        print(f"  Committed: {commit_hash[:12]}")
+
+    return True
+
+
+def _prepare_node(
+    workdir: Path,
+    config: dict,
+    state: dict,
+    platform: AutoresearchPlatform,
+    node: object,
+    parent: object | None,
+) -> bool:
+    """Prepare a node: restore source, apply code changes, and build."""
+    assert isinstance(node, _HypothesisNode)
+
+    exp = node.spec
+    run_id = node.node_id
+    knowledge = platform.agent._load_knowledge()
+
+    scm = config.get("scm", "")
+    source_dir = config.get("source_dir", "")
+    anchor = state.get("anchor_commit", "")
+    target_commit = exp.get("goto") or anchor
+    if target_commit and scm and source_dir:
+        try:
+            platform.workspace.goto(scm, source_dir, target_commit, anchor)
+        except Exception as error:
+            _raise_failure(
+                FailureKind.SOURCE_RESTORE_FAILED,
+                FailurePhase.SOURCE,
+                "Failed to restore source revision",
+                exception=error,
+            )
+
+    pipeline_code = _read_pipeline_code(config, workdir)
+    success = _apply_code_changes(
+        workdir,
+        config,
+        state,
+        platform,
+        exp,
+        run_id,
+        knowledge,
+        pipeline_code,
+    )
+    if not success:
+        _raise_failure(
+            FailureKind.CODE_CHANGE_FAILED,
+            FailurePhase.CODE_CHANGE,
+            "Failed to apply experiment source changes",
+        )
+    node.commit = exp.get("commit")
+
+    if scm and source_dir and platform.workspace.has_changes(scm, source_dir):
+        msg = f"[autoresearch] {run_id} changes"
+        platform.workspace.commit(scm, source_dir, msg)
+
+    build_cmd = config.get("build_command", "")
+    if build_cmd:
+        try:
+            image = platform.artifacts.build(build_cmd, workdir, source_dir)
+        except Exception as error:
+            raise _AutoresearchError(
+                _make_failure(
+                    FailureKind.BUILD_FAILED,
+                    FailurePhase.BUILD,
+                    "Build command raised an exception",
+                    exception=error,
+                )
+            ) from error
+        if image:
+            exp["_image"] = image
+        else:
+            _LG.warning("Build failed for %s", run_id)
+            _raise_failure(
+                FailureKind.BUILD_FAILED,
+                FailurePhase.BUILD,
+                "Build command failed or produced no image",
+            )
+
+    run_dir = workdir / "runs" / run_id
+    run_dir.mkdir(parents=True, exist_ok=True)
+    (run_dir / "meta.json").write_text(json.dumps(exp, indent=2) + "\n")
+    return True
+
+
+def _launch_node(
+    config: dict,
+    state: dict,
+    platform: AutoresearchPlatform,
+    node: object,
+    workdir: Path,
+) -> str | None:
+    """Launch a job for a node. Returns job_id or raises structured failure."""
+    assert isinstance(node, _HypothesisNode)
+
+    exp = node.spec
+    launch_cmd = exp.get("launch_command", "") or config.get("base_launch_command", "")
+    if not launch_cmd:
+        print(f"  Skipping {node.name}: no launch_command")
+        _raise_failure(
+            FailureKind.LAUNCH_FAILED,
+            FailurePhase.LAUNCH,
+            "No launch command configured for experiment",
+        )
+
+    image = exp.get("_image")
+    if "$IMAGE" in launch_cmd and image:
+        launch_cmd = launch_cmd.replace("$IMAGE", image)
+
+    try:
+        job_id = platform.execution.launch(launch_cmd, workdir)
+    except Exception as error:
+        raise _AutoresearchError(
+            _make_failure(
+                FailureKind.LAUNCH_FAILED,
+                FailurePhase.LAUNCH,
+                "Platform raised while launching job",
+                exception=error,
+            )
+        ) from error
+
+    run_dir = workdir / "runs" / node.node_id
+    run_dir.mkdir(parents=True, exist_ok=True)
+    if job_id:
+        print(f"  Job ID: {job_id}")
+        (run_dir / "job_id.txt").write_text(job_id + "\n")
+    else:
+        (run_dir / "job_id.txt").write_text("LAUNCH_FAILED\n")
+        _raise_failure(
+            FailureKind.LAUNCH_FAILED,
+            FailurePhase.LAUNCH,
+            "Platform did not return a job id",
+        )
+    return job_id
+
+
+__all__ = [
+    "_build_apply_prompt",
+    "_launch_node",
+    "_prepare_node",
+]

--- a/tools/autoresearch/utils/workflow/store.py
+++ b/tools/autoresearch/utils/workflow/store.py
@@ -1,0 +1,300 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Persistent autoresearch workflow state and monitoring views.
+
+Design note for future agents
+=============================
+
+This module owns files under ``<workdir>/engine`` and the persistent
+``state.json`` view written by ``state.py``. ``checkpoint.json`` is the resume
+source of truth for queued and running ``_WorkSpec`` objects; ``queue.json`` and
+``active.json`` are compatibility views for humans and monitoring tools.
+
+Keep persistence details here instead of spreading JSON writes across the
+runner or workflow. The runner should only ask the adapter to checkpoint; it
+should not know the autoresearch workdir layout.
+
+Structured failures are persisted next to node status as ``failure.json`` and
+summarized in ``engine_state.json``. Keep that write path centralized here so
+future failure categories remain durable and queryable.
+
+.. mermaid::
+
+   flowchart TB
+       Store["_AutoresearchStore"]
+       Checkpoint["engine/checkpoint.json\nresume source of truth"]
+       Tree["engine/tree.json"]
+       Queue["engine/queue.json\nmonitoring view"]
+       Active["engine/active.json\nmonitoring view"]
+       Nodes["engine/nodes/<node_id>/"]
+       Failure["nodes/<node_id>/failure.json"]
+       State["state.json"]
+
+       Store --> Checkpoint
+       Store --> Tree
+       Store --> Queue
+       Store --> Active
+       Store --> Nodes
+       Nodes --> Failure
+       Store --> State
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from pathlib import Path
+
+from ..runner import _WorkSpec
+from ..state import SCHEMA_VERSION, write_state
+from ..types import _HypothesisNode
+from .policy import (
+    _extract_counter,
+    _node_from_spec,
+    _update_spec_from_node,
+)
+
+__all__ = [
+    "_AutoresearchStore",
+    "_write_text_atomic",
+]
+
+
+class _AutoresearchStore:
+    """Own durable runner checkpoints and autoresearch monitoring files.
+
+    .. mermaid::
+
+       sequenceDiagram
+           participant Adapter as AutoresearchAdapter
+           participant Store as _AutoresearchStore
+           participant Disk as workdir/engine
+
+           Adapter->>Store: save_scheduler_state(queued, running, status)
+           Store->>Disk: checkpoint.json
+           Store->>Disk: queue.json / active.json
+           Adapter->>Store: update_spec(spec, node)
+           Store->>Disk: nodes/<node_id>/status.txt
+           Store->>Disk: tree.json
+    """
+
+    def __init__(self, workdir: Path, state: dict) -> None:
+        self.workdir = workdir
+        self.state = state
+        self.engine_dir = workdir / "engine"
+        self.nodes_dir = self.engine_dir / "nodes"
+        self.tree: dict[str, _HypothesisNode] = {}
+        self.queued: list[_WorkSpec] = []
+        self.running: list[_WorkSpec] = []
+        self.status = "running"
+        self.node_counter = 0
+
+    def load_checkpoint(self) -> list[_WorkSpec] | None:
+        checkpoint = self.engine_dir / "checkpoint.json"
+        if not checkpoint.exists():
+            return None
+        data = json.loads(checkpoint.read_text())
+        self._validate_checkpoint(data)
+        self.queued = [_WorkSpec.from_dict(spec) for spec in data.get("queued", [])]
+        self.running = [_WorkSpec.from_dict(spec) for spec in data.get("running", [])]
+        specs = self.queued + self.running
+        self.status = str(data.get("status", "running"))
+        for spec in specs:
+            self.upsert_node(_node_from_spec(spec))
+        return specs
+
+    def _validate_checkpoint(self, data: object) -> None:
+        if not isinstance(data, dict):
+            raise ValueError("engine/checkpoint.json must contain a JSON object")
+        for key in ("queued", "running"):
+            specs = data.get(key, [])
+            if not isinstance(specs, list):
+                raise ValueError(f"engine/checkpoint.json field {key!r} must be a list")
+            seen = set()
+            for index, raw_spec in enumerate(specs):
+                if not isinstance(raw_spec, dict):
+                    raise ValueError(f"{key}[{index}] must be a _WorkSpec object")
+                spec_id = raw_spec.get("id")
+                if not isinstance(spec_id, str) or not spec_id:
+                    raise ValueError(f"{key}[{index}] must have a non-empty string id")
+                if spec_id in seen:
+                    raise ValueError(f"Duplicate _WorkSpec id in {key}: {spec_id}")
+                seen.add(spec_id)
+                payload = raw_spec.get("payload")
+                if not isinstance(payload, dict) or not isinstance(
+                    payload.get("node"),
+                    dict,
+                ):
+                    raise ValueError(f"{key}[{index}] must contain payload.node")
+
+    def save_scheduler_state(
+        self,
+        queued: list[_WorkSpec],
+        running: list[_WorkSpec],
+        status: str,
+    ) -> None:
+        self.queued = queued
+        self.running = running
+        self.status = status
+        for spec in queued + running:
+            self.upsert_node(_node_from_spec(spec))
+        self.write_all()
+
+    def update_spec(self, spec: _WorkSpec, node: _HypothesisNode) -> None:
+        _update_spec_from_node(spec, node)
+        self.upsert_node(node)
+        self._replace_spec(spec, self.queued)
+        self._replace_spec(spec, self.running)
+        self.write_all()
+
+    def upsert_node(self, node: _HypothesisNode) -> None:
+        existing = self.tree.get(node.node_id)
+        if existing is not None and existing.children and not node.children:
+            node.children = existing.children
+        self.tree[node.node_id] = node
+        self.node_counter = max(self.node_counter, _extract_counter(node.node_id) + 1)
+
+    def add_child(self, parent: _HypothesisNode, spec: _WorkSpec) -> None:
+        node = _node_from_spec(spec)
+        self.upsert_node(node)
+        stored_parent = self.tree.get(parent.node_id)
+        if stored_parent is not None and node.node_id not in stored_parent.children:
+            stored_parent.children.append(node.node_id)
+        self.write_all()
+
+    def tree_dict(self) -> dict[str, dict]:
+        return {node_id: node.to_dict() for node_id, node in self.tree.items()}
+
+    def write_all(self) -> None:
+        self.engine_dir.mkdir(parents=True, exist_ok=True)
+        for node in self.tree.values():
+            self._persist_node(node)
+        self._persist_tree()
+        self._persist_checkpoint()
+        self._persist_queue_view()
+        self._persist_active_view()
+        self._persist_engine_state()
+        self.state["status"] = self.status
+        write_state(self.workdir, self.state)
+
+    def _replace_spec(self, spec: _WorkSpec, specs: list[_WorkSpec]) -> None:
+        for index, existing in enumerate(specs):
+            if existing.id == spec.id:
+                specs[index] = spec
+                return
+
+    def _persist_checkpoint(self) -> None:
+        _write_text_atomic(
+            self.engine_dir / "checkpoint.json",
+            json.dumps(
+                {
+                    "schema_version": SCHEMA_VERSION,
+                    "status": self.status,
+                    "timestamp": _timestamp(),
+                    "queued": [spec.to_dict() for spec in self.queued],
+                    "running": [spec.to_dict() for spec in self.running],
+                },
+                indent=2,
+            )
+            + "\n",
+        )
+
+    def _persist_queue_view(self) -> None:
+        queued = []
+        for spec in self.queued:
+            node = _node_from_spec(spec)
+            queued.append(
+                {
+                    "priority": spec.priority,
+                    "node_id": spec.id,
+                    "retry_of": node.spec.get("_startup_retry_of", ""),
+                    "retry_attempt": node.spec.get("_startup_retry_attempt", ""),
+                }
+            )
+        (self.engine_dir / "queue.json").write_text(json.dumps(queued, indent=2) + "\n")
+
+    def _persist_active_view(self) -> None:
+        active = []
+        for spec in self.running:
+            node = _node_from_spec(spec)
+            if node.status == "running" and node.job_id:
+                active.append(
+                    {
+                        "node_id": node.node_id,
+                        "job_id": node.job_id,
+                        "launched_at_iso": _timestamp(),
+                    }
+                )
+        (self.engine_dir / "active.json").write_text(
+            json.dumps(active, indent=2) + "\n"
+        )
+
+    def _persist_engine_state(self) -> None:
+        failed_by_kind: dict[str, int] = {}
+        for node in self.tree.values():
+            if node.status != "failed" or node.failure is None:
+                continue
+            kind = node.failure.kind.value
+            failed_by_kind[kind] = failed_by_kind.get(kind, 0) + 1
+
+        _write_text_atomic(
+            self.engine_dir / "engine_state.json",
+            json.dumps(
+                {
+                    "status": self.status,
+                    "timestamp": _timestamp(),
+                    "total_nodes": len(self.tree),
+                    "queued": len(self.queued),
+                    "running": len(self.running),
+                    "completed": sum(
+                        1 for node in self.tree.values() if node.status == "completed"
+                    ),
+                    "failed": sum(
+                        1 for node in self.tree.values() if node.status == "failed"
+                    ),
+                    "failed_by_kind": failed_by_kind,
+                },
+                indent=2,
+            )
+            + "\n",
+        )
+
+    def _persist_node(self, node: _HypothesisNode) -> None:
+        node_dir = self.nodes_dir / node.node_id
+        node_dir.mkdir(parents=True, exist_ok=True)
+        (node_dir / "spec.json").write_text(json.dumps(node.spec, indent=2) + "\n")
+        (node_dir / "status.txt").write_text(node.status + "\n")
+        if node.result is not None:
+            (node_dir / "result.json").write_text(
+                json.dumps(node.result, indent=2) + "\n"
+            )
+        failure_path = node_dir / "failure.json"
+        if node.failure is not None:
+            _write_text_atomic(
+                failure_path,
+                json.dumps(node.failure.to_dict(), indent=2) + "\n",
+            )
+        elif failure_path.exists():
+            failure_path.unlink()
+
+    def _persist_tree(self) -> None:
+        _write_text_atomic(
+            self.engine_dir / "tree.json",
+            json.dumps([node.to_dict() for node in self.tree.values()], indent=2)
+            + "\n",
+        )
+
+
+def _timestamp() -> str:
+    return time.strftime("%Y-%m-%dT%H:%M:%S")
+
+
+def _write_text_atomic(path: Path, text: str) -> None:
+    tmp = path.with_name(f"{path.name}.tmp.{os.getpid()}")
+    tmp.write_text(text)
+    tmp.replace(path)


### PR DESCRIPTION
Add the autoresearch-specific workflow that adapts experiment hypothesis nodes onto the generic runner. This includes the `AutoresearchAdapter`, a persistent store, deterministic policy helpers, structured failure records, and operation modules for source/build/launch and analysis/planning.

Architecture: The adapter is the domain side of the runner/adapter boundary. It orchestrates experiment coroutines, but durable state lives in `store.py` and deterministic policy lives in `policy.py`. The workflow sequences domain operations: restore source, apply experiment changes, build, launch, poll, collect metrics, analyze, update state, and produce child `_WorkSpec` objects. Infrastructure-specific work sits behind `AutoresearchPlatform` capability objects, keeping the adapter boundary small rather than a large flat callback interface. Workflow failures are structured domain data — expected failures carry a `FailureRecord` through `_AutoresearchError` or `_AnalysisResult.failure`; the runner never learns autoresearch failure kinds. The store owns files under `<workdir>/engine/` and keeps persistence details centralized rather than spreading JSON writes across the runner or workflow. `checkpoint.json` is the resume source of truth; `queue.json` and `active.json` are compatibility views for humans and monitoring. Policy helpers are pure functions of specs, nodes, state, and metrics — deterministic and testable without source control, subprocesses, or LLM calls.

Workflow layer (`utils/workflow/`):
- `adapter.py` — `AutoresearchAdapter` bridging domain logic into the runner, handles prepare/launch/poll/analyze/plan lifecycle
- `store.py` — `_AutoresearchStore` for persistent scheduler state, hypothesis tree, checkpoint round-tripping, node/failure views
- `policy.py` — pure deterministic helpers: planning gate, duplicate filter, stall policy, spec/node conversion, startup retry, thread budget validation
- `analysis_ops.py` — job analysis, metric comparison, state update on completion
- `planning_ops.py` — follow-up experiment planning via coding agent
- `source_ops.py` — source restore, code change application, build/launch sequencing
- `failures.py` — failure classification (`_classify_terminal_job_failure`), structured `FailureRecord` construction, per-kind retry policies

Domain types (`utils/types.py`):
- `FailureKind` / `FailurePhase` enums, `FailureRecord`, `_AutoresearchError`, `_HypothesisNode`, `_AnalysisResult`, typed config/state dicts

Also adds state schema normalization and versioning (`SCHEMA_VERSION`, `_normalize_config`, `_normalize_state`), `change_summary` column to master table, and comprehensive tests (~700 lines) covering retry, failure classification, checkpoint round-trip, store views, planning gates, and policy helpers.