### PR TITLE
[autoresearch] Redesign experiment dedup to use structured change sets

### DIFF
--- a/tools/autoresearch/prompts/plan_next.md
+++ b/tools/autoresearch/prompts/plan_next.md
@@ -170,6 +170,7 @@ Output your reasoning, then a JSON block:
   "experiments": [
     {
       "name": "<short_snake_case>",
+      "changes": ["<canonical_id_1>", "<canonical_id_2>"],
       "change_summary": "<2-5 word concise label for plots, e.g. raise fetch threads>",
       "description": "<what we are changing>",
       "hypothesis": "<why this should help>",
@@ -182,7 +183,8 @@ Output your reasoning, then a JSON block:
 ```
 
 Rules:
-- **Do NOT propose experiments that are semantically identical to existing ones**, even under a different name. Before proposing, check the Master Table for any run that used the same launch parameters (batch_size, num_workers, etc.) and code changes. If a configuration has been tested — regardless of what it was named — do not re-test it. The orchestrator also rejects duplicates with matching launch commands.
+- **`changes`** is the experiment's identity for dedup. List every modification as a short, canonical, snake_case identifier. For code changes use identifiers like `"torch_compile"`, `"fused_adamw"`, `"subprocess_mtp"`, `"priority_executor"`, `"cache_dataloader"`. For parameter changes use `"param_name=value"` format like `"batch_size=48"`, `"num_workers=16"`. Combination experiments list all changes (e.g. `["subprocess_mtp", "torch_compile"]`). Parameter changes are also auto-detected from launch command diffs, but code changes **must** be listed explicitly. The orchestrator rejects experiments whose change set matches a non-failed existing node.
+- **Do NOT propose experiments that are semantically identical to existing ones**, even under a different name. Before proposing, check the Master Table for any run that used the same launch parameters (batch_size, num_workers, etc.) and code changes. If a configuration has been tested — regardless of what it was named — do not re-test it.
 - Use `$IMAGE` as placeholder for the job image (the orchestrator substitutes it)
 - **`change_summary`** must be concise and operator-readable. Use 2-5 words describing the one change being tested. Do not put implementation detail here; keep that in `description`.
 - torchx entrypoint args use **underscores**, not dashes (e.g. `--num_threads`)

--- a/tools/autoresearch/tests/test_autoresearch_workflow.py
+++ b/tools/autoresearch/tests/test_autoresearch_workflow.py
@@ -50,10 +50,13 @@ from spdl.tools.autoresearch.utils.workflow.failures import (
     _make_failure,
 )
 from spdl.tools.autoresearch.utils.workflow.policy import (
+    _build_change_set,
     _change_summary_for_spec,
     _compare_metric_value,
     _extract_default_executor_concurrency,
+    _extract_param_changes,
     _extract_total_threads,
+    _is_duplicate_spec,
     _node_from_spec,
     _retry_policy_for_failure,
     _select_planning_node,
@@ -281,6 +284,257 @@ class _AutoresearchWorkflowTest(unittest.TestCase):
                 )
             ],
         )
+
+    # -- _extract_param_changes / _build_change_set / _is_duplicate_spec ------
+
+    def test_extract_param_changes_detects_flag_diffs(self) -> None:
+        base = "torchx run app --image $IMAGE --num_workers 8 --num_epochs 3"
+
+        # New flag added.
+        self.assertEqual(
+            ["batch_size=48"],
+            _extract_param_changes(base + " --batch_size 48", base),
+        )
+
+        # Flag value changed.
+        self.assertEqual(
+            ["num_workers=16"],
+            _extract_param_changes(
+                "torchx run app --image $IMAGE --num_workers 16 --num_epochs 3",
+                base,
+            ),
+        )
+
+        # No diff when identical.
+        self.assertEqual([], _extract_param_changes(base, base))
+
+        # Empty commands return nothing.
+        self.assertEqual([], _extract_param_changes("", base))
+        self.assertEqual([], _extract_param_changes(base, ""))
+
+    def test_extract_param_changes_normalizes_dashes(self) -> None:
+        base = "torchx run app --num-fetch-threads 8"
+        exp = "torchx run app --num-fetch-threads 16"
+        changes = _extract_param_changes(exp, base)
+        self.assertEqual(["num_fetch_threads=16"], changes)
+
+    def test_extract_param_changes_handles_negative_values(self) -> None:
+        base = "torchx run app --max_steps -1"
+        exp = "torchx run app --max_steps -2"
+        changes = _extract_param_changes(exp, base)
+        self.assertEqual(["max_steps=-2"], changes)
+
+    def test_build_change_set_merges_explicit_and_param_changes(self) -> None:
+        base = "torchx run --image $IMAGE --num_workers 8"
+        spec = {
+            "changes": ["torch_compile"],
+            "launch_command": base + " --batch_size 48",
+        }
+        result = _build_change_set(spec, base)
+        self.assertEqual(frozenset({"torch_compile", "batch_size=48"}), result)
+
+    def test_build_change_set_empty_for_baseline(self) -> None:
+        base = "torchx run --image $IMAGE --num_workers 8"
+        spec = {"changes": [], "launch_command": base}
+        self.assertEqual(frozenset(), _build_change_set(spec, base))
+
+    def test_build_change_set_normalizes_case(self) -> None:
+        spec = {"changes": ["Torch_Compile", " FUSED_ADAMW "]}
+        result = _build_change_set(spec, "")
+        self.assertEqual(frozenset({"torch_compile", "fused_adamw"}), result)
+
+    def test_duplicate_requires_matching_change_sets(self) -> None:
+        base = "torchx run --image $IMAGE --num_workers 8"
+        baseline = _HypothesisNode(
+            node_id="000_baseline",
+            name="baseline",
+            status="completed",
+            spec={"changes": [], "launch_command": base},
+        )
+        mtp = _HypothesisNode(
+            node_id="001_mtp",
+            name="subprocess_mtp",
+            status="completed",
+            spec={"changes": ["subprocess_mtp"], "launch_command": base},
+        )
+        nodes = [baseline, mtp]
+
+        # torch_compile: different code changes, same launch → NOT duplicate.
+        self.assertFalse(
+            _is_duplicate_spec(
+                {"changes": ["torch_compile"], "launch_command": base},
+                nodes,
+                base,
+            )
+        )
+
+        # fused_adamw: different code changes, same launch → NOT duplicate.
+        self.assertFalse(
+            _is_duplicate_spec(
+                {"changes": ["fused_adamw"], "launch_command": base},
+                nodes,
+                base,
+            )
+        )
+
+        # Exact same change set as baseline → IS duplicate.
+        self.assertTrue(
+            _is_duplicate_spec(
+                {"changes": [], "launch_command": base},
+                nodes,
+                base,
+            )
+        )
+
+        # Exact same change set as MTP → IS duplicate.
+        self.assertTrue(
+            _is_duplicate_spec(
+                {"changes": ["subprocess_mtp"], "launch_command": base},
+                nodes,
+                base,
+            )
+        )
+
+    def test_duplicate_distinguishes_param_only_experiments(self) -> None:
+        base = "torchx run --image $IMAGE --num_workers 8"
+        batch_48 = _HypothesisNode(
+            node_id="002_batch48",
+            name="batch_size_48",
+            status="completed",
+            spec={
+                "changes": [],
+                "launch_command": base + " --batch_size 48",
+            },
+        )
+        nodes = [batch_48]
+
+        # batch_size=64 has different param → NOT duplicate.
+        self.assertFalse(
+            _is_duplicate_spec(
+                {"changes": [], "launch_command": base + " --batch_size 64"},
+                nodes,
+                base,
+            )
+        )
+
+        # batch_size=48 again → IS duplicate.
+        self.assertTrue(
+            _is_duplicate_spec(
+                {"changes": [], "launch_command": base + " --batch_size 48"},
+                nodes,
+                base,
+            )
+        )
+
+    def test_duplicate_skips_failed_nodes(self) -> None:
+        base = "torchx run --image $IMAGE"
+        failed = _HypothesisNode(
+            node_id="003_oom",
+            name="batch_64",
+            status="failed",
+            spec={
+                "changes": [],
+                "launch_command": base + " --batch_size 64",
+            },
+        )
+        # Exact match of a failed node → NOT duplicate (allow retry).
+        self.assertFalse(
+            _is_duplicate_spec(
+                {"changes": [], "launch_command": base + " --batch_size 64"},
+                [failed],
+                base,
+            )
+        )
+
+    def test_duplicate_combination_vs_individual(self) -> None:
+        base = "torchx run --image $IMAGE"
+        mtp_only = _HypothesisNode(
+            node_id="001_mtp",
+            name="subprocess_mtp",
+            status="completed",
+            spec={"changes": ["subprocess_mtp"], "launch_command": base},
+        )
+        # Combination is not a dup of individual.
+        self.assertFalse(
+            _is_duplicate_spec(
+                {
+                    "changes": ["subprocess_mtp", "torch_compile"],
+                    "launch_command": base,
+                },
+                [mtp_only],
+                base,
+            )
+        )
+
+    def test_duplicate_backward_compat_no_changes_field(self) -> None:
+        base = "torchx run --image $IMAGE --num_workers 8"
+        # Old spec without changes field — change set is derived purely from
+        # launch command diffs.
+        old_node = _HypothesisNode(
+            node_id="002_batch48",
+            name="batch_size_48",
+            status="completed",
+            spec={"launch_command": base + " --batch_size 48"},
+        )
+
+        # Same param diff → duplicate.
+        self.assertTrue(
+            _is_duplicate_spec(
+                {"launch_command": base + " --batch_size 48"},
+                [old_node],
+                base,
+            )
+        )
+
+        # Different param → not duplicate.
+        self.assertFalse(
+            _is_duplicate_spec(
+                {"launch_command": base + " --batch_size 64"},
+                [old_node],
+                base,
+            )
+        )
+
+    def test_startup_retry_inherits_changes(self) -> None:
+        node = _HypothesisNode(
+            node_id="001_subprocess_mtp",
+            name="subprocess_mtp",
+            status="failed",
+            spec={
+                "name": "subprocess_mtp",
+                "changes": ["subprocess_mtp"],
+                "description": "try MTP",
+                "best_practices_tags": ["subprocess_mtp"],
+            },
+            failure=_make_failure(
+                FailureKind.JOB_STARTUP_FAILED,
+                FailurePhase.JOB,
+                "Tokenizer cannot pickle",
+            ),
+        )
+        retry = _startup_retry_spec(node, _config())
+        self.assertIsNotNone(retry)
+        assert retry is not None
+        self.assertEqual(["subprocess_mtp"], retry["changes"])
+
+    def test_initial_nodes_have_changes(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            adapter = self._adapter(Path(tmp))
+            specs = adapter.load()
+            nodes = []
+            for spec in specs:
+                node_data = spec.payload["node"]
+                assert isinstance(node_data, dict)
+                nodes.append(_HypothesisNode.from_dict(node_data))
+
+            by_name = {node.name: node for node in nodes}
+            self.assertEqual([], by_name["baseline"].spec["changes"])
+            self.assertEqual(
+                ["cache_dataloader"], by_name["headspace_cache"].spec["changes"]
+            )
+            self.assertEqual(
+                ["subprocess_mtp"], by_name["subprocess_mtp"].spec["changes"]
+            )
 
     def test_store_update_spec_refreshes_checkpoint_and_active_view(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/tools/autoresearch/utils/workflow/adapter.py
+++ b/tools/autoresearch/utils/workflow/adapter.py
@@ -169,7 +169,11 @@ class AutoresearchAdapter:
         children = []
         for child in result.children:
             node = _node_from_spec(child)
-            if _is_duplicate_spec(node.spec, self._store.tree.values()):
+            if _is_duplicate_spec(
+                node.spec,
+                self._store.tree.values(),
+                base_launch_command=self.config.get("base_launch_command", ""),
+            ):
                 _LG.info("Skipping duplicate experiment: %s", node.name)
                 continue
             parent = self._store.tree.get(node.parent_id) if node.parent_id else None

--- a/tools/autoresearch/utils/workflow/planning_ops.py
+++ b/tools/autoresearch/utils/workflow/planning_ops.py
@@ -289,6 +289,8 @@ def _plan_followups(
         _thread_cap_for_experiment(state, config),
     )
     for experiment in experiments:
+        if "changes" not in experiment:
+            experiment["changes"] = []
         experiment["change_summary"] = _change_summary_for_spec(experiment)
     _record_best_practices(state, {"experiments": experiments})
     state["_stop_overrides"] = 0
@@ -311,6 +313,7 @@ def _build_initial_nodes(workdir: Path, config: dict, state: dict) -> list:
                 name="baseline",
                 spec={
                     "name": "baseline",
+                    "changes": [],
                     "description": "Run the unchanged pipeline to establish baseline metrics",
                     "change_summary": "baseline",
                     "hypothesis": "Baseline measurement",
@@ -335,6 +338,7 @@ def _build_initial_nodes(workdir: Path, config: dict, state: dict) -> list:
                 name="headspace_cache",
                 spec={
                     "name": "headspace_cache",
+                    "changes": ["cache_dataloader"],
                     "description": "Wrap with CacheDataLoader for headspace analysis",
                     "change_summary": "headspace",
                     "hypothesis": (
@@ -356,6 +360,7 @@ def _build_initial_nodes(workdir: Path, config: dict, state: dict) -> list:
                 name="subprocess_mtp",
                 spec={
                     "name": "subprocess_mtp",
+                    "changes": ["subprocess_mtp"],
                     "description": (
                         "Run pipeline in subprocess to avoid background data "
                         "loading threads interfering with CUDA kernel launches"

--- a/tools/autoresearch/utils/workflow/policy.py
+++ b/tools/autoresearch/utils/workflow/policy.py
@@ -38,16 +38,19 @@ or LLM calls.
 from __future__ import annotations
 
 import re
+import shlex
 from collections.abc import Iterable, Mapping
 
 from ..runner import _WorkSpec
 from ..types import _HypothesisNode, _TERMINAL_STATUSES, FailureKind
 
 __all__ = [
+    "_build_change_set",
     "_change_summary_for_spec",
     "_compare_metric_value",
     "_extract_counter",
     "_extract_default_executor_concurrency",
+    "_extract_param_changes",
     "_extract_total_threads",
     "_initial_experiments_finished",
     "_is_duplicate_spec",
@@ -130,16 +133,119 @@ def _select_planning_node(
     return max(preferred or candidates, key=lambda node: _extract_counter(node.node_id))
 
 
-def _is_duplicate_spec(spec: dict, nodes: Iterable[_HypothesisNode]) -> bool:
-    name = spec.get("name", "")
-    launch_cmd = spec.get("launch_command", "")
+def _parse_flags(command: str) -> dict[str, str]:
+    """Parse ``--flag value`` pairs from a launch command into a dict.
+
+    Flag names are normalized: leading dashes are stripped, remaining dashes
+    become underscores, and the name is lowercased.  Both ``--flag value``
+    and ``--flag=value`` forms are supported.
+    """
+    try:
+        tokens = shlex.split(command)
+    except ValueError:
+        tokens = command.split()
+    flags: dict[str, str] = {}
+    i = 0
+    while i < len(tokens):
+        token = tokens[i]
+        if token.startswith("--"):
+            if "=" in token:
+                key, _, val = token.partition("=")
+                key = key.lstrip("-").replace("-", "_").lower()
+                flags[key] = val
+            elif i + 1 < len(tokens) and _is_flag_value(tokens[i + 1]):
+                key = token.lstrip("-").replace("-", "_").lower()
+                flags[key] = tokens[i + 1]
+                i += 1
+            else:
+                key = token.lstrip("-").replace("-", "_").lower()
+                flags[key] = ""
+        i += 1
+    return flags
+
+
+def _is_flag_value(token: str) -> bool:
+    if not token.startswith("-"):
+        return True
+    if token.startswith("--"):
+        return False
+    try:
+        float(token)
+    except ValueError:
+        return False
+    return True
+
+
+def _extract_param_changes(
+    launch_command: str,
+    base_launch_command: str,
+) -> list[str]:
+    """Return canonical ``flag=value`` identifiers for every flag that differs
+    between *launch_command* and *base_launch_command*.
+
+    Flags present in the experiment but absent from (or with a different value
+    in) the base command are included.  Flags removed from the base are also
+    included.
+    """
+    if not launch_command or not base_launch_command:
+        return []
+    exp_flags = _parse_flags(launch_command)
+    base_flags = _parse_flags(base_launch_command)
+    changes: list[str] = []
+    all_keys = sorted(set(exp_flags) | set(base_flags))
+    for key in all_keys:
+        exp_val = exp_flags.get(key)
+        base_val = base_flags.get(key)
+        if exp_val != base_val:
+            if exp_val is not None:
+                changes.append(f"{key}={exp_val}")
+            else:
+                changes.append(f"{key}=<removed>")
+    return changes
+
+
+def _build_change_set(
+    spec: dict,
+    base_launch_command: str = "",
+) -> frozenset[str]:
+    """Build the canonical set of change identifiers for an experiment spec.
+
+    Merges the explicit ``changes`` list with parameter diffs auto-extracted
+    from the launch command.  Each identifier is stripped and lowercased so
+    that ``"Torch_Compile"`` and ``"torch_compile"`` compare equal.
+    """
+    explicit = [
+        c.strip().lower() for c in spec.get("changes", []) if isinstance(c, str)
+    ]
+    param = _extract_param_changes(
+        spec.get("launch_command", ""),
+        base_launch_command,
+    )
+    return frozenset(explicit) | frozenset(p.lower() for p in param)
+
+
+def _is_duplicate_spec(
+    spec: dict,
+    nodes: Iterable[_HypothesisNode],
+    base_launch_command: str = "",
+) -> bool:
+    """Check whether *spec* duplicates a non-failed node in *nodes*.
+
+    Two experiments are duplicates when their change sets are equal.  The
+    change set is the union of the explicit ``changes`` list and the parameter
+    diffs auto-extracted by comparing each spec's ``launch_command`` against
+    *base_launch_command*.
+
+    Name and description are **not** used for dedup — they are labels, not
+    experiment identity.  Failed nodes are skipped so that a failed experiment
+    can be retried.
+    """
+    proposed = _build_change_set(spec, base_launch_command)
     for node in nodes:
         if node.status == "failed":
             continue
-        if name and node.name == name:
-            return True
-        existing = node.spec
-        if launch_cmd and existing.get("launch_command") == launch_cmd:
+        existing = _build_change_set(node.spec, base_launch_command)
+        if proposed == existing:
             return True
     return False
 
@@ -342,6 +448,7 @@ def _startup_retry_spec(node: _HypothesisNode, config: dict) -> dict | None:
 
     next_attempt = attempt + 1
     retry = dict(node.spec)
+    retry["changes"] = list(node.spec.get("changes", []))
     retry["name"] = f"{node.name}_startup_retry_{next_attempt}"
     retry["_startup_retry_attempt"] = next_attempt
     retry["_startup_retry_of"] = node.spec.get("_startup_retry_of", node.node_id)


### PR DESCRIPTION
Replace the broken OR-based dedup logic (`_is_duplicate_spec`) that compared experiment `name` or `launch_command` independently. The old approach caused false positives: code-change-only experiments like `torch_compile` and `fused_adamw` were rejected because they shared the same `launch_command` as baseline/MTP.

The new design introduces a structured `changes` field on each experiment spec — a list of short canonical identifiers (e.g. `["subprocess_mtp"]`, `["torch_compile", "batch_size=48"]`). Dedup now compares **change sets** computed by merging two sources:

1. Explicit `changes` list — authored by the LLM planning agent or hardcoded for initial experiments
2. Auto-extracted parameter diffs — `_extract_param_changes()` tokenizes the launch command against the base launch command and produces identifiers like `batch_size=48` for every flag that was added or changed

Two experiments are duplicates only when their computed change sets are equal. Name and description play no role in dedup.

Changes:
- `policy.py`: Added `_parse_flags`, `_extract_param_changes`, `_build_change_set`; redesigned `_is_duplicate_spec` to compare change sets; `_startup_retry_spec` explicitly inherits `changes`
- `planning_ops.py`: Added `changes` to initial baseline/headspace/MTP specs; defaults `changes=[]` for LLM-planned experiments missing the field
- `adapter.py`: Passes `base_launch_command` from config to `_is_duplicate_spec`
- `plan_next.md`: Added `changes` field to the LLM JSON output schema with documentation
- Tests: 13 new tests covering param extraction, change set building, dedup with code-change-only experiments, param-only experiments, combinations, failed node skipping, backward compat, startup retry inheritance, and initial node validation