### PR TITLE
Fix child experiments not inheriting parent code changes

### DIFF
--- a/tools/autoresearch/utils/workflow/policy.py
+++ b/tools/autoresearch/utils/workflow/policy.py
@@ -115,17 +115,25 @@ def _select_planning_node(
     completed_node: _HypothesisNode,
     tree: Mapping[str, _HypothesisNode],
 ) -> _HypothesisNode | None:
-    """Pick the non-headspace completed node that should trigger planning."""
+    """Pick the non-headspace completed node that should trigger planning.
+
+    Only successfully completed nodes can be planning parents.  Failed nodes
+    only get startup-retry children (handled earlier in the call chain), never
+    derived exploratory work that would inherit the broken code.
+    """
     if not _initial_experiments_finished(tree):
         return None
-    if not _is_headspace_node(completed_node):
-        if not _is_startup_failed_retry(completed_node):
-            return completed_node
+    if (
+        completed_node.status == "completed"
+        and not _is_headspace_node(completed_node)
+        and not _is_startup_failed_retry(completed_node)
+    ):
+        return completed_node
 
     candidates = [
         node
         for node in tree.values()
-        if node.status in _TERMINAL_STATUSES and not _is_headspace_node(node)
+        if node.status == "completed" and not _is_headspace_node(node)
     ]
     if not candidates:
         return None

--- a/tools/autoresearch/utils/workflow/source_ops.py
+++ b/tools/autoresearch/utils/workflow/source_ops.py
@@ -199,7 +199,13 @@ def _prepare_node(
     scm = config.get("scm", "")
     source_dir = config.get("source_dir", "")
     anchor = state.get("anchor_commit", "")
-    target_commit = exp.get("goto") or anchor
+    parent_ok = (
+        isinstance(parent, _HypothesisNode)
+        and parent.status == "completed"
+        and not parent.spec.get("_is_headspace")
+    )
+    parent_commit = node.commit if parent_ok else None
+    target_commit = exp.get("goto") or parent_commit or anchor
     if target_commit and scm and source_dir:
         try:
             platform.workspace.goto(scm, source_dir, target_commit, anchor)


### PR DESCRIPTION
When the engine creates child experiments (e.g., torch_compile_nw12 building on torch_compile), the code previously always checked out the anchor commit, discarding the parent's modifications. Child experiments would then only get the base instrumented code, not the parent's torch.compile/MTP changes.

The fix uses node.commit (inherited from the parent via _create_child_spec) as a fallback before the anchor commit. This makes child experiments check out the parent's commit, which contains the parent's code changes, before applying their own modifications.

Headspace experiments are excluded from this inheritance to prevent CacheDataLoader wrapper leaking into non-headspace children.