### PR TITLE
[autoresearch] Fix headspace prompt and thread budget validation

### DIFF
--- a/tools/autoresearch/prompts/headspace.md
+++ b/tools/autoresearch/prompts/headspace.md
@@ -2,6 +2,8 @@ You are adding CacheDataLoader instrumentation to a data loading pipeline for he
 
 **Important context:** With CacheDataLoader, the pipeline configuration (concurrency, MTP, batch size, etc.) does not affect the result — all batches come from cache after the initial fill. The result shows pure model compute time without any data loading. This is NOT a real training run — it is only used to estimate the upper bound of data loading optimization headroom.
 
+__KNOWLEDGE__
+
 ## Pipeline Source Code (`__PIPELINE_SCRIPT__`)
 
 ```python
@@ -26,6 +28,7 @@ dataloader = CacheDataLoader(dataloader, num_caches=10, return_caches_after=100,
 - If the pipeline is built inside a function that returns it, add the wrapping at the **call site** where the return value is used, or wrap it inside the function right before returning. Prefer the call site if it is clear.
 - If the pipeline uses `run_pipeline_in_subprocess`, wrap the **final outer pipeline** after `.build()`.
 - Add the `from spdl.dataloader import CacheDataLoader` import at the top of the file with the other imports.
+- The `CacheDataLoader(...)` call **must include `stop_after=500`**. Do not omit it and do not replace it with an unbounded cache wrapper.
 - **Step limit**: The `stop_after=500` parameter makes `CacheDataLoader` yield at most 500 batches then stop, so the training loop terminates naturally. No manual step counter is needed.
 - Keep all other code unchanged — only add the CacheDataLoader import and wrapping.
 - Do NOT remove or modify any existing instrumentation (e.g., TTFB logging).

--- a/tools/autoresearch/run.py
+++ b/tools/autoresearch/run.py
@@ -322,6 +322,7 @@ def main() -> None:
     is_fresh = not config_file.exists()
 
     platform_kind = ns.platform
+    source_dir = ns.source_dir or ""
     if not is_fresh:
         existing_config = read_config(workdir)
         platform_kind = str(existing_config.get("platform", "auto"))
@@ -329,10 +330,12 @@ def main() -> None:
         ns.local_execution_mode = str(
             existing_config.get("local_execution_mode", ns.local_execution_mode)
         )
+        source_dir = str(existing_config.get("source_dir", source_dir))
     platform_config = {
         "platform": platform_kind,
         "agent": ns.agent,
         "local_execution_mode": ns.local_execution_mode,
+        "source_dir": source_dir,
     }
     platform = create_platform(platform_config, workdir)
 

--- a/tools/autoresearch/tests/test_autoresearch_workflow.py
+++ b/tools/autoresearch/tests/test_autoresearch_workflow.py
@@ -17,6 +17,7 @@ from spdl.tools.autoresearch.plot_progress import (
     _load_tsv,
     _tree_font_sizes,
 )
+from spdl.tools.autoresearch.utils import prompts
 from spdl.tools.autoresearch.utils.commands.report import _read_failures
 from spdl.tools.autoresearch.utils.commands.status import _failure_summary
 from spdl.tools.autoresearch.utils.platform import _MetricsEvidence, create_platform
@@ -211,9 +212,31 @@ class _AutoresearchWorkflowTest(unittest.TestCase):
             ("step_ms", 12.5),
             _compare_metric_value({"steady_step_time_ms": 12.5, "duration_s": 100}),
         )
+        # Both fetch and decode flags present → sum them.
         self.assertEqual(
             24,
             _extract_total_threads("--num-fetch-threads 8 --num-decode-threads 16"),
+        )
+        # Only --num-threads → use it directly.
+        self.assertEqual(
+            12,
+            _extract_total_threads("--num-threads 12"),
+        )
+        # Only one of fetch/decode → default the other half.
+        self.assertEqual(
+            24,
+            _extract_total_threads("--num-fetch-threads 8"),
+        )
+        self.assertEqual(
+            24,
+            _extract_total_threads("--num-decode-threads 16"),
+        )
+        # No thread flags at all → None (unknown, not 24).
+        self.assertIsNone(
+            _extract_total_threads("--num_workers 8 --num_epochs 3"),
+        )
+        self.assertIsNone(
+            _extract_total_threads(""),
         )
         self.assertEqual(
             ["ok"],
@@ -223,6 +246,19 @@ class _AutoresearchWorkflowTest(unittest.TestCase):
                     [
                         {"name": "ok", "launch_command": "--num-threads 8"},
                         {"name": "too_many", "launch_command": "--num-threads 64"},
+                    ],
+                    16,
+                )
+            ],
+        )
+        # Commands with no thread flags pass validation (unknown budget).
+        self.assertEqual(
+            ["pass_through"],
+            [
+                spec["name"]
+                for spec in _validate_thread_budget(
+                    [
+                        {"name": "pass_through", "launch_command": "--num_workers 8"},
                     ],
                     16,
                 )
@@ -584,6 +620,41 @@ class _AutoresearchWorkflowTest(unittest.TestCase):
 
         self.assertIn("failed during job startup", prompt)
         self.assertIn("job_startup_failed", prompt)
+
+    def test_headspace_node_uses_dedicated_prompt_with_knowledge(self) -> None:
+        platform = create_platform({"platform": "local", "agent": "mock"})
+        assert isinstance(platform.agent, _MockAgent)
+        platform.agent.responses["prompt:headspace"] = (
+            "headspace prompt __KNOWLEDGE__ __PIPELINE_CODE__"
+        )
+
+        prompt = _build_apply_prompt(
+            platform,
+            {
+                "name": "headspace_cache",
+                "description": "Wrap with CacheDataLoader for headspace analysis",
+                "_is_headspace": True,
+            },
+            "000_headspace",
+            "knowledge",
+            "/tmp/pipeline.py",
+            "def main():\n    pass\n",
+        )
+
+        self.assertIn("headspace prompt", prompt)
+        self.assertIn("knowledge", prompt)
+        self.assertIn("def main", prompt)
+
+    def test_headspace_prompt_requires_stop_after(self) -> None:
+        prompt = prompts._load_prompt(
+            "headspace",
+            KNOWLEDGE="",
+            PIPELINE_SCRIPT="/tmp/pipeline.py",
+            PIPELINE_CODE="def main():\n    pass\n",
+        )
+
+        self.assertIn("stop_after=500", prompt)
+        self.assertIn("must include `stop_after=500`", prompt)
 
     def test_tree_edge_label_describes_experiment_evolution(self) -> None:
         parent = {"node_id": "001_parent", "name": "parent", "spec": {}}

--- a/tools/autoresearch/utils/workflow/planning_ops.py
+++ b/tools/autoresearch/utils/workflow/planning_ops.py
@@ -145,11 +145,25 @@ def _get_plan(
     findings_file = workdir / "findings.md"
     findings = findings_file.read_text() if findings_file.exists() else "(none yet)"
     cap = _thread_cap_for_experiment(state, config)
-    notes = config.get("notes", "") + (
+    base_cmd = config.get("base_launch_command", "")
+    base_threads = _extract_total_threads(base_cmd)
+    thread_note = (
         f"\n\n**CPU THREAD BUDGET (HARD LIMIT):** Total threads per rank "
-        f"(num_fetch_threads + num_decode_threads) must not exceed {cap}. "
-        f"Experiments exceeding this will be rejected automatically."
+        f"must not exceed {cap}. This is enforced via `--num_threads`, or the "
+        f"sum of `--num_fetch_threads` + `--num_decode_threads` in the launch "
+        f"command. Experiments exceeding this will be rejected automatically."
     )
+    if base_threads is not None:
+        thread_note += (
+            f" The base launch command currently uses {base_threads} threads."
+        )
+    else:
+        thread_note += (
+            " The base launch command does not set explicit thread flags, so "
+            "thread budget validation is skipped for commands that also omit "
+            "them. If you add thread flags, keep the total within the cap."
+        )
+    notes = config.get("notes", "") + thread_note
 
     prompt = platform.agent._load_prompt(
         "plan_next",

--- a/tools/autoresearch/utils/workflow/policy.py
+++ b/tools/autoresearch/utils/workflow/policy.py
@@ -169,8 +169,13 @@ def _compare_metric_value(metrics: Mapping[str, object]) -> tuple[str, float]:
 
 
 def _extract_total_threads(launch_cmd: str) -> int | None:
-    fetch = 8
-    decode = 16
+    """Extract the total CPU thread count from a launch command.
+
+    Returns ``None`` when no recognised thread flag is present, so callers
+    can distinguish "unknown" from "explicitly set".
+    """
+    fetch: int | None = None
+    decode: int | None = None
     match = re.search(r"--num[_-]fetch[_-]threads?\s+(\d+)", launch_cmd)
     if match:
         fetch = int(match.group(1))
@@ -180,7 +185,11 @@ def _extract_total_threads(launch_cmd: str) -> int | None:
     match = re.search(r"--num[_-]threads?\s+(\d+)", launch_cmd)
     if match:
         return int(match.group(1))
-    return fetch + decode
+    # If at least one of fetch/decode was explicitly set, use defaults for the
+    # missing half so the budget estimate is meaningful.
+    if fetch is not None or decode is not None:
+        return (fetch or 8) + (decode or 16)
+    return None
 
 
 def _validate_thread_budget(experiments: list[dict], cap: int) -> list[dict]:

--- a/tools/autoresearch/utils/workflow/source_ops.py
+++ b/tools/autoresearch/utils/workflow/source_ops.py
@@ -42,6 +42,13 @@ def _build_apply_prompt(
     pipeline_script: str,
     pipeline_code: str,
 ) -> str:
+    if exp.get("_is_headspace"):
+        return platform.agent._load_prompt(
+            "headspace",
+            KNOWLEDGE=knowledge,
+            PIPELINE_SCRIPT=pipeline_script,
+            PIPELINE_CODE=pipeline_code,
+        )
     if exp.get("_startup_retry_attempt"):
         return platform.agent._load_prompt(
             "apply_startup_repair",


### PR DESCRIPTION
Fix two issues in the autoresearch engine:

1. **Headspace prompt fix**: Headspace experiments now use the dedicated `headspace` prompt instead of the generic apply-changes prompt, so the agent sees the required `CacheDataLoader(..., stop_after=500)` instruction and the shared knowledge context.

2. **Thread budget false-positive fix**: `_extract_total_threads()` previously defaulted to `fetch=8 + decode=16 = 24` when no thread-related flags were found in the launch command. Pipelines that use `--num_workers` instead of `--num_fetch_threads`/`--num_decode_threads` were falsely scored at 24 threads, causing all follow-up experiments to be rejected against the cap of 16. Now the function returns `None` when no thread flags are found, and `_validate_thread_budget` passes experiments with unknown thread counts through. The planning prompt NOTES are also updated to explain the actual thread detection behavior to the coding agent.