### PR TITLE
[autoresearch] Clarify MTP motivation

### DIFF
--- a/tools/autoresearch/prompts/assess.md
+++ b/tools/autoresearch/prompts/assess.md
@@ -43,7 +43,7 @@ __NOTES__
 
    **TorchTNT detection**: Check whether the code uses TorchTNT (`torchtnt.framework.fit`, `train`, `AutoUnit`, or a unit class with `compute_loss`). If so, note this in the assessment — it affects where instrumentation and code changes target. In TorchTNT scripts, the SPDL Pipeline is typically wrapped in a dataloader class with `__iter__`, and the training loop is managed by TorchTNT internally. Pipeline optimization changes still target the pipeline builder function and the wrapper, not TorchTNT internals.
 
-3. **Estimate headroom**: Based on the metrics, estimate how much improvement is possible. Even if SM utilization is already high, there are always optimizations to try — reducing variance, improving data readiness, eliminating GIL contention via MTP, etc. Never dismiss optimization opportunities just because one metric looks acceptable.
+3. **Estimate headroom**: Based on the metrics, estimate how much improvement is possible. Even if SM utilization is already high, there are always optimizations to try — reducing variance, improving data readiness, isolating background data loading threads from CUDA kernel launch scheduling via MTP, etc. Never dismiss optimization opportunities just because one metric looks acceptable.
 
 4. **Propose 2-4 experiments** to run, ordered by expected impact. Always include best-practice structural changes that haven't been applied yet. For each experiment, specify:
    - What parameter or structural change to make
@@ -51,7 +51,7 @@ __NOTES__
    - The exact launch command to use (use `$IMAGE` as placeholder for the job image)
 
 **Always recommend these best practices if not already applied:**
-- **Subprocess mode (MTP)**: Use the full MTP pattern from the knowledge base — `run_pipeline_in_subprocess()` with `embed_shuffle()`, `continuous=True`, and proper pickling. This eliminates GIL contention, isolates GC stalls, and removes epoch-boundary pipeline teardown. For TorchTNT scripts, the MTP refactor changes the pipeline builder and the dataloader wrapper's `__iter__` — TorchTNT internals are not modified.
+- **Subprocess mode (MTP)**: Use the full MTP pattern from the knowledge base — `run_pipeline_in_subprocess()` with `embed_shuffle()`, `continuous=True`, and proper pickling. This isolates CPU data loading work from the training process so background threads do not interfere with CUDA kernel launch scheduling; it also reduces GIL/GC interference and removes epoch-boundary pipeline teardown. For TorchTNT scripts, the MTP refactor changes the pipeline builder and the dataloader wrapper's `__iter__` — TorchTNT internals are not modified.
 - **Batch size tuning**: If GPU memory utilization has headroom, try larger batch sizes
 - **Concurrency tuning**: Adjust concurrency of CPU-bound stages (try at least 2 values)
 

--- a/tools/autoresearch/prompts/knowledge/knowledge.md
+++ b/tools/autoresearch/prompts/knowledge/knowledge.md
@@ -6,6 +6,12 @@ This knowledge is assembled from shared skill files. The canonical sources are i
 
 ### MTP — PipelineBuilder vs Pipeline vs PipelineConfig
 
+MTP's main performance goal is to move CPU data loading work into a separate
+process so background data loading threads do not interfere with CUDA kernel
+launch scheduling in the training process. Avoiding GIL/GC interference is
+another benefit. Even in free-threaded Python, which does not have GIL contention,
+isolating CPU contention is still benefitial.
+
 The SPDL pipeline API has three distinct types:
 
 - **`PipelineBuilder`** — accumulates pipeline configuration in a monad pattern. Chain `.add_source()`, `.pipe()`, `.aggregate()`, `.add_sink()` on it. It does NOT run anything — it only builds up the config.

--- a/tools/autoresearch/prompts/supervisor/launch.md
+++ b/tools/autoresearch/prompts/supervisor/launch.md
@@ -70,7 +70,7 @@ The engine runs these fixed initial experiments (skipping any already done):
 
 1. **Baseline** — unmodified pipeline, establishes baseline metrics
 2. **Headspace** — wraps pipeline with CacheDataLoader to measure data loading overhead ceiling
-3. **MTP** — runs pipeline in subprocess to test GIL contention elimination
+3. **MTP** — runs pipeline in subprocess to isolate data loading threads from the training process and reduce CUDA kernel launch interference
 
 After the fixed experiments, the coding agent proposes follow-up experiments based on analysis results. The engine:
 

--- a/tools/autoresearch/utils/workflow/planning_ops.py
+++ b/tools/autoresearch/utils/workflow/planning_ops.py
@@ -342,11 +342,15 @@ def _build_initial_nodes(workdir: Path, config: dict, state: dict) -> list:
                 name="subprocess_mtp",
                 spec={
                     "name": "subprocess_mtp",
-                    "description": "Run pipeline in subprocess to avoid GIL contention",
+                    "description": (
+                        "Run pipeline in subprocess to avoid background data "
+                        "loading threads interfering with CUDA kernel launches"
+                    ),
                     "change_summary": "subprocess MTP",
                     "hypothesis": (
-                        "Subprocess isolation eliminates "
-                        "GIL contention and improves throughput"
+                        "Subprocess isolation keeps CPU data loading work out "
+                        "of the training process, reducing interference with "
+                        "CUDA kernel launch scheduling"
                     ),
                     "launch_command": base_launch,
                     "best_practices_tags": ["subprocess_mtp"],


### PR DESCRIPTION
Update the initial MTP experiment description and related prompts so commit messages and agent instructions describe the primary motivation correctly: subprocess MTP isolates CPU data loading threads from the training process, reducing interference with CUDA kernel launch scheduling. GIL and GC isolation remain secondary benefits, but are no longer presented as the main reason for the experiment.