### PR TITLE
[autoresearch] Clarify num_threads concurrency rule

### DIFF
--- a/tools/autoresearch/prompts/plan_next.md
+++ b/tools/autoresearch/prompts/plan_next.md
@@ -90,9 +90,10 @@ Before you can consider stopping, ALL of the following must have been attempted 
 3. **`concurrency_tuning`** — Adjust concurrency of the bottleneck stage. Try at least 2 different values.
 
    **Important — threads vs concurrency**:
-   - `PipelineBuilder.build(num_threads=N)` sets the thread pool size for the entire pipeline. Set this mechanically to `num_CPU_cores / num_GPU_workers` (or the number of allocated CPU cores per rank). This is NOT a tuning knob — it's a resource budget.
-   - `.pipe(fn, concurrency=C)` controls how many concurrent tasks run in a specific stage. THIS is the value to tune. The sum of all stage concurrencies should stay within the `num_threads` budget.
-   - For MTP subprocess mode, `run_pipeline_in_subprocess(config, num_threads=N)` — same rule: set `N` to `num_CPU_cores / num_GPU_workers`.
+   - `PipelineBuilder.build(num_threads=N)` sets the default executor thread pool size for the pipeline. Set this mechanically from the CPU cores available to each rank. If instrumentation reports the assigned CPU core count per rank, use that exact value. Otherwise use roughly 16-20 as the maximum practical value. This is NOT a tuning knob — it is the CPU resource budget.
+   - `.pipe(fn, concurrency=C)` controls how many concurrent tasks run in a specific stage. THIS is the value to tune. Do NOT set `num_threads` to the sum of all stage concurrencies.
+   - Requirement: `num_threads >= max(concurrency)` for stages that use the pipeline's default executor. Stages that use a dedicated `executor=` are governed by that executor's worker count instead.
+   - For MTP subprocess mode, `run_pipeline_in_subprocess(config, num_threads=N)` follows the same rule: `N` is the CPU-core budget per rank and must be at least the max default-executor stage concurrency.
    - **`spdl.pipeline.PriorityThreadPoolExecutor`** should be tried as part of concurrency tuning. It shares a single thread pool across all pipeline stages but prioritizes downstream stages (closer to output) over upstream ones, reducing end-to-end latency with no expected downside. Try it in at least one standalone experiment (without other changes) to verify the improvement, then combine it with other verified improvements (MTP, torch.compile, etc.) in later experiments. Usage: create one pool (`pool = PriorityThreadPoolExecutor(max_workers=N)`), then pass `executor=pool.get_executor()` to each CPU-bound `.pipe()` call — executors created later automatically get higher priority. It supports pickle for use with `run_pipeline_in_subprocess()`.
      **Critical PriorityThreadPoolExecutor rules:**
      - Do NOT pass `executor=` to GPU stages like `transfer_tensor` — GPU transfer must run on the pipeline's own thread, not in the CPU pool.
@@ -144,7 +145,7 @@ Propose **2-3 experiments per iteration** to make efficient use of compute. The 
    - Model the parameter → metric relationship from history
    - Pick values that maximize expected improvement
    - Balance exploration (untested regions) vs exploitation (near the current best)
-   - **HARD CONSTRAINT**: Total threads per rank (num_fetch_threads + num_decode_threads) must not exceed the cap stated in Additional Context. Experiments exceeding this are rejected automatically.
+   - **HARD CONSTRAINT**: `num_threads` must not exceed the cap stated in Additional Context, and must be at least the max default-executor stage concurrency. Do not add stage concurrencies together to derive `num_threads`.
 
 6. **Combine independently verified improvements**: Scan the Master Table for experiments that each improved over baseline via *different, orthogonal* changes (e.g., MTP improved step time, PriorityThreadPoolExecutor improved scheduling, torch.compile improved compute). When two or more such improvements exist, propose a **combination experiment** that applies all of them together. The combined gain is often larger than the sum of individual gains because the improvements target different bottlenecks. Describe ALL changes in the `"description"` field. Prioritize combinations of the best-performing variant of each independent idea.
 

--- a/tools/autoresearch/tests/test_autoresearch_workflow.py
+++ b/tools/autoresearch/tests/test_autoresearch_workflow.py
@@ -52,6 +52,7 @@ from spdl.tools.autoresearch.utils.workflow.failures import (
 from spdl.tools.autoresearch.utils.workflow.policy import (
     _change_summary_for_spec,
     _compare_metric_value,
+    _extract_default_executor_concurrency,
     _extract_total_threads,
     _node_from_spec,
     _retry_policy_for_failure,
@@ -212,26 +213,30 @@ class _AutoresearchWorkflowTest(unittest.TestCase):
             ("step_ms", 12.5),
             _compare_metric_value({"steady_step_time_ms": 12.5, "duration_s": 100}),
         )
-        # Both fetch and decode flags present → sum them.
-        self.assertEqual(
-            24,
-            _extract_total_threads("--num-fetch-threads 8 --num-decode-threads 16"),
-        )
         # Only --num-threads → use it directly.
         self.assertEqual(
             12,
             _extract_total_threads("--num-threads 12"),
         )
-        # Only one of fetch/decode → default the other half.
-        self.assertEqual(
-            24,
-            _extract_total_threads("--num-fetch-threads 8"),
+        # Stage concurrency flags are not additive thread budgets.
+        self.assertIsNone(
+            _extract_total_threads("--num-fetch-threads 8 --num-decode-threads 16"),
         )
         self.assertEqual(
-            24,
-            _extract_total_threads("--num-decode-threads 16"),
+            16,
+            _extract_default_executor_concurrency(
+                "--num-fetch-threads 8 --num-decode-threads 16"
+            ),
         )
-        # No thread flags at all → None (unknown, not 24).
+        self.assertEqual(
+            8,
+            _extract_default_executor_concurrency("--num-fetch-threads 8"),
+        )
+        self.assertEqual(
+            16,
+            _extract_default_executor_concurrency("--num-decode-threads 16"),
+        )
+        # No num_threads flag at all → None (unknown budget).
         self.assertIsNone(
             _extract_total_threads("--num_workers 8 --num_epochs 3"),
         )
@@ -239,13 +244,25 @@ class _AutoresearchWorkflowTest(unittest.TestCase):
             _extract_total_threads(""),
         )
         self.assertEqual(
-            ["ok"],
+            ["ok", "fits_concurrency"],
             [
                 spec["name"]
                 for spec in _validate_thread_budget(
                     [
                         {"name": "ok", "launch_command": "--num-threads 8"},
                         {"name": "too_many", "launch_command": "--num-threads 64"},
+                        {
+                            "name": "too_small",
+                            "launch_command": (
+                                "--num-threads 8 --num-decode-threads 16"
+                            ),
+                        },
+                        {
+                            "name": "fits_concurrency",
+                            "launch_command": (
+                                "--num-threads 16 --num-decode-threads 16"
+                            ),
+                        },
                     ],
                     16,
                 )

--- a/tools/autoresearch/utils/workflow/planning_ops.py
+++ b/tools/autoresearch/utils/workflow/planning_ops.py
@@ -20,6 +20,7 @@ from ..types import _AnalysisResult, _HypothesisNode
 from .common import _current_best_metric, _read_pipeline_code
 from .policy import (
     _change_summary_for_spec,
+    _extract_default_executor_concurrency,
     _extract_total_threads,
     _validate_thread_budget as _policy_validate_thread_budget,
 )
@@ -96,11 +97,14 @@ def _validate_thread_budget(experiments: list[dict], cap: int) -> list[dict]:
     valid_ids = {id(exp) for exp in valid}
     for exp in experiments:
         if id(exp) not in valid_ids:
-            total = _extract_total_threads(exp.get("launch_command", ""))
+            command = exp.get("launch_command", "")
+            total = _extract_total_threads(command)
+            concurrency = _extract_default_executor_concurrency(command)
             _LG.warning(
-                "Rejecting %s: %d threads exceeds cap of %d",
+                "Rejecting %s: num_threads=%s concurrency=%s cap=%d",
                 exp.get("name", "?"),
-                total or 0,
+                total,
+                concurrency,
                 cap,
             )
     return valid
@@ -149,9 +153,12 @@ def _get_plan(
     base_threads = _extract_total_threads(base_cmd)
     thread_note = (
         f"\n\n**CPU THREAD BUDGET (HARD LIMIT):** Total threads per rank "
-        f"must not exceed {cap}. This is enforced via `--num_threads`, or the "
-        f"sum of `--num_fetch_threads` + `--num_decode_threads` in the launch "
-        f"command. Experiments exceeding this will be rejected automatically."
+        f"must not exceed {cap}. Use the CPU cores assigned per rank when "
+        f"instrumentation reports it; otherwise use roughly 16-20 as the "
+        f"maximum practical value. This is enforced via `--num_threads`. "
+        f"For stages using the default executor, `num_threads` must be at "
+        f"least the maximum stage concurrency, not the sum of all stage "
+        f"concurrencies."
     )
     if base_threads is not None:
         thread_note += (
@@ -159,9 +166,10 @@ def _get_plan(
         )
     else:
         thread_note += (
-            " The base launch command does not set explicit thread flags, so "
+            " The base launch command does not set explicit `num_threads`, so "
             "thread budget validation is skipped for commands that also omit "
-            "them. If you add thread flags, keep the total within the cap."
+            "it. If you add `num_threads`, keep it within the cap and at least "
+            "as large as the max default-executor stage concurrency."
         )
     notes = config.get("notes", "") + thread_note
 

--- a/tools/autoresearch/utils/workflow/policy.py
+++ b/tools/autoresearch/utils/workflow/policy.py
@@ -47,6 +47,7 @@ __all__ = [
     "_change_summary_for_spec",
     "_compare_metric_value",
     "_extract_counter",
+    "_extract_default_executor_concurrency",
     "_extract_total_threads",
     "_initial_experiments_finished",
     "_is_duplicate_spec",
@@ -169,35 +170,51 @@ def _compare_metric_value(metrics: Mapping[str, object]) -> tuple[str, float]:
 
 
 def _extract_total_threads(launch_cmd: str) -> int | None:
-    """Extract the total CPU thread count from a launch command.
+    """Extract the explicit pipeline CPU thread budget from a launch command.
 
-    Returns ``None`` when no recognised thread flag is present, so callers
-    can distinguish "unknown" from "explicitly set".
+    ``num_threads`` is the available CPU-core budget per rank. It is not the
+    sum of stage concurrencies such as fetch/decode concurrency. Returns
+    ``None`` when no explicit thread budget is present.
     """
-    fetch: int | None = None
-    decode: int | None = None
-    match = re.search(r"--num[_-]fetch[_-]threads?\s+(\d+)", launch_cmd)
-    if match:
-        fetch = int(match.group(1))
-    match = re.search(r"--num[_-]decode[_-]threads?\s+(\d+)", launch_cmd)
-    if match:
-        decode = int(match.group(1))
     match = re.search(r"--num[_-]threads?\s+(\d+)", launch_cmd)
     if match:
         return int(match.group(1))
-    # If at least one of fetch/decode was explicitly set, use defaults for the
-    # missing half so the budget estimate is meaningful.
-    if fetch is not None or decode is not None:
-        return (fetch or 8) + (decode or 16)
     return None
+
+
+def _extract_default_executor_concurrency(launch_cmd: str) -> int | None:
+    """Extract the max visible stage concurrency using the default executor.
+
+    Some entrypoints expose stage concurrency as launch flags. Those values are
+    not additive thread budgets; the requirement is ``num_threads >= max(C)``
+    for stages that use the pipeline's default executor.
+    """
+
+    values = [
+        int(match.group(1))
+        for match in re.finditer(
+            r"--num[_-](?:fetch|decode)[_-]threads?\s+(\d+)",
+            launch_cmd,
+        )
+    ]
+    return max(values) if values else None
 
 
 def _validate_thread_budget(experiments: list[dict], cap: int) -> list[dict]:
     valid = []
     for experiment in experiments:
         command = experiment.get("launch_command", "")
-        total = _extract_total_threads(command) if command else None
-        if total is not None and total > cap:
+        num_threads = _extract_total_threads(command) if command else None
+        if num_threads is not None and num_threads > cap:
+            continue
+        concurrency = (
+            _extract_default_executor_concurrency(command) if command else None
+        )
+        if (
+            num_threads is not None
+            and concurrency is not None
+            and num_threads < concurrency
+        ):
             continue
         valid.append(experiment)
     return valid


### PR DESCRIPTION
Update autoresearch planning so `num_threads` is treated as the CPU-core budget per rank, not as the sum of pipeline stage concurrencies. The planning prompt now tells agents to use the instrumented CPU core count when available, otherwise use roughly 16-20 as the maximum practical value. Stage concurrency remains the tuning knob, and the required invariant is `num_threads >= max(concurrency)` for stages using the default executor.

Update deterministic validation to cap only explicit `num_threads` and reject commands where explicit `num_threads` is smaller than visible default-executor stage concurrency. Fetch/decode concurrency flags are no longer added together as a thread budget.