### PR TITLE
Add `spdl.autoresearch.core` public submodule with task scheduling types (#1449)

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -13,6 +13,7 @@ API Reference
    spdl.io
    spdl.io.utils
    spdl.autoresearch
+   spdl.autoresearch.core
 
    spdl.dataloader
    spdl.source

--- a/docs/source/autoresearch/autoresearch.rst
+++ b/docs/source/autoresearch/autoresearch.rst
@@ -170,7 +170,7 @@ After the seed experiments, autoresearch enters an iterative loop:
 .. mermaid::
 
    sequenceDiagram
-       participant Engine as AsyncWorkEngine
+       participant Engine as Orchestrator
        participant Adapter as AutoresearchAdapter
        participant Agent as Coding Agent
        participant Platform as Platform
@@ -199,7 +199,7 @@ useful for monitoring progress.
 
 ``engine/checkpoint.json``
    Runner checkpoint containing the serialized queued and running
-   ``_WorkSpec`` objects. This is the source of truth for resume.
+   ``TaskSpec`` objects. This is the source of truth for resume.
 
 ``engine/queue.json``
    Compatibility view of pending experiments in priority order.
@@ -275,7 +275,7 @@ Modifying the Queue
 
 To manually adjust the experiment queue, stop the engine and edit
 ``engine/checkpoint.json``. The ``queued`` list contains serialized
-``_WorkSpec`` objects; change their ``priority`` values or remove specs
+``TaskSpec`` objects; change their ``priority`` values or remove specs
 as needed. Lower values run first. ``engine/queue.json`` is a
 compatibility view for monitoring and should not be treated as the
 resume source of truth.

--- a/docs/source/autoresearch/autoresearch_architecture.rst
+++ b/docs/source/autoresearch/autoresearch_architecture.rst
@@ -18,7 +18,7 @@ testable, and infrastructure swappable.
    flowchart TB
        CLI["python cli.py"]
        Supervisor["Supervisor agent<br>(interactive)"]
-       Engine["AsyncWorkEngine<br>(runner.py)"]
+       Engine["Orchestrator<br>(runner.py)"]
        Adapter["AutoresearchAdapter<br>(workflow/)"]
        Policy["policy.py"]
        Store["store.py"]
@@ -78,15 +78,15 @@ remote job.
 Async Work Engine
 -----------------
 
-The generic runner (``utils/runner.py``) knows nothing about SPDL,
+The generic runner (``core/_orchestrator.py``) knows nothing about SPDL,
 training jobs, source control, metrics, or hypothesis planning. It
-operates on serializable ``_WorkSpec`` objects and a ``_WorkAdapter``
+operates on serializable ``TaskSpec`` objects and a ``WorkflowProtocol``
 protocol:
 
-- Maintains a priority queue of pending ``_WorkSpec`` objects.
+- Maintains a priority queue of pending ``TaskSpec`` objects.
 - Starts up to ``max_concurrency`` coroutines via the adapter.
 - Waits for the first coroutine to complete.
-- Passes completed ``_WorkResult`` objects (which may contain child
+- Passes completed ``TaskResult`` objects (which may contain child
   specs) back to the adapter and re-queues children.
 - Checkpoints queued and running specs on cancellation.
 
@@ -99,7 +99,7 @@ Workflow
 --------
 
 The autoresearch workflow (``utils/workflow/``) is the domain side of
-the boundary. It turns an experiment ``_WorkSpec`` into a coroutine
+the boundary. It turns an experiment ``TaskSpec`` into a coroutine
 that performs the full experiment lifecycle:
 
 - Restore or prepare the source tree.
@@ -109,12 +109,12 @@ that performs the full experiment lifecycle:
 - Collect metrics and run coding agent analysis.
 - Record state, master-table rows, findings, and plots.
 - Ask the coding agent for follow-up experiments and return them as
-  child ``_WorkSpec`` objects.
+  child ``TaskSpec`` objects.
 
 The workflow is split into focused modules:
 
 - **adapter.py** -- the ``AutoresearchAdapter`` that implements
-  ``_WorkAdapter`` and orchestrates the experiment coroutine.
+  ``WorkflowProtocol`` and orchestrates the experiment coroutine.
 - **policy.py** -- deterministic decisions (planning gates, duplicate
   filtering, stall detection) expressed as pure functions that can be
   unit tested without infrastructure.

--- a/src/spdl/autoresearch/__init__.py
+++ b/src/spdl/autoresearch/__init__.py
@@ -4,6 +4,11 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-"""Automated experiment engine for optimizing SPDL data loading pipelines."""
+"""Framework for automated, LLM-driven experiment workflows.
+
+Provides reusable infrastructure for running automated research loops:
+
+- :py:mod:`~spdl.autoresearch.core`: a domain-neutral async work scheduler.
+"""
 
 __all__: list[str] = []

--- a/src/spdl/autoresearch/core/__init__.py
+++ b/src/spdl/autoresearch/core/__init__.py
@@ -1,0 +1,28 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Core scheduling engine for autoresearch.
+
+Provides the domain-neutral building blocks for running automated experiment
+workflows: a bounded-concurrency async orchestrator, a workflow protocol for
+domain adapters, and serializable task types.
+
+Example::
+
+    from spdl.autoresearch.core import Orchestrator, TaskSpec
+
+    engine = Orchestrator(workflow=my_adapter, max_concurrency=4)
+    await engine.run([TaskSpec(id="exp_001", priority=0)])
+"""
+
+from ._orchestrator import Orchestrator, TaskResult, TaskSpec, WorkflowProtocol
+
+__all__ = [
+    "Orchestrator",
+    "TaskResult",
+    "TaskSpec",
+    "WorkflowProtocol",
+]

--- a/src/spdl/autoresearch/core/_orchestrator.py
+++ b/src/spdl/autoresearch/core/_orchestrator.py
@@ -23,15 +23,15 @@ can run any coroutine-producing adapter.
 .. mermaid::
 
    flowchart LR
-       Engine["AsyncWorkEngine"]
-       Adapter["_WorkAdapter"]
+       Engine["Orchestrator"]
+       Adapter["WorkflowProtocol"]
        Domain["Domain coroutine"]
        Checkpoint["adapter.checkpoint"]
 
        Engine -->|"load()"| Adapter
-       Engine -->|"make_coro(_WorkSpec)"| Adapter
+       Engine -->|"make_coro(TaskSpec)"| Adapter
        Adapter --> Domain
-       Domain -->|"_WorkResult(children)"| Engine
+       Domain -->|"TaskResult(children)"| Engine
        Engine -->|"on_result(...)"| Adapter
        Engine --> Checkpoint
 """
@@ -49,21 +49,44 @@ from typing import Any, Protocol
 _LG: logging.Logger = logging.getLogger(__name__)
 
 __all__ = [
-    "AsyncWorkEngine",
-    "_WorkAdapter",
-    "_WorkResult",
-    "_WorkSpec",
+    "Orchestrator",
+    "WorkflowProtocol",
+    "TaskResult",
+    "TaskSpec",
 ]
 
 
 @dataclass
-class _WorkSpec:
+class TaskSpec:
+    """Serializable unit of work for the async engine."""
+
     id: str
+    """Unique identifier for this work item."""
+
     priority: float = 0.0
+    """Scheduling priority.  Lower values are dequeued first.  The engine
+    uses a min-heap, so ``priority=-1000`` runs before ``priority=0``."""
+
     kind: str = "default"
+    """Category tag used by the adapter to distinguish spec types without
+    inspecting the payload.  For example, the SPDL workflow sets this to
+    ``"experiment"`` so the policy layer can filter experiment specs from
+    other internal bookkeeping specs."""
+
     payload: dict[str, object] = field(default_factory=dict)
+    """Arbitrary key-value data that travels with the spec through the
+    engine lifecycle (enqueue → checkpoint → make_coro → on_result).  The
+    adapter stores domain-specific state here — for example, the SPDL
+    workflow stores the full ``HypothesisNode`` dict under
+    ``payload["node"]``."""
 
     def to_dict(self) -> dict[str, object]:
+        """Serialize this spec to a JSON-compatible dictionary.
+
+        Returns:
+            A dictionary with keys ``"id"``, ``"priority"``, ``"kind"``,
+            and ``"payload"``.
+        """
         return {
             "id": self.id,
             "priority": self.priority,
@@ -72,7 +95,18 @@ class _WorkSpec:
         }
 
     @classmethod
-    def from_dict(cls, data: dict[str, object]) -> _WorkSpec:
+    def from_dict(cls, data: dict[str, object]) -> TaskSpec:
+        """Reconstruct a ``TaskSpec`` from a dictionary.
+
+        Missing keys fall back to field defaults.  A non-dict ``payload``
+        value is replaced with an empty dictionary.
+
+        Args:
+            data: Dictionary previously produced by :py:meth:`to_dict`.
+
+        Returns:
+            A new ``TaskSpec`` instance.
+        """
         payload = data.get("payload", {})
         if not isinstance(payload, dict):
             payload = {}
@@ -85,71 +119,114 @@ class _WorkSpec:
 
 
 @dataclass
-class _WorkResult:
-    children: list[_WorkSpec] = field(default_factory=list)
+class TaskResult:
+    """Result returned by a completed work coroutine."""
+
+    children: list[TaskSpec] = field(default_factory=list)
+    """New work specs to enqueue after this item completes.  The engine
+    passes these to ``WorkflowProtocol.on_result`` which may filter or transform
+    them before they enter the priority queue."""
 
 
-class _WorkAdapter(Protocol):
-    def load(self) -> list[_WorkSpec]: ...
+class WorkflowProtocol(Protocol):
+    """Protocol for domain-specific adapters that drive the work engine.
+
+    Implementations must provide ``load``, ``checkpoint``, ``make_coro``,
+    and ``on_result``.
+    """
+
+    def load(self) -> list[TaskSpec]:
+        """Return the initial list of work specs to process.
+
+        Called once at the start of ``Orchestrator.run`` when no
+        ``initial_specs`` are provided.  Typically reads from a checkpoint
+        file to resume interrupted work.
+        """
+        ...
 
     def checkpoint(
         self,
-        queued: list[_WorkSpec],
-        running: list[_WorkSpec],
+        queued: list[TaskSpec],
+        running: list[TaskSpec],
         status: str,
-    ) -> None: ...
+    ) -> None:
+        """Persist the current scheduler state.
 
-    def make_coro(self, spec: _WorkSpec) -> Coroutine[Any, Any, _WorkResult]: ...
+        Called on every engine loop iteration and on interruption.
+        ``status`` is one of ``"running"``, ``"stopped"``, or
+        ``"interrupted"``.
+        """
+        ...
 
-    async def on_result(
-        self, spec: _WorkSpec, result: _WorkResult
-    ) -> list[_WorkSpec]: ...
+    def make_coro(self, spec: TaskSpec) -> Coroutine[Any, Any, TaskResult]:
+        """Create the coroutine that executes a work spec.
+
+        The returned coroutine is scheduled as an ``asyncio.Task``.  It
+        should return a ``TaskResult`` whose ``children`` field contains
+        any follow-up specs to enqueue.
+        """
+        ...
+
+    async def on_result(self, spec: TaskSpec, result: TaskResult) -> list[TaskSpec]:
+        """Process a completed result and return specs to enqueue.
+
+        Called after a work coroutine finishes.  The adapter can filter
+        duplicates, update persistent state, or transform the result's
+        children before they enter the priority queue.
+        """
+        ...
 
 
 class _PriorityQueue:
-    def __init__(self, specs: list[_WorkSpec] | None = None) -> None:
-        self._items: list[tuple[float, int, _WorkSpec]] = []
+    def __init__(self, specs: list[TaskSpec] | None = None) -> None:
+        self._items: list[tuple[float, int, TaskSpec]] = []
         self._counter = 0
         for spec in specs or []:
             self.push(spec)
 
-    def push(self, spec: _WorkSpec) -> None:
+    def push(self, spec: TaskSpec) -> None:
         heapq.heappush(self._items, (spec.priority, self._counter, spec))
         self._counter += 1
 
-    def extend(self, specs: list[_WorkSpec]) -> None:
+    def extend(self, specs: list[TaskSpec]) -> None:
         for spec in specs:
             self.push(spec)
 
-    def pop(self) -> _WorkSpec | None:
+    def pop(self) -> TaskSpec | None:
         if not self._items:
             return None
         return heapq.heappop(self._items)[2]
 
-    def items(self) -> list[_WorkSpec]:
+    def items(self) -> list[TaskSpec]:
         return [spec for _, _, spec in sorted(self._items)]
 
     def __bool__(self) -> bool:
         return bool(self._items)
 
 
-class AsyncWorkEngine:
+class Orchestrator:
     """Run serializable work specs with bounded async concurrency.
+
+    Args:
+        workflow: Domain-specific adapter implementing the
+            :py:class:`WorkflowProtocol` protocol.
+        max_concurrency: Maximum number of work coroutines to run
+            concurrently (clamped to at least 1).
 
     .. mermaid::
 
        sequenceDiagram
-           participant Engine as AsyncWorkEngine
-           participant Adapter as _WorkAdapter
+           participant Engine as Orchestrator
+           participant Adapter as WorkflowProtocol
            participant Task as Work coroutine
 
            Engine->>Adapter: load()
            Engine->>Adapter: checkpoint(queued, running, "running")
            Engine->>Adapter: make_coro(spec)
            Engine->>Task: schedule up to max_concurrency
-           Task-->>Engine: _WorkResult(children)
+           Task-->>Engine: TaskResult(children)
            Engine->>Adapter: on_result(spec, result)
-           Adapter-->>Engine: child WorkSpecs
+           Adapter-->>Engine: child TaskSpecs
            Engine->>Adapter: checkpoint(..., "stopped")
 
            Note over Engine,Adapter: On SIGINT/SIGTERM, cancel tasks and
@@ -159,17 +236,31 @@ class AsyncWorkEngine:
     def __init__(
         self,
         *,
-        adapter: _WorkAdapter,
+        workflow: WorkflowProtocol,
         max_concurrency: int,
     ) -> None:
-        self.adapter = adapter
+        self.adapter = workflow
         self.max_concurrency = max(1, max_concurrency)
 
-    async def run(self, initial_specs: list[_WorkSpec] | None = None) -> None:
+    async def run(self, initial_specs: list[TaskSpec] | None = None) -> None:
+        """Run the engine until all work is complete or interrupted.
+
+        The engine dequeues specs from a priority queue, schedules up to
+        ``max_concurrency`` coroutines at a time, and checkpoints state on
+        every iteration.  On ``SIGINT`` / ``SIGTERM`` it cancels running
+        tasks and checkpoints with ``"interrupted"`` status so that a
+        subsequent run can resume from where it left off.
+
+        Args:
+            initial_specs: Specs to seed the priority queue with.  When
+                ``None``, the adapter's ``load()`` method is called instead,
+                which typically reads a checkpoint file written by a previous
+                interrupted run.
+        """
         queued = _PriorityQueue(
             self.adapter.load() if initial_specs is None else initial_specs
         )
-        running: dict[asyncio.Task[_WorkResult], _WorkSpec] = {}
+        running: dict[asyncio.Task[TaskResult], TaskSpec] = {}
         main_task = asyncio.current_task()
         self._install_signal_handlers(main_task)
 
@@ -204,7 +295,7 @@ class AsyncWorkEngine:
     def _fill_slots(
         self,
         queued: _PriorityQueue,
-        running: dict[asyncio.Task[_WorkResult], _WorkSpec],
+        running: dict[asyncio.Task[TaskResult], TaskSpec],
     ) -> None:
         while len(running) < self.max_concurrency and queued:
             spec = queued.pop()
@@ -215,8 +306,8 @@ class AsyncWorkEngine:
 
     async def _process_done(
         self,
-        done: set[asyncio.Task[_WorkResult]],
-        running: dict[asyncio.Task[_WorkResult], _WorkSpec],
+        done: set[asyncio.Task[TaskResult]],
+        running: dict[asyncio.Task[TaskResult], TaskSpec],
         queued: _PriorityQueue,
     ) -> None:
         for task in done:
@@ -227,7 +318,7 @@ class AsyncWorkEngine:
 
     async def _cancel_running(
         self,
-        running: dict[asyncio.Task[_WorkResult], _WorkSpec],
+        running: dict[asyncio.Task[TaskResult], TaskSpec],
     ) -> None:
         for task in running:
             task.cancel()

--- a/tests/autoresearch/orchestrator_test.py
+++ b/tests/autoresearch/orchestrator_test.py
@@ -9,78 +9,77 @@ from __future__ import annotations
 import asyncio
 import unittest
 
-from spdl.tools.autoresearch.utils.runner import (
-    _WorkResult,
-    _WorkSpec,
-    AsyncWorkEngine,
-)
+from spdl.autoresearch.core import Orchestrator, TaskResult, TaskSpec
 
 __all__: list[str] = []
 
 
 class _FakeAdapter:
-    def __init__(self, specs: list[_WorkSpec]) -> None:
+    def __init__(self, specs: list[TaskSpec]) -> None:
         self.specs = specs
         self.started: list[str] = []
         self.checkpoints: list[tuple[list[str], list[str], str]] = []
-        self.children: dict[str, list[_WorkSpec]] = {}
+        self.children: dict[str, list[TaskSpec]] = {}
         self.block = False
 
-    def load(self) -> list[_WorkSpec]:
+    def load(self) -> list[TaskSpec]:
         return self.specs
 
     def checkpoint(
         self,
-        queued: list[_WorkSpec],
-        running: list[_WorkSpec],
+        queued: list[TaskSpec],
+        running: list[TaskSpec],
         status: str,
     ) -> None:
         self.checkpoints.append(
             ([spec.id for spec in queued], [spec.id for spec in running], status)
         )
 
-    async def make_coro(self, spec: _WorkSpec) -> _WorkResult:
+    async def make_coro(self, spec: TaskSpec) -> TaskResult:
         self.started.append(spec.id)
         if self.block:
             await asyncio.sleep(60)
-        return _WorkResult(children=self.children.get(spec.id, []))
+        return TaskResult(children=self.children.get(spec.id, []))
 
-    async def on_result(self, spec: _WorkSpec, result: _WorkResult) -> list[_WorkSpec]:
+    async def on_result(self, spec: TaskSpec, result: TaskResult) -> list[TaskSpec]:
         return result.children
 
 
-class _SimpleEngineTest(unittest.IsolatedAsyncioTestCase):
+class OrchestratorTest(unittest.IsolatedAsyncioTestCase):
     async def test_priority_order_lowest_first(self) -> None:
+        """Specs are executed in ascending priority order (lowest value first)."""
         adapter = _FakeAdapter(
             [
-                _WorkSpec(id="slow", priority=10),
-                _WorkSpec(id="first", priority=-1),
-                _WorkSpec(id="middle", priority=5),
+                TaskSpec(id="slow", priority=10),
+                TaskSpec(id="first", priority=-1),
+                TaskSpec(id="middle", priority=5),
             ]
         )
 
-        await AsyncWorkEngine(adapter=adapter, max_concurrency=1).run()
+        await Orchestrator(workflow=adapter, max_concurrency=1).run()
 
         self.assertEqual(["first", "middle", "slow"], adapter.started)
         self.assertEqual(([], [], "stopped"), adapter.checkpoints[-1])
 
     async def test_completion_enqueues_children(self) -> None:
-        adapter = _FakeAdapter([_WorkSpec(id="root", priority=0)])
+        """Child specs returned by a completed item are enqueued and executed."""
+        adapter = _FakeAdapter([TaskSpec(id="root", priority=0)])
         adapter.children["root"] = [
-            _WorkSpec(id="child_a", priority=1),
-            _WorkSpec(id="child_b", priority=2),
+            TaskSpec(id="child_a", priority=1),
+            TaskSpec(id="child_b", priority=2),
         ]
 
-        await AsyncWorkEngine(adapter=adapter, max_concurrency=1).run()
+        await Orchestrator(workflow=adapter, max_concurrency=1).run()
 
         self.assertEqual(["root", "child_a", "child_b"], adapter.started)
         self.assertEqual(([], [], "stopped"), adapter.checkpoints[-1])
 
     async def test_cancelled_error_persists_interrupted_state(self) -> None:
-        adapter = _FakeAdapter([_WorkSpec(id="running", priority=0)])
+        """Cancellation checkpoints running specs with 'interrupted' status."""
+        adapter = _FakeAdapter([TaskSpec(id="running", priority=0)])
         adapter.block = True
         task = asyncio.create_task(
-            AsyncWorkEngine(adapter=adapter, max_concurrency=1).run()
+            Orchestrator(workflow=adapter, max_concurrency=1).run()
         )
 
         while not adapter.checkpoints:
@@ -91,15 +90,16 @@ class _SimpleEngineTest(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(([], ["running"], "interrupted"), adapter.checkpoints[-1])
 
     async def test_checkpoint_resume_golden_lifecycle(self) -> None:
+        """An interrupted engine can resume from checkpointed state and complete."""
         first = _FakeAdapter(
             [
-                _WorkSpec(id="running", priority=0),
-                _WorkSpec(id="queued", priority=1),
+                TaskSpec(id="running", priority=0),
+                TaskSpec(id="queued", priority=1),
             ]
         )
         first.block = True
         task = asyncio.create_task(
-            AsyncWorkEngine(adapter=first, max_concurrency=1).run()
+            Orchestrator(workflow=first, max_concurrency=1).run()
         )
 
         while not first.checkpoints:
@@ -113,11 +113,11 @@ class _SimpleEngineTest(unittest.IsolatedAsyncioTestCase):
         )
 
         resumed_specs = [
-            _WorkSpec(id=spec_id, priority=0 if spec_id == "running" else 1)
+            TaskSpec(id=spec_id, priority=0 if spec_id == "running" else 1)
             for spec_id in running_ids + queued_ids
         ]
         resumed = _FakeAdapter(resumed_specs)
-        await AsyncWorkEngine(adapter=resumed, max_concurrency=1).run()
+        await Orchestrator(workflow=resumed, max_concurrency=1).run()
 
         self.assertEqual("interrupted", status)
         self.assertEqual(["running", "queued"], resumed.started)

--- a/tools/autoresearch/README.md
+++ b/tools/autoresearch/README.md
@@ -80,7 +80,7 @@ adapter.py  asyncio.wait(FIRST_COMPLETED)
 
 ### Engine Design
 
-The runner (`utils/runner.py`) is generic and domain-agnostic. It knows nothing about SPDL, coding agents, source control, local subprocesses, training jobs, metrics, or hypothesis planning. It only runs serializable `WorkSpec` objects as coroutines, checkpoints queued/running work, and persists an `interrupted` checkpoint when cancellation reaches the process.
+The runner (`core/_orchestrator.py`) is generic and domain-agnostic. It knows nothing about SPDL, coding agents, source control, local subprocesses, training jobs, metrics, or hypothesis planning. It only runs serializable `WorkSpec` objects as coroutines, checkpoints queued/running work, and persists an `interrupted` checkpoint when cancellation reaches the process.
 
 Autoresearch behavior belongs in the workflow side of the boundary:
 

--- a/tools/autoresearch/run.py
+++ b/tools/autoresearch/run.py
@@ -42,12 +42,12 @@ import sys
 from datetime import datetime
 from pathlib import Path
 
+from spdl.autoresearch.core import Orchestrator
 from spdl.tools.autoresearch.utils.log import setup_logging
 from spdl.tools.autoresearch.utils.platform import (
     AutoresearchPlatform,
     create_platform,
 )
-from spdl.tools.autoresearch.utils.runner import AsyncWorkEngine
 from spdl.tools.autoresearch.utils.state import (
     MASTER_TABLE_HEADERS,
     read_config,
@@ -376,8 +376,8 @@ def main() -> None:
         state=state,
         platform=platform,
     )
-    engine = AsyncWorkEngine(
-        adapter=adapter,
+    engine = Orchestrator(
+        workflow=adapter,
         max_concurrency=config.get("max_concurrency", 3),
     )
 

--- a/tools/autoresearch/tests/test_autoresearch_workflow.py
+++ b/tools/autoresearch/tests/test_autoresearch_workflow.py
@@ -12,6 +12,7 @@ import tempfile
 import unittest
 from pathlib import Path
 
+from spdl.autoresearch.core import TaskSpec
 from spdl.tools.autoresearch.plot_progress import (
     _edge_label,
     _load_tsv,
@@ -22,7 +23,6 @@ from spdl.tools.autoresearch.utils.commands.status import _failure_summary
 from spdl.tools.autoresearch.utils.platform import _MetricsEvidence, create_platform
 from spdl.tools.autoresearch.utils.platform.agents import _MockAgent
 from spdl.tools.autoresearch.utils.platform.local import _summarize_error
-from spdl.tools.autoresearch.utils.runner import _WorkSpec
 from spdl.tools.autoresearch.utils.state import (
     _append_master_row,
     _normalize_config,
@@ -181,8 +181,8 @@ class _AutoresearchWorkflowTest(unittest.TestCase):
 
         self.assertIsNone(selected)
 
-    def _load_node(self, spec: _WorkSpec) -> _HypothesisNode:
-        """Extract node from a WorkSpec with a safe dict cast for Pyre."""
+    def _load_node(self, spec: TaskSpec) -> _HypothesisNode:
+        """Extract node from a TaskSpec with a safe dict cast for Pyre."""
         node_data = spec.payload["node"]
         assert isinstance(node_data, dict)
         return _HypothesisNode.from_dict(node_data)
@@ -643,9 +643,7 @@ class _AutoresearchWorkflowTest(unittest.TestCase):
                 (workdir / "engine" / "checkpoint.json").read_text()
             )
             active = json.loads((workdir / "engine" / "active.json").read_text())
-            running_node = _node_from_spec(
-                _WorkSpec.from_dict(checkpoint["running"][0])
-            )
+            running_node = _node_from_spec(TaskSpec.from_dict(checkpoint["running"][0]))
 
             self.assertEqual("remote_job", running_node.job_id)
             self.assertEqual("000_baseline", active[0]["node_id"])

--- a/tools/autoresearch/utils/commands/queue.py
+++ b/tools/autoresearch/utils/commands/queue.py
@@ -10,7 +10,7 @@ import argparse
 import json
 from pathlib import Path
 
-from ..runner import _WorkSpec
+from spdl.autoresearch.core import TaskSpec
 
 __all__ = ["_run"]
 
@@ -32,7 +32,7 @@ def _run(args: list[str]) -> None:
     ns = _parse_args(args)
     checkpoint = Path(ns.workdir).resolve() / "engine" / "checkpoint.json"
     data = _read_checkpoint(checkpoint)
-    queued = [_WorkSpec.from_dict(spec) for spec in data.get("queued", [])]
+    queued = [TaskSpec.from_dict(spec) for spec in data.get("queued", [])]
 
     if ns.action == "list":
         for spec in sorted(queued, key=lambda item: item.priority):

--- a/tools/autoresearch/utils/workflow/adapter.py
+++ b/tools/autoresearch/utils/workflow/adapter.py
@@ -16,7 +16,7 @@ and hypothesis-planning decisions out of ``runner.py``.
 
 The workflow is the right place to sequence domain operations: restore source,
 apply experiment changes, build, launch, poll, collect metrics, analyze, update
-state, and produce child ``_WorkSpec`` objects. Infrastructure-specific work
+state, and produce child ``TaskSpec`` objects. Infrastructure-specific work
 should sit behind ``AutoresearchPlatform`` capability objects. Do not turn the
 runner adapter boundary back into a large flat callback interface.
 
@@ -29,7 +29,7 @@ should not record durable failures as bare strings.
 
    flowchart TB
        Run["run.py"]
-       Runner["AsyncWorkEngine"]
+       Runner["Orchestrator"]
        Adapter["AutoresearchAdapter"]
        Store["_AutoresearchStore"]
        Policy["autoresearch_policy"]
@@ -38,12 +38,12 @@ should not record durable failures as bare strings.
 
        Run --> Runner
        Run --> Adapter
-       Runner -->|"_WorkSpec coroutine"| Adapter
+       Runner -->|"TaskSpec coroutine"| Adapter
        Adapter --> Store
        Adapter --> Policy
        Adapter --> Platform
        Platform --> Agent
-       Adapter -->|"_WorkResult(children)"| Runner
+       Adapter -->|"TaskResult(children)"| Runner
 """
 
 from __future__ import annotations
@@ -55,8 +55,9 @@ from collections.abc import Coroutine
 from pathlib import Path
 from typing import Any
 
+from spdl.autoresearch.core import TaskResult, TaskSpec
+
 from ..platform import AutoresearchPlatform
-from ..runner import _WorkResult, _WorkSpec
 from ..state import _append_master_row
 from ..types import (
     _AnalysisResult,
@@ -105,7 +106,7 @@ class AutoresearchAdapter:
     .. mermaid::
 
        flowchart LR
-           Spec["_WorkSpec"]
+           Spec["TaskSpec"]
            Node["_HypothesisNode"]
            Prepare["prepare source/build"]
            Launch["launch or resume job"]
@@ -113,7 +114,7 @@ class AutoresearchAdapter:
            Failure["FailureRecord"]
            Analyze["collect metrics + analyze"]
            Store["update store/views"]
-           Children["child WorkSpecs"]
+           Children["child TaskSpecs"]
 
            Spec --> Node
            Node --> Prepare
@@ -144,7 +145,7 @@ class AutoresearchAdapter:
         self._state_lock = asyncio.Lock()
         self._store = _AutoresearchStore(workdir, state)
 
-    def load(self) -> list[_WorkSpec]:
+    def load(self) -> list[TaskSpec]:
         specs = self._store.load_checkpoint()
         if specs is not None:
             _LG.info("Loaded %d work specs from checkpoint", len(specs))
@@ -156,16 +157,16 @@ class AutoresearchAdapter:
 
     def checkpoint(
         self,
-        queued: list[_WorkSpec],
-        running: list[_WorkSpec],
+        queued: list[TaskSpec],
+        running: list[TaskSpec],
         status: str,
     ) -> None:
         self._store.save_scheduler_state(queued, running, status)
 
-    def make_coro(self, spec: _WorkSpec) -> Coroutine[Any, Any, _WorkResult]:
+    def make_coro(self, spec: TaskSpec) -> Coroutine[Any, Any, TaskResult]:
         return self.run_experiment(spec)
 
-    async def on_result(self, spec: _WorkSpec, result: _WorkResult) -> list[_WorkSpec]:
+    async def on_result(self, spec: TaskSpec, result: TaskResult) -> list[TaskSpec]:
         children = []
         for child in result.children:
             node = _node_from_spec(child)
@@ -185,7 +186,7 @@ class AutoresearchAdapter:
             children.append(child)
         return children
 
-    async def run_experiment(self, spec: _WorkSpec) -> _WorkResult:
+    async def run_experiment(self, spec: TaskSpec) -> TaskResult:
         node = _node_from_spec(spec)
         self._store.upsert_node(node)
         try:
@@ -195,7 +196,7 @@ class AutoresearchAdapter:
             raise
         except _AutoresearchError as error:
             await self._record_failure(spec, node, error.failure)
-            return _WorkResult()
+            return TaskResult()
         except Exception as error:
             _LG.exception("Experiment %s failed unexpectedly", node.node_id)
             await self._record_failure(
@@ -203,13 +204,13 @@ class AutoresearchAdapter:
                 node,
                 _unexpected_failure(error, job_id=node.job_id),
             )
-            return _WorkResult()
+            return TaskResult()
 
     async def _run_experiment_inner(
         self,
-        spec: _WorkSpec,
+        spec: TaskSpec,
         node: _HypothesisNode,
-    ) -> _WorkResult:
+    ) -> TaskResult:
         if node.status == "analyzing" and node.job_id:
             status = str(spec.payload.get("terminal_status", "completed"))
             return await self._analyze_record_and_plan(spec, node, status)
@@ -229,7 +230,7 @@ class AutoresearchAdapter:
                     "Prepare step failed",
                 ),
             )
-            return _WorkResult()
+            return TaskResult()
 
         node.job_id = await asyncio.to_thread(
             _launch_node,
@@ -247,7 +248,7 @@ class AutoresearchAdapter:
         status = await self._poll_until_terminal(spec, node)
         return await self._analyze_record_and_plan(spec, node, status)
 
-    async def _prepare(self, spec: _WorkSpec, node: _HypothesisNode) -> bool:
+    async def _prepare(self, spec: TaskSpec, node: _HypothesisNode) -> bool:
         async with self._state_lock:
             node.status = "preparing"
             self._store.update_spec(spec, node)
@@ -264,7 +265,7 @@ class AutoresearchAdapter:
             self._store.update_spec(spec, node)
             return prepared
 
-    async def _poll_until_terminal(self, spec: _WorkSpec, node: _HypothesisNode) -> str:
+    async def _poll_until_terminal(self, spec: TaskSpec, node: _HypothesisNode) -> str:
         if node.launched_at is None:
             node.launched_at = time.monotonic()
 
@@ -332,10 +333,10 @@ class AutoresearchAdapter:
 
     async def _analyze_record_and_plan(
         self,
-        spec: _WorkSpec,
+        spec: TaskSpec,
         node: _HypothesisNode,
         status: str,
-    ) -> _WorkResult:
+    ) -> TaskResult:
         async with self._state_lock:
             node.status = "analyzing"
             self._store.update_spec(spec, node)
@@ -373,11 +374,11 @@ class AutoresearchAdapter:
             retry_spec = _startup_retry_spec(node, self.config)
             if retry_spec is not None:
                 self._store.write_all()
-                return _WorkResult(children=[self._create_child_spec(node, retry_spec)])
+                return TaskResult(children=[self._create_child_spec(node, retry_spec)])
 
             planning_node = _select_planning_node(node, self._store.tree)
             if planning_node is None:
-                return _WorkResult()
+                return TaskResult()
 
             planning_result = result
             if planning_node.node_id != node.node_id:
@@ -409,11 +410,11 @@ class AutoresearchAdapter:
                 self._create_child_spec(planning_node, child) for child in followups
             ]
             self._store.write_all()
-            return _WorkResult(children=children)
+            return TaskResult(children=children)
 
     async def _record_failure(
         self,
-        spec: _WorkSpec,
+        spec: TaskSpec,
         node: _HypothesisNode,
         failure: FailureRecord,
     ) -> None:
@@ -460,9 +461,7 @@ class AutoresearchAdapter:
         self._store.write_all()
         return nodes
 
-    def _create_child_spec(
-        self, parent: _HypothesisNode, child_spec: dict
-    ) -> _WorkSpec:
+    def _create_child_spec(self, parent: _HypothesisNode, child_spec: dict) -> TaskSpec:
         name = child_spec.get("name", f"exp_{self._store.node_counter}")
         child_spec["change_summary"] = _change_summary_for_spec(child_spec)
         actual_parent = self._resolve_parent(parent, child_spec)

--- a/tools/autoresearch/utils/workflow/policy.py
+++ b/tools/autoresearch/utils/workflow/policy.py
@@ -22,7 +22,7 @@ or LLM calls.
 .. mermaid::
 
    flowchart LR
-       Inputs["_WorkSpec / _HypothesisNode / state"]
+       Inputs["TaskSpec / _HypothesisNode / state"]
        Policy["pure policy helpers"]
        Decisions["workflow decisions"]
        Tests["unit tests"]
@@ -41,7 +41,8 @@ import re
 import shlex
 from collections.abc import Iterable, Mapping
 
-from ..runner import _WorkSpec
+from spdl.autoresearch.core import TaskSpec
+
 from ..types import _HypothesisNode, _TERMINAL_STATUSES, FailureKind
 
 __all__ = [
@@ -473,9 +474,9 @@ def _startup_retry_spec(node: _HypothesisNode, config: dict) -> dict | None:
     return retry
 
 
-def _spec_from_node(node: _HypothesisNode) -> _WorkSpec:
+def _spec_from_node(node: _HypothesisNode) -> TaskSpec:
     node.spec["change_summary"] = _change_summary_for_spec(node.spec)
-    return _WorkSpec(
+    return TaskSpec(
         id=node.node_id,
         priority=node.priority,
         kind=_KIND_EXPERIMENT,
@@ -483,14 +484,14 @@ def _spec_from_node(node: _HypothesisNode) -> _WorkSpec:
     )
 
 
-def _node_from_spec(spec: _WorkSpec) -> _HypothesisNode:
+def _node_from_spec(spec: TaskSpec) -> _HypothesisNode:
     node_data = spec.payload.get("node", {})
     if not isinstance(node_data, dict):
         raise ValueError(f"Work spec {spec.id} has no node payload")
     return _HypothesisNode.from_dict(node_data)
 
 
-def _update_spec_from_node(spec: _WorkSpec, node: _HypothesisNode) -> None:
+def _update_spec_from_node(spec: TaskSpec, node: _HypothesisNode) -> None:
     spec.id = node.node_id
     spec.priority = node.priority
     spec.kind = _KIND_EXPERIMENT

--- a/tools/autoresearch/utils/workflow/store.py
+++ b/tools/autoresearch/utils/workflow/store.py
@@ -11,7 +11,7 @@ Design note
 
 This module owns files under ``<workdir>/engine`` and the persistent
 ``state.json`` view written by ``state.py``. ``checkpoint.json`` is the resume
-source of truth for queued and running ``_WorkSpec`` objects; ``queue.json`` and
+source of truth for queued and running ``TaskSpec`` objects; ``queue.json`` and
 ``active.json`` are compatibility views for humans and monitoring tools.
 
 Keep persistence details here instead of spreading JSON writes across the
@@ -50,7 +50,8 @@ import os
 import time
 from pathlib import Path
 
-from ..runner import _WorkSpec
+from spdl.autoresearch.core import TaskSpec
+
 from ..state import SCHEMA_VERSION, write_state
 from ..types import _HypothesisNode
 from .policy import (
@@ -89,19 +90,19 @@ class _AutoresearchStore:
         self.engine_dir = workdir / "engine"
         self.nodes_dir = self.engine_dir / "nodes"
         self.tree: dict[str, _HypothesisNode] = {}
-        self.queued: list[_WorkSpec] = []
-        self.running: list[_WorkSpec] = []
+        self.queued: list[TaskSpec] = []
+        self.running: list[TaskSpec] = []
         self.status = "running"
         self.node_counter = 0
 
-    def load_checkpoint(self) -> list[_WorkSpec] | None:
+    def load_checkpoint(self) -> list[TaskSpec] | None:
         checkpoint = self.engine_dir / "checkpoint.json"
         if not checkpoint.exists():
             return None
         data = json.loads(checkpoint.read_text())
         self._validate_checkpoint(data)
-        self.queued = [_WorkSpec.from_dict(spec) for spec in data.get("queued", [])]
-        self.running = [_WorkSpec.from_dict(spec) for spec in data.get("running", [])]
+        self.queued = [TaskSpec.from_dict(spec) for spec in data.get("queued", [])]
+        self.running = [TaskSpec.from_dict(spec) for spec in data.get("running", [])]
         specs = self.queued + self.running
         self.status = str(data.get("status", "running"))
         for spec in specs:
@@ -118,12 +119,12 @@ class _AutoresearchStore:
             seen = set()
             for index, raw_spec in enumerate(specs):
                 if not isinstance(raw_spec, dict):
-                    raise ValueError(f"{key}[{index}] must be a _WorkSpec object")
+                    raise ValueError(f"{key}[{index}] must be a TaskSpec object")
                 spec_id = raw_spec.get("id")
                 if not isinstance(spec_id, str) or not spec_id:
                     raise ValueError(f"{key}[{index}] must have a non-empty string id")
                 if spec_id in seen:
-                    raise ValueError(f"Duplicate _WorkSpec id in {key}: {spec_id}")
+                    raise ValueError(f"Duplicate TaskSpec id in {key}: {spec_id}")
                 seen.add(spec_id)
                 payload = raw_spec.get("payload")
                 if not isinstance(payload, dict) or not isinstance(
@@ -134,8 +135,8 @@ class _AutoresearchStore:
 
     def save_scheduler_state(
         self,
-        queued: list[_WorkSpec],
-        running: list[_WorkSpec],
+        queued: list[TaskSpec],
+        running: list[TaskSpec],
         status: str,
     ) -> None:
         self.queued = queued
@@ -145,7 +146,7 @@ class _AutoresearchStore:
             self.upsert_node(_node_from_spec(spec))
         self.write_all()
 
-    def update_spec(self, spec: _WorkSpec, node: _HypothesisNode) -> None:
+    def update_spec(self, spec: TaskSpec, node: _HypothesisNode) -> None:
         _update_spec_from_node(spec, node)
         self.upsert_node(node)
         self._replace_spec(spec, self.queued)
@@ -159,7 +160,7 @@ class _AutoresearchStore:
         self.tree[node.node_id] = node
         self.node_counter = max(self.node_counter, _extract_counter(node.node_id) + 1)
 
-    def add_child(self, parent: _HypothesisNode, spec: _WorkSpec) -> None:
+    def add_child(self, parent: _HypothesisNode, spec: TaskSpec) -> None:
         node = _node_from_spec(spec)
         self.upsert_node(node)
         stored_parent = self.tree.get(parent.node_id)
@@ -182,7 +183,7 @@ class _AutoresearchStore:
         self.state["status"] = self.status
         write_state(self.workdir, self.state)
 
-    def _replace_spec(self, spec: _WorkSpec, specs: list[_WorkSpec]) -> None:
+    def _replace_spec(self, spec: TaskSpec, specs: list[TaskSpec]) -> None:
         for index, existing in enumerate(specs):
             if existing.id == spec.id:
                 specs[index] = spec


### PR DESCRIPTION
Summary:

Create the `spdl.autoresearch.core` public submodule containing the domain-neutral scheduling engine.

Public types exposed via `from spdl.autoresearch.core import ...`:
- `Orchestrator` — bounded-concurrency async scheduler with checkpoint/resume and SIGINT/SIGTERM handling
- `WorkflowProtocol` — protocol that domain adapters implement (load, checkpoint, make_coro, on_result)
- `TaskSpec` — serializable unit of work with id, priority, kind, and payload
- `TaskResult` — result carrying child specs to enqueue after completion

The `core` submodule is logically independent from the rest of `spdl.autoresearch` — it has zero coupling to SPDL, coding agents, or experiment workflows. Per the code authoring guideline, it is a public submodule (not re-exported through the parent `__init__.py`).

Dataclass fields use per-attribute docstrings. Constructor arguments documented in the class-level docstring. Each `WorkflowProtocol` method has its own docstring.

Move tests to `spdl/tests/autoresearch/orchestrator_test.py` with `*_test.py` naming and one-line docstrings on each test method.

Reviewed By: kiminoue7

Differential Revision: D105866950
