### PR TITLE
Make autoresearch platforms extensible

### DIFF
--- a/tools/autoresearch/launch.sh
+++ b/tools/autoresearch/launch.sh
@@ -10,13 +10,6 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROMPT="$(cat "$SCRIPT_DIR/prompts/launch.md")"
 
-FB_PROMPT="$SCRIPT_DIR/prompts/fb/launch.md"
-if [ -f "$FB_PROMPT" ]; then
-  PROMPT="$PROMPT
-
-$(cat "$FB_PROMPT")"
-fi
-
 if [ $# -gt 0 ]; then
   exec claude --system-prompt "$PROMPT" "$*"
 else

--- a/tools/autoresearch/prompts/analyze.md
+++ b/tools/autoresearch/prompts/analyze.md
@@ -2,7 +2,7 @@ You are an expert in SPDL data loading pipeline optimization for AI training. Yo
 
 __KNOWLEDGE__
 
-> Note: If infrastructure-specific knowledge (job scheduler CLIs, storage backends, etc.) is available, it is appended above from `fb/knowledge.md`.
+> Note: If infrastructure-specific knowledge (job scheduler CLIs, storage backends, etc.) is available, it is appended above by the selected platform provider.
 
 ---
 

--- a/tools/autoresearch/prompts/assess.md
+++ b/tools/autoresearch/prompts/assess.md
@@ -2,7 +2,7 @@ You are an expert in SPDL data loading pipeline optimization for AI training. Yo
 
 __KNOWLEDGE__
 
-> Note: If infrastructure-specific knowledge (job scheduler CLIs, storage backends, etc.) is available, it is appended above from `fb/knowledge.md`.
+> Note: If infrastructure-specific knowledge (job scheduler CLIs, storage backends, etc.) is available, it is appended above by the selected platform provider.
 
 ---
 

--- a/tools/autoresearch/prompts/plan_next.md
+++ b/tools/autoresearch/prompts/plan_next.md
@@ -2,7 +2,7 @@ You are an expert in SPDL data loading pipeline optimization for AI training. Yo
 
 __KNOWLEDGE__
 
-> Note: If infrastructure-specific knowledge (job scheduler CLIs, storage backends, etc.) is available, it is appended above from `fb/knowledge.md`.
+> Note: If infrastructure-specific knowledge (job scheduler CLIs, storage backends, etc.) is available, it is appended above by the selected platform provider.
 
 ---
 

--- a/tools/autoresearch/run.py
+++ b/tools/autoresearch/run.py
@@ -16,7 +16,7 @@ First run::
     fbpython run.py <workdir> \\
       --pipeline-script path/to/pipeline.py \\
       --source-dir path/to/source \\
-      --build-command "fbpkg build ..." \\
+      --build-command "docker build -t my_image ." \\
       --base-launch-command "torchx run ... --image \\$IMAGE ..." \\
       --platform auto \\
       --agent claude
@@ -89,9 +89,11 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument("--job-timeout", type=int, default=1800)
     parser.add_argument(
         "--platform",
-        choices=("auto", "remote", "local"),
         default="auto",
-        help="_Execution platform. 'auto' uses the best available implementation.",
+        help=(
+            "Job execution platform provider. 'auto' uses the best available "
+            "provider discovered in this environment."
+        ),
     )
     parser.add_argument(
         "--agent",

--- a/tools/autoresearch/tests/test_platform.py
+++ b/tools/autoresearch/tests/test_platform.py
@@ -10,6 +10,7 @@ import tempfile
 import time
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 from spdl.tools.autoresearch.utils.commands import queue as cmd_queue
 from spdl.tools.autoresearch.utils.platform import (
@@ -28,7 +29,11 @@ __all__: list[str] = []
 class _PlatformTest(unittest.TestCase):
     def test_default_platform_has_capability_parts(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
-            platform = create_platform("auto", Path(tmp))
+            with patch.dict(
+                "os.environ",
+                {"SPDL_AUTORESEARCH_PLATFORM_PROVIDERS": ""},
+            ):
+                platform = create_platform("auto", Path(tmp))
 
             self.assertIsInstance(platform, AutoresearchPlatform)
             self.assertTrue(hasattr(platform, "workspace"))
@@ -124,6 +129,20 @@ class _PlatformTest(unittest.TestCase):
                     {"platform": "local", "local_execution_mode": "unknown"},
                     Path(tmp),
                 )
+
+    def test_unknown_remote_provider_is_explicit(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            with patch.dict(
+                "os.environ",
+                {"SPDL_AUTORESEARCH_PLATFORM_PROVIDERS": ""},
+            ):
+                with self.assertRaisesRegex(
+                    ValueError, "Unknown autoresearch platform"
+                ):
+                    create_platform(
+                        {"platform": "unknown_remote", "agent": "mock"},
+                        Path(tmp),
+                    )
 
     def test_agent_result_reports_parse_errors_without_llm(self) -> None:
         agent = _MockAgent()

--- a/tools/autoresearch/utils/commands/init.py
+++ b/tools/autoresearch/utils/commands/init.py
@@ -74,9 +74,11 @@ def _parse_args(args: list[str]) -> argparse.Namespace:
     )
     parser.add_argument(
         "--platform",
-        choices=("auto", "remote", "local"),
         default="auto",
-        help="_Execution platform. 'auto' uses the best available implementation.",
+        help=(
+            "Job execution platform provider. 'auto' uses the best available "
+            "provider discovered in this environment."
+        ),
     )
     parser.add_argument(
         "--agent",

--- a/tools/autoresearch/utils/platform/factory.py
+++ b/tools/autoresearch/utils/platform/factory.py
@@ -8,26 +8,18 @@
 
 from __future__ import annotations
 
-from importlib import import_module
 from pathlib import Path
-from typing import Any, cast
+from typing import Any
 
-from .agents import _create_agent
-from .local import (
-    _DefaultArtifacts,
-    _DefaultEvidence,
-    _DefaultExecution,
-    _DefaultWorkspace,
-    _LocalEvidence,
-    _LocalExecution,
-    _LocalWorkspace,
+from .providers import (
+    _create_agent_for_config,
+    _find_provider,
+    _resolve_providers,
+    _validate_common_config,
 )
-from .types import _CodingAgent, AutoresearchPlatform
+from .types import AutoresearchPlatform
 
 __all__ = ["create_platform"]
-
-_LOCAL_EXECUTION_MODES = frozenset({"full", "dataloader_only", "dry_run"})
-_AGENT_KINDS = frozenset({"claude", "codex", "mock"})
 
 
 def create_platform(
@@ -42,79 +34,6 @@ def create_platform(
         config = config_or_kind
 
     kind = str(config.get("platform", "auto"))
-    agent_kind = str(config.get("agent", "claude"))
-    _validate_platform_config(config, workdir)
-    agent = cast(
-        _CodingAgent, _create_agent(agent_kind, command=config.get("agent_command"))
-    )
-
-    if kind == "local":
-        mode = str(config.get("local_execution_mode", "full"))
-        execution = _LocalExecution(mode, config.get("local_dataloader_command"))
-        if workdir is not None:
-            execution.bind_workdir(workdir)
-        return AutoresearchPlatform(
-            workspace=_LocalWorkspace(),
-            artifacts=_DefaultArtifacts(),
-            execution=execution,
-            evidence=_LocalEvidence(),
-            agent=agent,
-        )
-
-    if kind in ("auto", "remote"):
-        fb_platform = _create_fb_platform(config, workdir, agent)
-        if fb_platform is not None:
-            return fb_platform
-        if kind == "remote":
-            raise ValueError("Remote autoresearch platform is not available")
-        return AutoresearchPlatform(
-            workspace=_DefaultWorkspace(),
-            artifacts=_DefaultArtifacts(),
-            execution=_DefaultExecution(),
-            evidence=_DefaultEvidence(),
-            agent=agent,
-        )
-
-    raise ValueError(f"Unknown autoresearch platform: {kind}")
-
-
-def _validate_platform_config(config: dict[str, Any], workdir: Path | None) -> None:
-    kind = str(config.get("platform", "auto"))
-    if kind not in ("auto", "remote", "local"):
-        raise ValueError(f"Unknown autoresearch platform: {kind}")
-
-    agent = str(config.get("agent", "claude"))
-    if agent not in _AGENT_KINDS:
-        raise ValueError(f"Unknown autoresearch agent: {agent}")
-
-    mode = str(config.get("local_execution_mode", "full"))
-    if mode not in _LOCAL_EXECUTION_MODES:
-        raise ValueError(f"Unknown local execution mode: {mode}")
-
-    source_dir = str(config.get("source_dir", ""))
-    if source_dir and not Path(source_dir).exists():
-        raise ValueError(f"Autoresearch source_dir does not exist: {source_dir}")
-
-    pipeline_script = config.get("pipeline_script")
-    if pipeline_script and not Path(str(pipeline_script)).exists():
-        raise ValueError(
-            f"Autoresearch pipeline_script does not exist: {pipeline_script}"
-        )
-
-    if workdir is not None and not workdir.exists():
-        workdir.mkdir(parents=True, exist_ok=True)
-
-
-def _create_fb_platform(
-    config: dict[str, Any],
-    workdir: Path | None,
-    agent: object,
-) -> AutoresearchPlatform | None:
-    try:
-        factory = import_module("spdl.tools.autoresearch.utils.platform.fb.factory")
-    except ImportError:
-        return None
-    create = getattr(factory, "_create_platform", None)
-    if create is None:
-        return None
-    return create(config=config, workdir=workdir, agent=agent)
+    _validate_common_config(config, workdir)
+    provider = _find_provider(_resolve_providers(), kind, config, workdir)
+    return provider.create(config, workdir, _create_agent_for_config(config))

--- a/tools/autoresearch/utils/platform/providers.py
+++ b/tools/autoresearch/utils/platform/providers.py
@@ -1,0 +1,257 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Neutral platform provider discovery for autoresearch.
+
+Core autoresearch owns the CLI, runner, workflow, and provider interface.
+Environment-specific infrastructure is supplied by provider modules discovered
+through standard Python entry points or an explicit environment hook. Keep this
+module free of provider-specific imports so OSS code does not know about any
+particular internal extension.
+"""
+
+from __future__ import annotations
+
+import importlib
+import importlib.metadata
+import os
+import pkgutil
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, cast, Protocol
+
+from .agents import _create_agent
+from .local import (
+    _DefaultArtifacts,
+    _DefaultEvidence,
+    _DefaultExecution,
+    _DefaultWorkspace,
+    _LocalEvidence,
+    _LocalExecution,
+    _LocalWorkspace,
+)
+from .types import _CodingAgent, AutoresearchPlatform
+
+__all__ = [
+    "_AutoresearchPlatformProvider",
+    "_ProviderAvailability",
+    "_ProviderFactory",
+    "_builtin_providers",
+    "_discover_convention_providers",
+    "_discover_extension_providers",
+    "_find_provider",
+    "_provider_from_spec",
+    "_resolve_providers",
+]
+
+_ENTRY_POINT_GROUP = "spdl.autoresearch.platforms"
+_PROVIDER_ENV = "SPDL_AUTORESEARCH_PLATFORM_PROVIDERS"
+_LOCAL_EXECUTION_MODES = frozenset({"full", "dataloader_only", "dry_run"})
+_AGENT_KINDS = frozenset({"claude", "codex", "mock"})
+
+
+@dataclass(frozen=True)
+class _ProviderAvailability:
+    available: bool
+    reason: str = ""
+
+
+class _AutoresearchPlatformProvider(Protocol):
+    name: str
+    priority: int
+
+    def is_available(
+        self, config: dict[str, Any], workdir: Path | None
+    ) -> _ProviderAvailability: ...
+
+    def create(
+        self,
+        config: dict[str, Any],
+        workdir: Path | None,
+        agent: _CodingAgent,
+    ) -> AutoresearchPlatform: ...
+
+
+_ProviderFactory = Callable[[], _AutoresearchPlatformProvider]
+
+
+class _LocalProvider:
+    name = "local"
+    priority = 10
+
+    def is_available(
+        self, config: dict[str, Any], workdir: Path | None
+    ) -> _ProviderAvailability:
+        mode = str(config.get("local_execution_mode", "full"))
+        if mode not in _LOCAL_EXECUTION_MODES:
+            return _ProviderAvailability(False, f"unknown local execution mode: {mode}")
+        return _ProviderAvailability(True)
+
+    def create(
+        self,
+        config: dict[str, Any],
+        workdir: Path | None,
+        agent: _CodingAgent,
+    ) -> AutoresearchPlatform:
+        mode = str(config.get("local_execution_mode", "full"))
+        execution = _LocalExecution(mode, config.get("local_dataloader_command"))
+        if workdir is not None:
+            execution.bind_workdir(workdir)
+        return AutoresearchPlatform(
+            workspace=_LocalWorkspace(),
+            artifacts=_DefaultArtifacts(),
+            execution=execution,
+            evidence=_LocalEvidence(),
+            agent=agent,
+        )
+
+
+class _DefaultProvider:
+    name = "default"
+    priority = 0
+
+    def is_available(
+        self, config: dict[str, Any], workdir: Path | None
+    ) -> _ProviderAvailability:
+        return _ProviderAvailability(True)
+
+    def create(
+        self,
+        config: dict[str, Any],
+        workdir: Path | None,
+        agent: _CodingAgent,
+    ) -> AutoresearchPlatform:
+        return AutoresearchPlatform(
+            workspace=_DefaultWorkspace(),
+            artifacts=_DefaultArtifacts(),
+            execution=_DefaultExecution(),
+            evidence=_DefaultEvidence(),
+            agent=agent,
+        )
+
+
+def _builtin_providers() -> list[_AutoresearchPlatformProvider]:
+    return [_LocalProvider(), _DefaultProvider()]
+
+
+def _resolve_providers() -> list[_AutoresearchPlatformProvider]:
+    providers = _builtin_providers()
+    providers.extend(_discover_extension_providers())
+    return providers
+
+
+def _discover_extension_providers() -> list[_AutoresearchPlatformProvider]:
+    providers: list[_AutoresearchPlatformProvider] = []
+    specs = [
+        spec.strip()
+        for spec in os.environ.get(_PROVIDER_ENV, "").split(",")
+        if spec.strip()
+    ]
+    for spec in specs:
+        providers.append(_provider_from_spec(spec))
+
+    for entry_point in importlib.metadata.entry_points(group=_ENTRY_POINT_GROUP):
+        loaded = entry_point.load()
+        providers.append(loaded() if callable(loaded) else loaded)
+    providers.extend(_discover_convention_providers())
+    return providers
+
+
+def _discover_convention_providers() -> list[_AutoresearchPlatformProvider]:
+    root = importlib.import_module("spdl.tools.autoresearch")
+    package_paths = getattr(root, "__path__", None)
+    if package_paths is None:
+        return []
+
+    providers: list[_AutoresearchPlatformProvider] = []
+    for module_info in pkgutil.iter_modules(package_paths):
+        try:
+            module = importlib.import_module(
+                f"spdl.tools.autoresearch.{module_info.name}.platform"
+            )
+        except ImportError:
+            continue
+        factory = getattr(module, "create_provider", None)
+        if factory is not None:
+            providers.append(factory())
+    return providers
+
+
+def _provider_from_spec(spec: str) -> _AutoresearchPlatformProvider:
+    module_name, sep, attr = spec.partition(":")
+    if not sep:
+        attr = "create_provider"
+    module = importlib.import_module(module_name)
+    factory = getattr(module, attr)
+    provider = factory()
+    return provider
+
+
+def _find_provider(
+    providers: list[_AutoresearchPlatformProvider],
+    requested: str,
+    config: dict[str, Any],
+    workdir: Path | None,
+) -> _AutoresearchPlatformProvider:
+    if requested == "auto":
+        available = [
+            provider
+            for provider in providers
+            if provider.is_available(config, workdir).available
+        ]
+        if not available:
+            reasons = "; ".join(
+                f"{provider.name}: {provider.is_available(config, workdir).reason}"
+                for provider in providers
+            )
+            raise ValueError(
+                f"No autoresearch platform providers are available: {reasons}"
+            )
+        return max(available, key=lambda provider: provider.priority)
+
+    for provider in providers:
+        aliases = getattr(provider, "aliases", ())
+        if provider.name != requested and requested not in aliases:
+            continue
+        availability = provider.is_available(config, workdir)
+        if not availability.available:
+            raise ValueError(
+                f"Autoresearch platform provider {requested!r} is unavailable: "
+                f"{availability.reason}"
+            )
+        return provider
+
+    raise ValueError(
+        f"Unknown autoresearch platform provider: {requested}. "
+        f"Available providers: {', '.join(provider.name for provider in providers)}"
+    )
+
+
+def _validate_common_config(config: dict[str, Any], workdir: Path | None) -> None:
+    agent = str(config.get("agent", "claude"))
+    if agent not in _AGENT_KINDS:
+        raise ValueError(f"Unknown autoresearch agent: {agent}")
+
+    source_dir = str(config.get("source_dir", ""))
+    if source_dir and not Path(source_dir).exists():
+        raise ValueError(f"Autoresearch source_dir does not exist: {source_dir}")
+
+    pipeline_script = config.get("pipeline_script")
+    if pipeline_script and not Path(str(pipeline_script)).exists():
+        raise ValueError(
+            f"Autoresearch pipeline_script does not exist: {pipeline_script}"
+        )
+
+    if workdir is not None and not workdir.exists():
+        workdir.mkdir(parents=True, exist_ok=True)
+
+
+def _create_agent_for_config(config: dict[str, Any]) -> _CodingAgent:
+    agent_kind = str(config.get("agent", "claude"))
+    return cast(
+        _CodingAgent, _create_agent(agent_kind, command=config.get("agent_command"))
+    )

--- a/tools/autoresearch/utils/platform/types.py
+++ b/tools/autoresearch/utils/platform/types.py
@@ -30,7 +30,7 @@ capability objects without learning any implementation-specific commands.
        _Evidence["_Evidence"]
        Agent["_CodingAgent"]
        Local["local implementations"]
-       Remote["optional fb implementations"]
+       Extension["optional provider implementations"]
 
        Workflow --> Platform
        Platform --> _Workspace
@@ -42,10 +42,10 @@ capability objects without learning any implementation-specific commands.
        _Artifacts --> Local
        _Execution --> Local
        _Evidence --> Local
-       _Workspace --> Remote
-       _Artifacts --> Remote
-       _Execution --> Remote
-       _Evidence --> Remote
+       _Workspace --> Extension
+       _Artifacts --> Extension
+       _Execution --> Extension
+       _Evidence --> Extension
 """
 
 from __future__ import annotations


### PR DESCRIPTION
Refactor autoresearch platform selection so the generic CLI can support OSS/local execution and environment-specific infrastructure through extension providers, without generic code importing or naming those extensions.

Motivation:
- Autoresearch needs one future entrypoint, such as `spdl autoresearch`, that works for OSS users and internal environments.
- Platform-specific defaults should be discoverable when available, but users still need explicit override control through `--platform`.
- Generic SPDL code must remain open-source clean: no Meta infrastructure imports, Buck targets, tests, or prompt text should leak into the generic implementation.

Design:
- Add `utils/platform/providers.py` with a provider protocol, availability reporting, priority-based `auto` selection, and extension discovery.
- Keep built-in `local` and default providers available in generic code.
- Discover extension providers through environment-variable registration, package entry points, and package-convention loading.
- Refactor `utils/platform/factory.py` and `run.py` so platform names are resolved dynamically instead of hardcoded in CLI choices.
- Keep generic prompts extension-neutral; selected providers append any platform-specific knowledge.