### PR TITLE
Show launch order and changes in hypothesis tree plot

### DIFF
--- a/tools/autoresearch/plot_progress.py
+++ b/tools/autoresearch/plot_progress.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import argparse
 import csv
+import json
 import sys
 from pathlib import Path
 
@@ -468,15 +469,15 @@ def _shorten(text: str, limit: int) -> str:
 
 def _edge_label(parent_node: dict, child_node: dict) -> str:
     spec = child_node.get("spec") or {}
-    value = spec.get("change_summary")
-    if value:
-        return _short_change_label(str(value))
     retry_attempt = spec.get("_startup_retry_attempt")
     if retry_attempt:
         return f"startup repair #{retry_attempt}"
-    tags = spec.get("best_practices_tags")
-    if isinstance(tags, list) and tags:
-        return _short_change_label(str(tags[0]))
+    changes = spec.get("changes")
+    if isinstance(changes, list) and changes:
+        return _short_change_label(", ".join(str(c) for c in changes))
+    value = spec.get("change_summary")
+    if value:
+        return _short_change_label(str(value))
     return _short_change_label(
         str(child_node.get("name", child_node.get("node_id", "")))
     )
@@ -552,7 +553,7 @@ def _draw_tree_edges(
                 )
 
 
-def _draw_tree_node(ax, nid, n, x, y, best_nid, fontsize):
+def _draw_tree_node(ax, nid, n, x, y, best_nid, fontsize, launch_order=None):
     box_w, box_h = 2.4, 1.0
     status = n.get("status", "queued")
     color = "#27ae60" if nid == best_nid else _STATUS_COLORS.get(status, "#ecf0f1")
@@ -574,6 +575,8 @@ def _draw_tree_node(ax, nid, n, x, y, best_nid, fontsize):
     name = n.get("name", nid)
     if len(name) > 20:
         name = name[:17] + "..."
+    if launch_order is not None:
+        name = f"#{launch_order} {name}"
     dur = n.get("duration")
     metric_str = f"\n{dur:.0f}s" if dur and dur > 0 else ""
     text_color = (
@@ -602,6 +605,11 @@ def _plot_hypothesis_tree(
         return
 
     nodes = {n["node_id"]: n for n in tree_data}
+    launched = sorted(
+        (n["node_id"] for n in tree_data if n.get("launched_at") is not None),
+        key=lambda nid: nodes[nid]["launched_at"],
+    )
+    launch_order = {nid: i for i, nid in enumerate(launched)}
     order, levels = _tree_bfs_order(nodes)
     x_pos, y_pos, level_counts = _compute_positions(order, levels)
     if not order:
@@ -634,6 +642,7 @@ def _plot_hypothesis_tree(
             y_pos[nid],
             best_nid,
             fonts["node"],
+            launch_order=launch_order.get(nid),
         )
 
     legend_items = [
@@ -685,6 +694,12 @@ def main() -> None:
     output = args.output or str(tsv_path.parent / "progress.png")
     experiments = _load_tsv(tsv_path)
     _plot_progress(experiments, output, args.title)
+
+    tree_file = tsv_path.parent / "engine" / "tree.json"
+    if tree_file.exists():
+        tree_output = str(tsv_path.parent / "hypothesis_tree.png")
+        tree_data = json.loads(tree_file.read_text())
+        _plot_hypothesis_tree(tree_data, tree_output, args.title)
 
 
 if __name__ == "__main__":

--- a/tools/autoresearch/prompts/knowledge/knowledge.md
+++ b/tools/autoresearch/prompts/knowledge/knowledge.md
@@ -94,7 +94,7 @@ Use pure multithreading in the main process instead:
 - Set decode stage concurrency to match GPU hardware decoder slots (7 for H100/B100; higher for sparse decoding patterns)
 - **Use a dedicated `ThreadPoolExecutor` for the decode stage** — do NOT share the pipeline's default thread pool. Create `ThreadPoolExecutor(max_workers=C)` and pass it via `executor=` to the decode `.pipe()` call. This avoids contention between NVDEC decode threads (which need their own CUDA contexts) and CPU fetch/processing threads
 
-`gpu_video_decode` and `subprocess_mtp` are **independent, mutually exclusive** optimization paths. They cannot be combined. GPU decode experiments must apply changes to the original instrumented pipeline, not on top of MTP changes. Compare their results independently to determine which approach yields better throughput.
+`gpu_video_decode` and `mtp` are **independent, mutually exclusive** optimization paths. They cannot be combined. GPU decode experiments must apply changes to the original instrumented pipeline, not on top of MTP changes. Compare their results independently to determine which approach yields better throughput.
 
 ### Headspace Analysis in the Loop
 

--- a/tools/autoresearch/prompts/plan_next.md
+++ b/tools/autoresearch/prompts/plan_next.md
@@ -21,7 +21,7 @@ __KNOWLEDGE__
 - **Already tried**: __BEST_PRACTICES_TRIED__
 - **Not yet tried**: __BEST_PRACTICES_REMAINING__
 
-Valid best practice tags: `subprocess_mtp`, `batch_size_tuning`, `concurrency_tuning`, `gpu_video_decode`
+Valid best practice tags: `mtp`, `batch_size_tuning`, `concurrency_tuning`, `gpu_video_decode`
 
 ### Master Table (all runs so far)
 
@@ -70,7 +70,7 @@ Do NOT compare experiments using raw average SM utilization — it is misleading
 
 Before you can consider stopping, ALL of the following must have been attempted (check the "Not yet tried" list above):
 
-1. **`subprocess_mtp`** — Apply the **full MTP pattern** from the knowledge base. This is the highest-impact optimization and includes continuous mode, subprocess isolation, and proper GPU transfer. **Follow the MTP section in the knowledge base.** Key points:
+1. **`mtp`** — Apply the **full MTP pattern** from the knowledge base. This is the highest-impact optimization and includes continuous mode, subprocess isolation, and proper GPU transfer. **Follow the MTP section in the knowledge base.** Key points:
    - **Critical — understand the existing code first**: Inspect the pipeline builder function's return type and structure. If it calls `.build()` or `.get_iterator()` (returning a `Pipeline` or iterator), the MTP refactor must change it to return a `PipelineConfig` (via `.get_config()`) or an unbuilt `PipelineBuilder` instead. `run_pipeline_in_subprocess()` accepts ONLY `PipelineConfig` — NOT `Pipeline` objects or iterators. Check type annotations and return statements.
    - **Separate CPU and GPU stages**: The backend pipeline (subprocess) must contain ONLY CPU-bound stages (fetch, decode, aggregate, collate). GPU stages like `transfer_tensor` require a CUDA context and MUST be in the frontend pipeline (main process). If the existing code includes `transfer_tensor` or similar GPU ops in the pipeline, exclude them from the backend config.
    - **Write the `description` field to explicitly instruct the code modifier** about these structural requirements, e.g.: "Refactor `build_pipeline()` to NOT call `.build()`. Instead, build a `PipelineBuilder` with only CPU stages (no `transfer_tensor`), call `.get_config()`, pass the config to `run_pipeline_in_subprocess(config, num_threads=N)`, then create a frontend `PipelineBuilder` that takes the subprocess iterable as source and applies `transfer_tensor`."
@@ -106,7 +106,7 @@ Before you can consider stopping, ALL of the following must have been attempted 
    - Create `CUDAConfig` with PyTorch allocator: `spdl.io.cuda_config(device_index=..., allocator=(torch.cuda.caching_allocator_alloc, torch.cuda.caching_allocator_delete))`.
    - **GPU decoder concurrency** — H100/B100 have 7 NVDEC instances per GPU, so set decode concurrency around 7. For sparse decoding patterns (sampling a few frames per file, not sequential decode), concurrency can exceed 7. Older GPUs (A100, V100) have 3–5 slots.
    - **Even dimensions required** — `scale_width` and `scale_height` must be even numbers.
-   - **NOT compatible with MTP (subprocess mode)** — `VideoPackets` are not picklable and cannot cross process boundaries. GPU video decode must run as a pure multithreaded pipeline in the main process (using `PipelineBuilder.build(num_threads=N)`). `gpu_video_decode` is an **independent optimization path** from `subprocess_mtp` — they are mutually exclusive alternatives, not stackable. The GPU decode experiment must apply its changes to the original instrumented pipeline (not on top of MTP changes). Do NOT set `goto` to an MTP commit.
+   - **NOT compatible with MTP (subprocess mode)** — `VideoPackets` are not picklable and cannot cross process boundaries. GPU video decode must run as a pure multithreaded pipeline in the main process (using `PipelineBuilder.build(num_threads=N)`). `gpu_video_decode` is an **independent optimization path** from `mtp` — they are mutually exclusive alternatives, not stackable. The GPU decode experiment must apply its changes to the original instrumented pipeline (not on top of MTP changes). Do NOT set `goto` to an MTP commit.
    - **Use a dedicated `ThreadPoolExecutor` for the NVDEC decode stage** — do NOT share the pipeline's default thread pool. Create `ThreadPoolExecutor(max_workers=C)` and pass it via `executor=` to the decode `.pipe()` call. This prevents NVDEC decode threads (which need their own CUDA contexts) from competing with CPU fetch threads.
    - Write the `description` field with explicit instructions, e.g.: "Replace `spdl.io.decode_packets(packets)` + `convert_frames` + `transfer_buffer` with `spdl.io.decode_packets_nvdec(packets, device_config=cuda_cfg, pix_fmt='rgb')`. Remove the `transfer_buffer`/`transfer_tensor` stage since data is already on GPU. Set decode concurrency to 7. Use a dedicated `ThreadPoolExecutor(7)` for the decode stage via `executor=ThreadPoolExecutor(7)`. Create `cuda_cfg` using `spdl.io.cuda_config(device_index, allocator=(torch.cuda.caching_allocator_alloc, torch.cuda.caching_allocator_delete))`. Use pure multithreading (no subprocess MTP)."
 
@@ -120,9 +120,9 @@ Propose **2-3 experiments per iteration** to make efficient use of compute. The 
 
 1. **If best practices remain untried**: Propose experiments that cover them. Prioritize structural changes (MTP) over parameter tuning.
 
-   **MTP retry logic**: If a previous `subprocess_mtp` experiment failed (subprocess crash, 0 batches, silent death), check the experiment history to understand what approach was used. The knowledge base describes a two-tier approach:
+   **MTP retry logic**: If a previous `mtp` experiment failed (subprocess crash, 0 batches, silent death), check the experiment history to understand what approach was used. The knowledge base describes a two-tier approach:
    - If Tier 1 was tried (module-level functions with `functools.partial`, re-creating objects in subprocess) and failed, retry with Tier 2 (picklable callable classes that pickle objects directly from the main process, avoiding subprocess imports). Write the `description` field to explicitly specify "Use Tier 2 pickling approach — pickle tokenizer/data objects directly instead of re-creating them in the subprocess."
-   - Do NOT mark `subprocess_mtp` as tried until at least one MTP attempt has succeeded or both tiers have been tried.
+   - Do NOT mark `mtp` as tried until at least one MTP attempt has succeeded or both tiers have been tried.
 
 2. **Use headspace to guide priorities**: Look at the headspace result in the Master Table (the `headspace_cache` row). If headspace is **less than 10%**, data loading is NOT the bottleneck — pivot immediately to model-side optimizations:
    - `torch.compile` — often the single biggest win (20-40% step time reduction)
@@ -183,7 +183,7 @@ Output your reasoning, then a JSON block:
 ```
 
 Rules:
-- **`changes`** is the experiment's identity for dedup. List every modification as a short, canonical, snake_case identifier. For code changes use identifiers like `"torch_compile"`, `"fused_adamw"`, `"subprocess_mtp"`, `"priority_executor"`, `"cache_dataloader"`. For parameter changes use `"param_name=value"` format like `"batch_size=48"`, `"num_workers=16"`. Combination experiments list all changes (e.g. `["subprocess_mtp", "torch_compile"]`). Parameter changes are also auto-detected from launch command diffs, but code changes **must** be listed explicitly. The orchestrator rejects experiments whose change set matches a non-failed existing node.
+- **`changes`** is the experiment's identity for dedup. List every modification as a short, canonical, snake_case identifier. For code changes use identifiers like `"torch_compile"`, `"fused_adamw"`, `"mtp"`, `"priority_executor"`, `"cache_dataloader"`. For parameter changes use `"param_name=value"` format like `"batch_size=48"`, `"num_workers=16"`. Combination experiments list all changes (e.g. `["mtp", "torch_compile"]`). Parameter changes are also auto-detected from launch command diffs, but code changes **must** be listed explicitly. The orchestrator rejects experiments whose change set matches a non-failed existing node.
 - **Do NOT propose experiments that are semantically identical to existing ones**, even under a different name. Before proposing, check the Master Table for any run that used the same launch parameters (batch_size, num_workers, etc.) and code changes. If a configuration has been tested — regardless of what it was named — do not re-test it.
 - Use `$IMAGE` as placeholder for the job image (the orchestrator substitutes it)
 - **`change_summary`** must be concise and operator-readable. Use 2-5 words describing the one change being tested. Do not put implementation detail here; keep that in `description`.

--- a/tools/autoresearch/run.py
+++ b/tools/autoresearch/run.py
@@ -181,7 +181,7 @@ def _init_workdir(
         "job_timeout_s": ns.job_timeout,
         "poll_interval": ns.poll_interval,
         "startup_failure_retries": 2,
-        "startup_retryable_experiments": ["subprocess_mtp"],
+        "startup_retryable_experiments": ["mtp"],
         "platform": ns.platform,
         "agent": ns.agent,
         "local_execution_mode": ns.local_execution_mode,

--- a/tools/autoresearch/tests/test_autoresearch_workflow.py
+++ b/tools/autoresearch/tests/test_autoresearch_workflow.py
@@ -109,7 +109,7 @@ class _AutoresearchWorkflowTest(unittest.TestCase):
             specs = adapter.load()
 
             self.assertEqual(
-                ["000_baseline", "000_headspace", "001_subprocess_mtp"],
+                ["000_baseline", "000_headspace", "001_mtp"],
                 [spec.id for spec in specs],
             )
             self.assertEqual([-1000, -999, -998], [spec.priority for spec in specs])
@@ -135,7 +135,7 @@ class _AutoresearchWorkflowTest(unittest.TestCase):
             self.assertEqual(2, engine_state["queued"])
             self.assertEqual(1, engine_state["running"])
             self.assertEqual(
-                ["000_headspace", "001_subprocess_mtp"], [q["node_id"] for q in queue]
+                ["000_headspace", "001_mtp"], [q["node_id"] for q in queue]
             )
             self.assertEqual([], active)
             self.assertEqual("queued\n", baseline_status)
@@ -150,7 +150,7 @@ class _AutoresearchWorkflowTest(unittest.TestCase):
             loaded = self._adapter(workdir).load()
 
             self.assertEqual(
-                ["000_headspace", "001_subprocess_mtp", "000_baseline"],
+                ["000_headspace", "001_mtp", "000_baseline"],
                 [spec.id for spec in loaded],
             )
 
@@ -166,8 +166,8 @@ class _AutoresearchWorkflowTest(unittest.TestCase):
             status="queued",
         )
         mtp = _HypothesisNode(
-            node_id="001_subprocess_mtp",
-            name="subprocess_mtp",
+            node_id="001_mtp",
+            name="mtp",
             status="completed",
         )
 
@@ -195,8 +195,8 @@ class _AutoresearchWorkflowTest(unittest.TestCase):
             spec={"_is_headspace": True},
         )
         mtp = _HypothesisNode(
-            node_id="001_subprocess_mtp",
-            name="subprocess_mtp",
+            node_id="001_mtp",
+            name="mtp",
             status="completed",
         )
 
@@ -353,9 +353,9 @@ class _AutoresearchWorkflowTest(unittest.TestCase):
         )
         mtp = _HypothesisNode(
             node_id="001_mtp",
-            name="subprocess_mtp",
+            name="mtp",
             status="completed",
-            spec={"changes": ["subprocess_mtp"], "launch_command": base},
+            spec={"changes": ["mtp"], "launch_command": base},
         )
         nodes = [baseline, mtp]
 
@@ -389,7 +389,7 @@ class _AutoresearchWorkflowTest(unittest.TestCase):
         # Exact same change set as MTP → IS duplicate.
         self.assertTrue(
             _is_duplicate_spec(
-                {"changes": ["subprocess_mtp"], "launch_command": base},
+                {"changes": ["mtp"], "launch_command": base},
                 nodes,
                 base,
             )
@@ -450,15 +450,15 @@ class _AutoresearchWorkflowTest(unittest.TestCase):
         base = "torchx run --image $IMAGE"
         mtp_only = _HypothesisNode(
             node_id="001_mtp",
-            name="subprocess_mtp",
+            name="mtp",
             status="completed",
-            spec={"changes": ["subprocess_mtp"], "launch_command": base},
+            spec={"changes": ["mtp"], "launch_command": base},
         )
         # Combination is not a dup of individual.
         self.assertFalse(
             _is_duplicate_spec(
                 {
-                    "changes": ["subprocess_mtp", "torch_compile"],
+                    "changes": ["mtp", "torch_compile"],
                     "launch_command": base,
                 },
                 [mtp_only],
@@ -497,14 +497,14 @@ class _AutoresearchWorkflowTest(unittest.TestCase):
 
     def test_startup_retry_inherits_changes(self) -> None:
         node = _HypothesisNode(
-            node_id="001_subprocess_mtp",
-            name="subprocess_mtp",
+            node_id="001_mtp",
+            name="mtp",
             status="failed",
             spec={
-                "name": "subprocess_mtp",
-                "changes": ["subprocess_mtp"],
+                "name": "mtp",
+                "changes": ["mtp"],
                 "description": "try MTP",
-                "best_practices_tags": ["subprocess_mtp"],
+                "best_practices_tags": ["mtp"],
             },
             failure=_make_failure(
                 FailureKind.JOB_STARTUP_FAILED,
@@ -515,7 +515,7 @@ class _AutoresearchWorkflowTest(unittest.TestCase):
         retry = _startup_retry_spec(node, _config())
         self.assertIsNotNone(retry)
         assert retry is not None
-        self.assertEqual(["subprocess_mtp"], retry["changes"])
+        self.assertEqual(["mtp"], retry["changes"])
 
     def test_initial_nodes_have_changes(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -532,9 +532,7 @@ class _AutoresearchWorkflowTest(unittest.TestCase):
             self.assertEqual(
                 ["cache_dataloader"], by_name["headspace_cache"].spec["changes"]
             )
-            self.assertEqual(
-                ["subprocess_mtp"], by_name["subprocess_mtp"].spec["changes"]
-            )
+            self.assertEqual(["mtp"], by_name["mtp"].spec["changes"])
 
     def test_store_update_spec_refreshes_checkpoint_and_active_view(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -576,7 +574,7 @@ class _AutoresearchWorkflowTest(unittest.TestCase):
                 name="retry",
                 status="queued",
                 spec={
-                    "_startup_retry_of": "001_subprocess_mtp",
+                    "_startup_retry_of": "001_mtp",
                     "_startup_retry_attempt": 1,
                 },
             )
@@ -588,7 +586,7 @@ class _AutoresearchWorkflowTest(unittest.TestCase):
             )
 
             queue = json.loads((workdir / "engine" / "queue.json").read_text())
-            self.assertEqual("001_subprocess_mtp", queue[0]["retry_of"])
+            self.assertEqual("001_mtp", queue[0]["retry_of"])
             self.assertEqual(1, queue[0]["retry_attempt"])
 
     def test_store_rejects_malformed_checkpoint(self) -> None:
@@ -771,13 +769,13 @@ class _AutoresearchWorkflowTest(unittest.TestCase):
 
     def test_startup_failure_retry_is_bounded_for_mtp(self) -> None:
         node = _HypothesisNode(
-            node_id="001_subprocess_mtp",
-            name="subprocess_mtp",
+            node_id="001_mtp",
+            name="mtp",
             status="failed",
             spec={
-                "name": "subprocess_mtp",
+                "name": "mtp",
                 "description": "try MTP",
-                "best_practices_tags": ["subprocess_mtp"],
+                "best_practices_tags": ["mtp"],
             },
             failure=_make_failure(
                 FailureKind.JOB_STARTUP_FAILED,
@@ -789,7 +787,7 @@ class _AutoresearchWorkflowTest(unittest.TestCase):
         retry = _startup_retry_spec(node, _config())
         self.assertIsNotNone(retry)
         assert retry is not None
-        self.assertEqual("subprocess_mtp_startup_retry_1", retry["name"])
+        self.assertEqual("mtp_startup_retry_1", retry["name"])
         self.assertEqual(1, retry["_startup_retry_attempt"])
         self.assertIn("pickling", retry["hypothesis"])
 
@@ -798,9 +796,9 @@ class _AutoresearchWorkflowTest(unittest.TestCase):
 
     def test_retry_policy_is_kind_specific(self) -> None:
         node = _HypothesisNode(
-            node_id="001_subprocess_mtp",
-            name="subprocess_mtp",
-            spec={"best_practices_tags": ["subprocess_mtp"]},
+            node_id="001_mtp",
+            name="mtp",
+            spec={"best_practices_tags": ["mtp"]},
             failure=_make_failure(
                 FailureKind.JOB_STARTUP_FAILED,
                 FailurePhase.JOB,
@@ -832,8 +830,8 @@ class _AutoresearchWorkflowTest(unittest.TestCase):
             spec={"_is_headspace": True},
         )
         mtp = _HypothesisNode(
-            node_id="001_subprocess_mtp",
-            name="subprocess_mtp",
+            node_id="001_mtp",
+            name="mtp",
             status="failed",
             failure=_make_failure(
                 FailureKind.JOB_STARTUP_FAILED,
@@ -842,10 +840,10 @@ class _AutoresearchWorkflowTest(unittest.TestCase):
             ),
         )
         retry = _HypothesisNode(
-            node_id="002_subprocess_mtp_startup_retry_1",
-            name="subprocess_mtp_startup_retry_1",
+            node_id="002_mtp_startup_retry_1",
+            name="mtp_startup_retry_1",
             status="failed",
-            spec={"_startup_retry_of": "001_subprocess_mtp"},
+            spec={"_startup_retry_of": "001_mtp"},
             failure=_make_failure(
                 FailureKind.JOB_STARTUP_FAILED,
                 FailurePhase.JOB,
@@ -877,13 +875,13 @@ class _AutoresearchWorkflowTest(unittest.TestCase):
         prompt = _build_apply_prompt(
             platform,
             {
-                "name": "subprocess_mtp_startup_retry_1",
+                "name": "mtp_startup_retry_1",
                 "description": "repair",
                 "hypothesis": "fix startup",
                 "_startup_retry_attempt": 1,
                 "_startup_failure": {"kind": "job_startup_failed"},
             },
-            "002_subprocess_mtp_startup_retry_1",
+            "002_mtp_startup_retry_1",
             "knowledge",
             "/tmp/pipeline.py",
             "def main():\n    pass\n",

--- a/tools/autoresearch/utils/commands/init.py
+++ b/tools/autoresearch/utils/commands/init.py
@@ -139,7 +139,7 @@ def _run(args: list[str]) -> None:
         "job_timeout_s": ns.job_timeout,
         "poll_interval": ns.poll_interval,
         "startup_failure_retries": 2,
-        "startup_retryable_experiments": ["subprocess_mtp"],
+        "startup_retryable_experiments": ["mtp"],
         "platform": ns.platform,
         "agent": ns.agent,
         "local_execution_mode": ns.local_execution_mode,

--- a/tools/autoresearch/utils/state.py
+++ b/tools/autoresearch/utils/state.py
@@ -80,7 +80,7 @@ def _normalize_config(config: dict) -> dict:
     normalized.setdefault("agent", "claude")
     normalized.setdefault("local_execution_mode", "full")
     normalized.setdefault("startup_failure_retries", 2)
-    normalized.setdefault("startup_retryable_experiments", ["subprocess_mtp"])
+    normalized.setdefault("startup_retryable_experiments", ["mtp"])
     return normalized
 
 

--- a/tools/autoresearch/utils/workflow/analysis_ops.py
+++ b/tools/autoresearch/utils/workflow/analysis_ops.py
@@ -40,7 +40,7 @@ from .policy import _change_summary_for_spec
 
 _LG: logging.Logger = logging.getLogger(__name__)
 
-_STRUCTURAL_PRACTICES = {"subprocess_mtp"}
+_STRUCTURAL_PRACTICES = {"mtp"}
 _STRUCTURAL_ATTEMPT_THRESHOLD = 3
 
 

--- a/tools/autoresearch/utils/workflow/planning_ops.py
+++ b/tools/autoresearch/utils/workflow/planning_ops.py
@@ -28,11 +28,11 @@ from .policy import (
 _LG: logging.Logger = logging.getLogger(__name__)
 
 _BEST_PRACTICES = [
-    "subprocess_mtp",
+    "mtp",
     "batch_size_tuning",
     "concurrency_tuning",
 ]
-_STRUCTURAL_PRACTICES = {"subprocess_mtp"}
+_STRUCTURAL_PRACTICES = {"mtp"}
 _MAX_THREADS_PER_RANK_DEFAULT = 16
 _MAX_THREADS_PER_RANK_EXTENDED = 32
 _HISTORY_JSON_MAX_CHARS = 12000
@@ -353,14 +353,14 @@ def _build_initial_nodes(workdir: Path, config: dict, state: dict) -> list:
             )
         )
 
-    if "subprocess_mtp" not in tried_practices:
+    if "mtp" not in tried_practices:
         nodes.append(
             _HypothesisNode(
-                node_id="001_subprocess_mtp",
-                name="subprocess_mtp",
+                node_id="001_mtp",
+                name="mtp",
                 spec={
-                    "name": "subprocess_mtp",
-                    "changes": ["subprocess_mtp"],
+                    "name": "mtp",
+                    "changes": ["mtp"],
                     "description": (
                         "Run pipeline in subprocess to avoid background data "
                         "loading threads interfering with CUDA kernel launches"
@@ -372,7 +372,7 @@ def _build_initial_nodes(workdir: Path, config: dict, state: dict) -> list:
                         "CUDA kernel launch scheduling"
                     ),
                     "launch_command": base_launch,
-                    "best_practices_tags": ["subprocess_mtp"],
+                    "best_practices_tags": ["mtp"],
                 },
                 priority=-998,
             )

--- a/tools/autoresearch/utils/workflow/policy.py
+++ b/tools/autoresearch/utils/workflow/policy.py
@@ -69,14 +69,12 @@ __all__ = [
 ]
 
 _KIND_EXPERIMENT = "experiment"
-_REQUIRED_INITIAL_EXPERIMENTS = frozenset(
-    {"baseline", "headspace_cache", "subprocess_mtp"}
-)
+_REQUIRED_INITIAL_EXPERIMENTS = frozenset({"baseline", "headspace_cache", "mtp"})
 _STRUCTURAL_ATTEMPT_THRESHOLD = 3
 _MAX_THREADS_PER_RANK_DEFAULT = 16
 _MAX_THREADS_PER_RANK_EXTENDED = 32
 _STARTUP_FAILURE_RETRIES_DEFAULT = 2
-_STARTUP_RETRYABLE_EXPERIMENTS_DEFAULT = ("subprocess_mtp",)
+_STARTUP_RETRYABLE_EXPERIMENTS_DEFAULT = ("mtp",)
 _NON_RETRYABLE_FAILURES = frozenset(
     {
         FailureKind.JOB_RUNTIME_FAILED,
@@ -390,7 +388,7 @@ def _record_failed_best_practice_attempt(state: dict, node: _HypothesisNode) -> 
     tried = set(state.get("best_practices_tried", []))
     attempts: dict[str, int] = state.get("_structural_attempts", {})
     for tag in tags:
-        if tag == "subprocess_mtp":
+        if tag == "mtp":
             attempts[tag] = attempts.get(tag, 0) + 1
             if attempts[tag] >= _STRUCTURAL_ATTEMPT_THRESHOLD:
                 tried.add(tag)


### PR DESCRIPTION
Two improvements to the hypothesis_tree.png visualization:

1. Node labels now show launch order as a prefix (e.g., "#0 baseline", "#1 subprocess_mtp", "#5 torch_compile") extracted from the node_id counter.

2. Edge labels now prefer the structured "changes" list from the experiment spec over change_summary, giving more concise and consistent descriptions of what each experiment modifies.

Also rename subprocess_mtp to mtp as subprocess is already included.