### PR TITLE
[autoresearch] Resolve hypothesis tree parent from goto field

### DIFF
--- a/tools/autoresearch/prompts/plan_next.md
+++ b/tools/autoresearch/prompts/plan_next.md
@@ -166,7 +166,6 @@ Output your reasoning, then a JSON block:
 {
   "action": "launch|stop|manual",
   "reasoning": "<2-3 sentence summary of your decision>",
-  "goto": "<commit hash to check out before applying changes, or null>",
   "experiments": [
     {
       "name": "<short_snake_case>",
@@ -175,6 +174,7 @@ Output your reasoning, then a JSON block:
       "description": "<what we are changing>",
       "hypothesis": "<why this should help>",
       "launch_command": "<full command; use $IMAGE for image>",
+      "goto": "<commit hash to check out before applying changes, or null>",
 
       "best_practices_tags": ["<tag1>", "<tag2>"]
     }
@@ -192,4 +192,4 @@ Rules:
 - Each experiment should differ from the baseline in exactly one dimension (or a small, justified set of changes)
 - **TorchTNT scripts**: When writing `description` for rebuild experiments in TorchTNT code, specify changes to the pipeline builder function only. The `Pipeline` abstracts away MTP vs pure multithreading, so the wrapper class (which calls `get_iterator(timeout=...)`) and TorchTNT internals (`fit()`, `train()`, `AutoUnit`) do not change. Do NOT use `auto_stop()` — Pipeline supports multiple iterations without it.
 - **`best_practices_tags`**: Tag each experiment with which best practices it covers from the valid tags list. This is how the orchestrator tracks progress. If an experiment covers multiple practices, include all relevant tags.
-- **`goto`**: The orchestrator checks out the instrumentation (anchor) commit before applying each experiment's code changes by default. This ensures every experiment starts from a clean slate. Set `goto` to `null` in most cases. Only set it to a specific commit hash if you want to stack changes on top of a previous successful experiment (e.g., adding batch size tuning on top of an MTP experiment that already improved metrics). Never stack incompatible changes (e.g., GPU decode on top of MTP — they are mutually exclusive).
+- **`goto`** (per-experiment): The orchestrator checks out the instrumentation (anchor) commit before applying each experiment's code changes by default. This ensures every experiment starts from a clean slate. Set `goto` to `null` in most cases. Only set it to a specific commit hash if you want to stack changes on top of a previous successful experiment (e.g., adding batch size tuning on top of an MTP experiment that already improved metrics). Never stack incompatible changes (e.g., GPU decode on top of MTP — they are mutually exclusive). **The `goto` field also determines the experiment's parent in the hypothesis tree**: `null` means the experiment branches from baseline; a specific commit means it branches from the experiment that produced that commit. This allows a single planning round to propose experiments with different parents (e.g., NVDEC from baseline + batch_size from a successful MTP experiment).

--- a/tools/autoresearch/tests/test_autoresearch_workflow.py
+++ b/tools/autoresearch/tests/test_autoresearch_workflow.py
@@ -182,6 +182,95 @@ class _AutoresearchWorkflowTest(unittest.TestCase):
 
         self.assertIsNone(selected)
 
+    def _load_node(self, spec: _WorkSpec) -> _HypothesisNode:
+        """Extract node from a WorkSpec with a safe dict cast for Pyre."""
+        node_data = spec.payload["node"]
+        assert isinstance(node_data, dict)
+        return _HypothesisNode.from_dict(node_data)
+
+    def test_child_spec_parents_under_baseline_when_goto_is_null(self) -> None:
+        """Experiments that start from anchor (goto=null) should be parented
+        under the baseline node, not whichever node triggered planning."""
+        with tempfile.TemporaryDirectory() as tmp:
+            workdir = Path(tmp)
+            adapter = self._adapter(workdir)
+            specs = adapter.load()
+            # Simulate baseline completed with a commit.
+            baseline_node = self._load_node(specs[0])
+            baseline_node.status = "completed"
+            baseline_node.commit = "baseline_commit_abc"
+            adapter._store.upsert_node(baseline_node)
+
+            # Simulate MTP completed with a different commit.
+            mtp_node = self._load_node(specs[2])
+            mtp_node.status = "completed"
+            mtp_node.commit = "mtp_commit_xyz"
+            adapter._store.upsert_node(mtp_node)
+
+            # Create a child with goto=None (should parent under baseline).
+            child_spec = adapter._create_child_spec(
+                mtp_node,
+                {"name": "nvdec_decode", "goto": None},
+            )
+            child_node = self._load_node(child_spec)
+
+            self.assertEqual("000_baseline", child_node.parent_id)
+            self.assertEqual("baseline_commit_abc", child_node.commit)
+
+    def test_child_spec_parents_under_goto_commit_owner(self) -> None:
+        """Experiments with a goto commit should be parented under the node
+        that produced that commit."""
+        with tempfile.TemporaryDirectory() as tmp:
+            workdir = Path(tmp)
+            adapter = self._adapter(workdir)
+            specs = adapter.load()
+
+            baseline_node = self._load_node(specs[0])
+            baseline_node.status = "completed"
+            baseline_node.commit = "baseline_commit_abc"
+            adapter._store.upsert_node(baseline_node)
+
+            mtp_node = self._load_node(specs[2])
+            mtp_node.status = "completed"
+            mtp_node.commit = "mtp_commit_xyz"
+            adapter._store.upsert_node(mtp_node)
+
+            # Create a child with goto pointing to MTP's commit.
+            child_spec = adapter._create_child_spec(
+                baseline_node,  # default parent is baseline
+                {"name": "batch_on_mtp", "goto": "mtp_commit_xyz"},
+            )
+            child_node = self._load_node(child_spec)
+
+            self.assertEqual(mtp_node.node_id, child_node.parent_id)
+            self.assertEqual("mtp_commit_xyz", child_node.commit)
+
+    def test_child_spec_parents_under_baseline_without_goto(self) -> None:
+        """When goto is absent, the spec defaults to anchor (baseline)."""
+        with tempfile.TemporaryDirectory() as tmp:
+            workdir = Path(tmp)
+            adapter = self._adapter(workdir)
+            specs = adapter.load()
+
+            mtp_node = self._load_node(specs[2])
+            mtp_node.status = "completed"
+            mtp_node.commit = "mtp_commit_xyz"
+            adapter._store.upsert_node(mtp_node)
+
+            # Ensure baseline exists so _resolve_parent can find it.
+            baseline_node = self._load_node(specs[0])
+            baseline_node.status = "completed"
+            adapter._store.upsert_node(baseline_node)
+
+            # No goto key at all — .get("goto") returns None, which means
+            # "start from anchor".  Parent should be baseline.
+            child_spec = adapter._create_child_spec(
+                mtp_node,
+                {"name": "some_exp"},
+            )
+            child_node = self._load_node(child_spec)
+            self.assertEqual("000_baseline", child_node.parent_id)
+
     def test_headspace_completion_selects_mtp_after_must_run_finish(self) -> None:
         baseline = _HypothesisNode(
             node_id="000_baseline",

--- a/tools/autoresearch/utils/workflow/adapter.py
+++ b/tools/autoresearch/utils/workflow/adapter.py
@@ -465,17 +465,59 @@ class AutoresearchAdapter:
     ) -> _WorkSpec:
         name = child_spec.get("name", f"exp_{self._store.node_counter}")
         child_spec["change_summary"] = _change_summary_for_spec(child_spec)
+        actual_parent = self._resolve_parent(parent, child_spec)
         node = _HypothesisNode(
             node_id=f"{self._store.node_counter:03d}_{name}",
             name=name,
-            parent_id=parent.node_id,
-            commit=parent.commit,
+            parent_id=actual_parent.node_id,
+            commit=actual_parent.commit,
             spec=child_spec,
             status="queued",
             priority=child_spec.get("priority", 0.0),
         )
         self._store.node_counter += 1
         return _spec_from_node(node)
+
+    def _resolve_parent(
+        self,
+        default_parent: _HypothesisNode,
+        child_spec: dict,
+    ) -> _HypothesisNode:
+        """Resolve the actual parent node for a child experiment.
+
+        When ``goto`` is absent or null (experiment starts from the anchor
+        commit, i.e. the baseline), the parent should be the baseline node —
+        not whichever node triggered the planning round.  When ``goto`` points
+        to a specific commit, find the node that produced it.
+
+        This prevents mutually-exclusive experiments (e.g. NVDEC GPU decode)
+        from being incorrectly parented under incompatible experiments
+        (e.g. MTP subprocess).
+        """
+        goto = child_spec.get("goto")
+        if goto is None:
+            # Experiment starts from anchor (baseline).  Find the baseline
+            # node so the hypothesis tree reflects the true lineage.
+            baseline = self._store.tree.get("000_baseline")
+            if baseline is not None:
+                return baseline
+            _LG.warning(
+                "Baseline node 000_baseline not found in tree; "
+                "falling back to planning node %s",
+                default_parent.node_id,
+            )
+        else:
+            # goto points to a specific commit — find the node that owns it.
+            for node in self._store.tree.values():
+                if node.commit and node.commit == goto:
+                    return node
+            _LG.warning(
+                "goto commit %s does not match any node; "
+                "falling back to planning node %s",
+                goto,
+                default_parent.node_id,
+            )
+        return default_parent
 
 
 def _timestamp() -> str:

--- a/tools/autoresearch/utils/workflow/planning_ops.py
+++ b/tools/autoresearch/utils/workflow/planning_ops.py
@@ -288,9 +288,13 @@ def _plan_followups(
         plan.get("experiments", []),
         _thread_cap_for_experiment(state, config),
     )
+    plan_goto = plan.get("goto")
     for experiment in experiments:
         if "changes" not in experiment:
             experiment["changes"] = []
+        # Propagate plan-level goto to experiments that don't specify their own.
+        if "goto" not in experiment:
+            experiment["goto"] = plan_goto
         experiment["change_summary"] = _change_summary_for_spec(experiment)
     _record_best_practices(state, {"experiments": experiments})
     state["_stop_overrides"] = 0


### PR DESCRIPTION
Experiments that start from the anchor commit (goto=null) were incorrectly parented under whichever node triggered the planning round. This caused mutually-exclusive experiments like NVDEC GPU decode to appear as children of MTP subprocess in the hypothesis tree, even though NVDEC is incompatible with MTP and must branch from baseline.

Fix by resolving the actual tree parent from the experiment's `goto` field: null means baseline, a specific commit means the node that produced it. Also move `goto` from plan-level to per-experiment in the planner prompt so a single planning round can propose experiments with different parents.