### PR TITLE
Add autoresearch domain types to `spdl.autoresearch` public API (#1450)

### DIFF
--- a/docs/source/autoresearch/autoresearch_architecture.rst
+++ b/docs/source/autoresearch/autoresearch_architecture.rst
@@ -69,7 +69,7 @@ cancellation is needed, the coroutine or adapter must do it explicitly.
 **Failures are structured domain data.** Every failure path (prepare,
 build, launch, poll, analyze, plan) produces a ``FailureRecord`` with a
 ``FailureKind`` and ``FailurePhase``. The runner never learns about
-failure kinds. Expected failures flow through ``_AutoresearchError``;
+failure kinds. Expected failures flow through ``AutoresearchError``;
 unexpected exceptions are caught and wrapped into structured records.
 This ensures durable accounting even for phases that never reach a
 remote job.

--- a/src/spdl/autoresearch/core/__init__.py
+++ b/src/spdl/autoresearch/core/__init__.py
@@ -4,25 +4,69 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-"""Core scheduling engine for autoresearch.
+"""Core types and scheduling engine for autoresearch.
 
-Provides the domain-neutral building blocks for running automated experiment
-workflows: a bounded-concurrency async orchestrator, a workflow protocol for
-domain adapters, and serializable task types.
+Provides the foundational building blocks for running automated experiment
+workflows: domain types for tracking experiments and failures, a
+bounded-concurrency async orchestrator, a workflow protocol for domain
+adapters, and serializable task types.
 
 Example::
 
-    from spdl.autoresearch.core import Orchestrator, TaskSpec
+    from spdl.autoresearch.core import (
+        Orchestrator, TaskSpec, TaskResult, WorkflowProtocol,
+    )
 
-    engine = Orchestrator(workflow=my_adapter, max_concurrency=4)
+    class MyWorkflow(WorkflowProtocol):
+        def load(self) -> list[TaskSpec]:
+            return []  # or resume from checkpoint
+
+        def checkpoint(self, queued, running, status) -> None:
+            ...  # persist scheduler state for resumption
+
+        def make_coro(self, spec: TaskSpec) -> ...:
+            # Called for each dequeued TaskSpec.  Return a coroutine
+            # that runs the experiment and produces a TaskResult.
+            return self._run_experiment(spec)
+
+        async def _run_experiment(self, spec: TaskSpec) -> TaskResult:
+            metrics = await launch_and_wait(spec.payload)
+            # Return child TaskSpecs to expand the search tree —
+            # the engine enqueues them by priority for later execution.
+            return TaskResult(children=[
+                TaskSpec(id=f"{spec.id}_variant_a", priority=-1),
+                TaskSpec(id=f"{spec.id}_variant_b", priority=0),
+            ])
+
+        async def on_result(self, spec, result) -> list[TaskSpec]:
+            # Filter or transform children before they enter the queue.
+            return result.children
+
+    engine = Orchestrator(workflow=MyWorkflow(), max_concurrency=4)
     await engine.run([TaskSpec(id="exp_001", priority=0)])
 """
 
 from ._orchestrator import Orchestrator, TaskResult, TaskSpec, WorkflowProtocol
+from ._types import (
+    AnalysisResult,
+    AutoresearchError,
+    FailureKind,
+    FailurePhase,
+    FailureRecord,
+    HypothesisNode,
+    TERMINAL_STATUSES,
+)
 
 __all__ = [
+    "AnalysisResult",
+    "AutoresearchError",
+    "FailureKind",
+    "FailurePhase",
+    "FailureRecord",
+    "HypothesisNode",
     "Orchestrator",
     "TaskResult",
     "TaskSpec",
+    "TERMINAL_STATUSES",
     "WorkflowProtocol",
 ]

--- a/src/spdl/autoresearch/core/_types.py
+++ b/src/spdl/autoresearch/core/_types.py
@@ -12,16 +12,16 @@ import dataclasses
 from dataclasses import dataclass, field
 from enum import Enum
 
-_TERMINAL_STATUSES = frozenset({"completed", "failed"})
+TERMINAL_STATUSES = frozenset({"completed", "failed"})
 
 __all__ = [
     "FailureKind",
     "FailurePhase",
     "FailureRecord",
-    "_AnalysisResult",
-    "_AutoresearchError",
-    "_HypothesisNode",
-    "_TERMINAL_STATUSES",
+    "AnalysisResult",
+    "AutoresearchError",
+    "HypothesisNode",
+    "TERMINAL_STATUSES",
 ]
 
 
@@ -85,13 +85,28 @@ class FailureRecord:
     """Machine-readable failure attached to a failed hypothesis node."""
 
     kind: FailureKind
+    """Category of the failure."""
+
     phase: FailurePhase
+    """Workflow phase where the failure occurred."""
+
     message: str
+    """Human-readable description."""
+
     retryable: bool = False
+    """Whether the engine should attempt a retry."""
+
     details: dict = field(default_factory=dict)
+    """Arbitrary extra context for debugging."""
+
     exception_type: str | None = None
+    """Fully qualified name of the original exception, if any."""
+
     job_id: str | None = None
+    """Identifier of the failed job, if applicable."""
+
     created_at: str | None = None
+    """ISO 8601 timestamp when the failure was recorded."""
 
     def to_dict(self) -> dict:
         data = dataclasses.asdict(self)
@@ -113,8 +128,14 @@ class FailureRecord:
         )
 
 
-class _AutoresearchError(RuntimeError):
-    """Expected workflow failure carrying a structured failure record."""
+class AutoresearchError(RuntimeError):
+    """Expected workflow failure carrying a structured failure record.
+
+    Args:
+        failure: The structured failure record describing what went wrong.
+            Stored as the ``failure`` attribute and its ``message`` field
+            is forwarded to ``RuntimeError``.
+    """
 
     def __init__(self, failure: FailureRecord) -> None:
         super().__init__(failure.message)
@@ -122,22 +143,48 @@ class _AutoresearchError(RuntimeError):
 
 
 @dataclass
-class _HypothesisNode:
+class HypothesisNode:
     """A node in the autoresearch hypothesis tree."""
 
     node_id: str
+    """Unique identifier (e.g. ``"003_nvdec"``)."""
+
     name: str
+    """Human-readable experiment name."""
+
     parent_id: str | None = None
+    """ID of the parent node, or ``None`` for root nodes."""
+
     commit: str | None = None
+    """Source-control commit hash for this experiment's code state."""
+
     spec: dict = field(default_factory=dict)
+    """Free-form experiment specification dict."""
+
     status: str = "queued"
+    """Current lifecycle status (``"queued"``, ``"running"``,
+    ``"completed"``, ``"failed"``)."""
+
     job_id: str | None = None
+    """External job identifier, if launched."""
+
     launched_at: float | None = None
+    """Unix timestamp when the job was launched."""
+
     result: dict | None = None
+    """Raw result dict from analysis."""
+
     children: list[str] = field(default_factory=list)
+    """IDs of child nodes in the hypothesis tree."""
+
     priority: float = 0.0
+    """Scheduling priority (lower runs first)."""
+
     duration: float | None = None
+    """Job duration in seconds, if completed."""
+
     failure: FailureRecord | None = None
+    """Structured failure record, if the experiment failed."""
 
     def to_dict(self) -> dict:
         data = dataclasses.asdict(self)
@@ -146,7 +193,7 @@ class _HypothesisNode:
         return data
 
     @classmethod
-    def from_dict(cls, data: dict) -> _HypothesisNode:
+    def from_dict(cls, data: dict) -> HypothesisNode:
         field_names = {field.name for field in dataclasses.fields(cls)}
         values = {k: v for k, v in data.items() if k in field_names}
         if isinstance(values.get("failure"), dict):
@@ -155,10 +202,17 @@ class _HypothesisNode:
 
 
 @dataclass
-class _AnalysisResult:
+class AnalysisResult:
     """Structured analysis returned after an experiment finishes."""
 
     structured: dict | None = None
+    """Parsed JSON from the agent's analysis response."""
+
     duration: float | None = None
+    """Job duration in seconds."""
+
     improved: bool = False
+    """Whether the experiment improved on the current best."""
+
     failure: FailureRecord | None = None
+    """Structured failure, if analysis detected a problem."""

--- a/tests/autoresearch/types_test.py
+++ b/tests/autoresearch/types_test.py
@@ -1,0 +1,80 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+import unittest
+
+from spdl.autoresearch.core import (
+    FailureKind,
+    FailurePhase,
+    FailureRecord,
+    HypothesisNode,
+)
+
+
+class FailureRecordTest(unittest.TestCase):
+    def test_round_trips_through_dict(self) -> None:
+        """FailureRecord survives to_dict/from_dict serialization."""
+        record = FailureRecord(
+            kind=FailureKind.JOB_STARTUP_FAILED,
+            phase=FailurePhase.JOB,
+            message="MTP failed during initialization",
+            details={"component": "mtp"},
+            job_id="job123",
+            created_at="2026-01-01T00:00:00",
+        )
+
+        loaded = FailureRecord.from_dict(record.to_dict())
+
+        self.assertEqual(FailureKind.JOB_STARTUP_FAILED, loaded.kind)
+        self.assertEqual(FailurePhase.JOB, loaded.phase)
+        self.assertEqual("MTP failed during initialization", loaded.message)
+        self.assertEqual({"component": "mtp"}, loaded.details)
+        self.assertEqual("job123", loaded.job_id)
+
+
+class HypothesisNodeTest(unittest.TestCase):
+    def test_round_trips_through_dict(self) -> None:
+        """HypothesisNode with a failure survives to_dict/from_dict."""
+        node = HypothesisNode(
+            node_id="001_bad_mtp",
+            name="bad_mtp",
+            status="failed",
+            failure=FailureRecord(
+                kind=FailureKind.JOB_STARTUP_FAILED,
+                phase=FailurePhase.JOB,
+                message="MTP failed during initialization",
+                details={"component": "mtp"},
+                job_id="job123",
+                created_at="2026-01-01T00:00:00",
+            ),
+        )
+
+        loaded = HypothesisNode.from_dict(node.to_dict())
+
+        self.assertEqual("001_bad_mtp", loaded.node_id)
+        self.assertEqual("failed", loaded.status)
+        failure = loaded.failure
+        assert failure is not None
+        self.assertEqual(FailureKind.JOB_STARTUP_FAILED, failure.kind)
+        self.assertEqual({"component": "mtp"}, failure.details)
+
+    def test_round_trips_without_failure(self) -> None:
+        """HypothesisNode without a failure round-trips cleanly."""
+        node = HypothesisNode(
+            node_id="000_baseline",
+            name="baseline",
+            status="completed",
+            priority=-1000,
+        )
+
+        loaded = HypothesisNode.from_dict(node.to_dict())
+
+        self.assertEqual("000_baseline", loaded.node_id)
+        self.assertEqual("completed", loaded.status)
+        self.assertIsNone(loaded.failure)
+        self.assertEqual(-1000, loaded.priority)

--- a/tools/autoresearch/run.py
+++ b/tools/autoresearch/run.py
@@ -42,7 +42,12 @@ import sys
 from datetime import datetime
 from pathlib import Path
 
-from spdl.autoresearch.core import Orchestrator
+from spdl.autoresearch.core import (
+    FailureKind,
+    FailurePhase,
+    FailureRecord,
+    Orchestrator,
+)
 from spdl.tools.autoresearch.utils.log import setup_logging
 from spdl.tools.autoresearch.utils.platform import (
     AutoresearchPlatform,
@@ -55,7 +60,6 @@ from spdl.tools.autoresearch.utils.state import (
     SCHEMA_VERSION,
     write_state,
 )
-from spdl.tools.autoresearch.utils.types import FailureKind, FailurePhase, FailureRecord
 from spdl.tools.autoresearch.utils.workflow import AutoresearchAdapter
 from spdl.tools.autoresearch.utils.workflow.failures import _make_failure
 

--- a/tools/autoresearch/tests/test_autoresearch_workflow.py
+++ b/tools/autoresearch/tests/test_autoresearch_workflow.py
@@ -12,7 +12,13 @@ import tempfile
 import unittest
 from pathlib import Path
 
-from spdl.autoresearch.core import TaskSpec
+from spdl.autoresearch.core import (
+    AnalysisResult,
+    FailureKind,
+    FailurePhase,
+    HypothesisNode,
+    TaskSpec,
+)
 from spdl.tools.autoresearch.plot_progress import (
     _edge_label,
     _load_tsv,
@@ -30,13 +36,6 @@ from spdl.tools.autoresearch.utils.state import (
     MASTER_TABLE_HEADERS,
     SCHEMA_VERSION,
     write_state,
-)
-from spdl.tools.autoresearch.utils.types import (
-    _AnalysisResult,
-    _HypothesisNode,
-    FailureKind,
-    FailurePhase,
-    FailureRecord,
 )
 from spdl.tools.autoresearch.utils.workflow import (
     _AutoresearchStore,
@@ -154,17 +153,17 @@ class _AutoresearchWorkflowTest(unittest.TestCase):
             )
 
     def test_planning_is_blocked_until_must_run_experiments_finish(self) -> None:
-        baseline = _HypothesisNode(
+        baseline = HypothesisNode(
             node_id="000_baseline",
             name="baseline",
             status="completed",
         )
-        headspace = _HypothesisNode(
+        headspace = HypothesisNode(
             node_id="000_headspace",
             name="headspace_cache",
             status="queued",
         )
-        mtp = _HypothesisNode(
+        mtp = HypothesisNode(
             node_id="001_mtp",
             name="mtp",
             status="completed",
@@ -181,11 +180,11 @@ class _AutoresearchWorkflowTest(unittest.TestCase):
 
         self.assertIsNone(selected)
 
-    def _load_node(self, spec: TaskSpec) -> _HypothesisNode:
+    def _load_node(self, spec: TaskSpec) -> HypothesisNode:
         """Extract node from a TaskSpec with a safe dict cast for Pyre."""
         node_data = spec.payload["node"]
         assert isinstance(node_data, dict)
-        return _HypothesisNode.from_dict(node_data)
+        return HypothesisNode.from_dict(node_data)
 
     def test_child_spec_parents_under_baseline_when_goto_is_null(self) -> None:
         """Experiments that start from anchor (goto=null) should be parented
@@ -271,18 +270,18 @@ class _AutoresearchWorkflowTest(unittest.TestCase):
             self.assertEqual("000_baseline", child_node.parent_id)
 
     def test_headspace_completion_selects_mtp_after_must_run_finish(self) -> None:
-        baseline = _HypothesisNode(
+        baseline = HypothesisNode(
             node_id="000_baseline",
             name="baseline",
             status="completed",
         )
-        headspace = _HypothesisNode(
+        headspace = HypothesisNode(
             node_id="000_headspace",
             name="headspace_cache",
             status="completed",
             spec={"_is_headspace": True},
         )
-        mtp = _HypothesisNode(
+        mtp = HypothesisNode(
             node_id="001_mtp",
             name="mtp",
             status="completed",
@@ -433,13 +432,13 @@ class _AutoresearchWorkflowTest(unittest.TestCase):
 
     def test_duplicate_requires_matching_change_sets(self) -> None:
         base = "torchx run --image $IMAGE --num_workers 8"
-        baseline = _HypothesisNode(
+        baseline = HypothesisNode(
             node_id="000_baseline",
             name="baseline",
             status="completed",
             spec={"changes": [], "launch_command": base},
         )
-        mtp = _HypothesisNode(
+        mtp = HypothesisNode(
             node_id="001_mtp",
             name="mtp",
             status="completed",
@@ -485,7 +484,7 @@ class _AutoresearchWorkflowTest(unittest.TestCase):
 
     def test_duplicate_distinguishes_param_only_experiments(self) -> None:
         base = "torchx run --image $IMAGE --num_workers 8"
-        batch_48 = _HypothesisNode(
+        batch_48 = HypothesisNode(
             node_id="002_batch48",
             name="batch_size_48",
             status="completed",
@@ -516,7 +515,7 @@ class _AutoresearchWorkflowTest(unittest.TestCase):
 
     def test_duplicate_skips_failed_nodes(self) -> None:
         base = "torchx run --image $IMAGE"
-        failed = _HypothesisNode(
+        failed = HypothesisNode(
             node_id="003_oom",
             name="batch_64",
             status="failed",
@@ -536,7 +535,7 @@ class _AutoresearchWorkflowTest(unittest.TestCase):
 
     def test_duplicate_combination_vs_individual(self) -> None:
         base = "torchx run --image $IMAGE"
-        mtp_only = _HypothesisNode(
+        mtp_only = HypothesisNode(
             node_id="001_mtp",
             name="mtp",
             status="completed",
@@ -558,7 +557,7 @@ class _AutoresearchWorkflowTest(unittest.TestCase):
         base = "torchx run --image $IMAGE --num_workers 8"
         # Old spec without changes field — change set is derived purely from
         # launch command diffs.
-        old_node = _HypothesisNode(
+        old_node = HypothesisNode(
             node_id="002_batch48",
             name="batch_size_48",
             status="completed",
@@ -584,7 +583,7 @@ class _AutoresearchWorkflowTest(unittest.TestCase):
         )
 
     def test_startup_retry_inherits_changes(self) -> None:
-        node = _HypothesisNode(
+        node = HypothesisNode(
             node_id="001_mtp",
             name="mtp",
             status="failed",
@@ -613,7 +612,7 @@ class _AutoresearchWorkflowTest(unittest.TestCase):
             for spec in specs:
                 node_data = spec.payload["node"]
                 assert isinstance(node_data, dict)
-                nodes.append(_HypothesisNode.from_dict(node_data))
+                nodes.append(HypothesisNode.from_dict(node_data))
 
             by_name = {node.name: node for node in nodes}
             self.assertEqual([], by_name["baseline"].spec["changes"])
@@ -627,7 +626,7 @@ class _AutoresearchWorkflowTest(unittest.TestCase):
             workdir = Path(tmp)
             self._write_base_files(workdir)
             store = _AutoresearchStore(workdir, _state())
-            node = _HypothesisNode(
+            node = HypothesisNode(
                 node_id="000_baseline",
                 name="baseline",
                 status="queued",
@@ -655,7 +654,7 @@ class _AutoresearchWorkflowTest(unittest.TestCase):
             workdir = Path(tmp)
             self._write_base_files(workdir)
             store = _AutoresearchStore(workdir, _state())
-            node = _HypothesisNode(
+            node = HypothesisNode(
                 node_id="002_retry",
                 name="retry",
                 status="queued",
@@ -689,35 +688,12 @@ class _AutoresearchWorkflowTest(unittest.TestCase):
             with self.assertRaisesRegex(ValueError, "payload.node"):
                 store.load_checkpoint()
 
-    def test_failure_record_round_trips_with_node(self) -> None:
-        node = _HypothesisNode(
-            node_id="001_bad_mtp",
-            name="bad_mtp",
-            status="failed",
-            failure=FailureRecord(
-                kind=FailureKind.JOB_STARTUP_FAILED,
-                phase=FailurePhase.JOB,
-                message="MTP failed during initialization",
-                details={"component": "mtp"},
-                job_id="job123",
-                created_at="2026-01-01T00:00:00",
-            ),
-        )
-
-        loaded = _HypothesisNode.from_dict(node.to_dict())
-
-        loaded_failure = loaded.failure
-        self.assertIsNotNone(loaded_failure)
-        assert loaded_failure is not None
-        self.assertEqual(FailureKind.JOB_STARTUP_FAILED, loaded_failure.kind)
-        self.assertEqual({"component": "mtp"}, loaded_failure.details)
-
     def test_store_persists_failure_view(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             workdir = Path(tmp)
             self._write_base_files(workdir)
             store = _AutoresearchStore(workdir, _state())
-            node = _HypothesisNode(
+            node = HypothesisNode(
                 node_id="001_failed",
                 name="failed",
                 status="failed",
@@ -748,7 +724,7 @@ class _AutoresearchWorkflowTest(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             workdir = Path(tmp)
             adapter = self._adapter(workdir)
-            node = _HypothesisNode(node_id="001_failed", name="failed")
+            node = HypothesisNode(node_id="001_failed", name="failed")
             spec = _spec_from_node(node)
             failure = _make_failure(
                 FailureKind.LAUNCH_FAILED,
@@ -772,13 +748,13 @@ class _AutoresearchWorkflowTest(unittest.TestCase):
             workdir = Path(tmp)
             self._write_base_files(workdir)
             state = _state()
-            node = _HypothesisNode(
+            node = HypothesisNode(
                 node_id="001_failed",
                 name="failed",
                 status="failed",
                 spec={"name": "failed"},
             )
-            result = _AnalysisResult(
+            result = AnalysisResult(
                 structured={"metrics": {}, "findings": []},
                 failure=_make_failure(
                     FailureKind.JOB_FAILED,
@@ -854,7 +830,7 @@ class _AutoresearchWorkflowTest(unittest.TestCase):
         self.assertEqual(1, runtime.details["exit_code"])
 
     def test_startup_failure_retry_is_bounded_for_mtp(self) -> None:
-        node = _HypothesisNode(
+        node = HypothesisNode(
             node_id="001_mtp",
             name="mtp",
             status="failed",
@@ -881,7 +857,7 @@ class _AutoresearchWorkflowTest(unittest.TestCase):
         self.assertIsNone(_startup_retry_spec(node, _config()))
 
     def test_retry_policy_is_kind_specific(self) -> None:
-        node = _HypothesisNode(
+        node = HypothesisNode(
             node_id="001_mtp",
             name="mtp",
             spec={"best_practices_tags": ["mtp"]},
@@ -904,18 +880,18 @@ class _AutoresearchWorkflowTest(unittest.TestCase):
         self.assertIsNone(_retry_policy_for_failure(node, _config()))
 
     def test_planning_prefers_non_startup_failed_retry(self) -> None:
-        baseline = _HypothesisNode(
+        baseline = HypothesisNode(
             node_id="000_baseline",
             name="baseline",
             status="completed",
         )
-        headspace = _HypothesisNode(
+        headspace = HypothesisNode(
             node_id="000_headspace",
             name="headspace_cache",
             status="completed",
             spec={"_is_headspace": True},
         )
-        mtp = _HypothesisNode(
+        mtp = HypothesisNode(
             node_id="001_mtp",
             name="mtp",
             status="failed",
@@ -925,7 +901,7 @@ class _AutoresearchWorkflowTest(unittest.TestCase):
                 "startup",
             ),
         )
-        retry = _HypothesisNode(
+        retry = HypothesisNode(
             node_id="002_mtp_startup_retry_1",
             name="mtp_startup_retry_1",
             status="failed",
@@ -936,7 +912,7 @@ class _AutoresearchWorkflowTest(unittest.TestCase):
                 "startup",
             ),
         )
-        better_candidate = _HypothesisNode(
+        better_candidate = HypothesisNode(
             node_id="003_threads",
             name="threads",
             status="completed",

--- a/tools/autoresearch/utils/workflow/adapter.py
+++ b/tools/autoresearch/utils/workflow/adapter.py
@@ -7,7 +7,6 @@
 """Autoresearch workflow adapter for the generic async runner.
 
 Design note
-===========
 
 This module is the domain side of the runner/adapter boundary. It orchestrates
 experiment coroutines, but durable state lives in ``store.py`` and deterministic
@@ -21,7 +20,7 @@ should sit behind ``AutoresearchPlatform`` capability objects. Do not turn the
 runner adapter boundary back into a large flat callback interface.
 
 Workflow failures are structured domain data. Expected failures should carry a
-``FailureRecord`` through ``_AutoresearchError`` or ``_AnalysisResult.failure``;
+``FailureRecord`` through ``AutoresearchError`` or ``AnalysisResult.failure``;
 the runner should never learn autoresearch failure kinds, and workflow code
 should not record durable failures as bare strings.
 
@@ -55,19 +54,20 @@ from collections.abc import Coroutine
 from pathlib import Path
 from typing import Any
 
-from spdl.autoresearch.core import TaskResult, TaskSpec
-
-from ..platform import AutoresearchPlatform
-from ..state import _append_master_row
-from ..types import (
-    _AnalysisResult,
-    _AutoresearchError,
-    _HypothesisNode,
-    _TERMINAL_STATUSES,
+from spdl.autoresearch.core import (
+    AnalysisResult,
+    AutoresearchError,
     FailureKind,
     FailurePhase,
     FailureRecord,
+    HypothesisNode,
+    TaskResult,
+    TaskSpec,
+    TERMINAL_STATUSES,
 )
+
+from ..platform import AutoresearchPlatform
+from ..state import _append_master_row
 from .analysis_ops import (
     _analyze_job,
     _update_on_complete,
@@ -107,7 +107,7 @@ class AutoresearchAdapter:
 
        flowchart LR
            Spec["TaskSpec"]
-           Node["_HypothesisNode"]
+           Node["HypothesisNode"]
            Prepare["prepare source/build"]
            Launch["launch or resume job"]
            Poll["poll status/progress"]
@@ -194,7 +194,7 @@ class AutoresearchAdapter:
         except asyncio.CancelledError:
             self._store.update_spec(spec, node)
             raise
-        except _AutoresearchError as error:
+        except AutoresearchError as error:
             await self._record_failure(spec, node, error.failure)
             return TaskResult()
         except Exception as error:
@@ -209,7 +209,7 @@ class AutoresearchAdapter:
     async def _run_experiment_inner(
         self,
         spec: TaskSpec,
-        node: _HypothesisNode,
+        node: HypothesisNode,
     ) -> TaskResult:
         if node.status == "analyzing" and node.job_id:
             status = str(spec.payload.get("terminal_status", "completed"))
@@ -248,7 +248,7 @@ class AutoresearchAdapter:
         status = await self._poll_until_terminal(spec, node)
         return await self._analyze_record_and_plan(spec, node, status)
 
-    async def _prepare(self, spec: TaskSpec, node: _HypothesisNode) -> bool:
+    async def _prepare(self, spec: TaskSpec, node: HypothesisNode) -> bool:
         async with self._state_lock:
             node.status = "preparing"
             self._store.update_spec(spec, node)
@@ -265,7 +265,7 @@ class AutoresearchAdapter:
             self._store.update_spec(spec, node)
             return prepared
 
-    async def _poll_until_terminal(self, spec: TaskSpec, node: _HypothesisNode) -> str:
+    async def _poll_until_terminal(self, spec: TaskSpec, node: HypothesisNode) -> str:
         if node.launched_at is None:
             node.launched_at = time.monotonic()
 
@@ -279,7 +279,7 @@ class AutoresearchAdapter:
                 node.job_id or "",
             )
             status = _normalize_status(raw_status)
-            if status in _TERMINAL_STATUSES:
+            if status in TERMINAL_STATUSES:
                 spec.payload["terminal_status"] = status
                 spec.payload["progress_seen"] = ever_progressed
                 self._store.update_spec(spec, node)
@@ -315,7 +315,7 @@ class AutoresearchAdapter:
 
     async def _is_stalled(
         self,
-        node: _HypothesisNode,
+        node: HypothesisNode,
         stall_start: float,
         ever_progressed: bool,
     ) -> bool:
@@ -334,7 +334,7 @@ class AutoresearchAdapter:
     async def _analyze_record_and_plan(
         self,
         spec: TaskSpec,
-        node: _HypothesisNode,
+        node: HypothesisNode,
         status: str,
     ) -> TaskResult:
         async with self._state_lock:
@@ -351,8 +351,8 @@ class AutoresearchAdapter:
                 status,
                 bool(spec.payload.get("progress_seen", False)),
             )
-            if not isinstance(result, _AnalysisResult):
-                raise TypeError(f"Expected _AnalysisResult, got {type(result)}")
+            if not isinstance(result, AnalysisResult):
+                raise TypeError(f"Expected AnalysisResult, got {type(result)}")
 
             node.status = "completed" if status == "completed" else "failed"
             node.result = result.structured
@@ -382,7 +382,7 @@ class AutoresearchAdapter:
 
             planning_result = result
             if planning_node.node_id != node.node_id:
-                planning_result = _AnalysisResult(structured=planning_node.result)
+                planning_result = AnalysisResult(structured=planning_node.result)
 
             try:
                 followups = await asyncio.to_thread(
@@ -395,10 +395,10 @@ class AutoresearchAdapter:
                     planning_result,
                     self._store.tree_dict(),
                 )
-            except _AutoresearchError:
+            except AutoresearchError:
                 raise
             except Exception as error:
-                raise _AutoresearchError(
+                raise AutoresearchError(
                     _make_failure(
                         FailureKind.PLANNING_FAILED,
                         FailurePhase.PLANNING,
@@ -415,7 +415,7 @@ class AutoresearchAdapter:
     async def _record_failure(
         self,
         spec: TaskSpec,
-        node: _HypothesisNode,
+        node: HypothesisNode,
         failure: FailureRecord,
     ) -> None:
         async with self._state_lock:
@@ -454,18 +454,18 @@ class AutoresearchAdapter:
             self._store.write_all()
             await asyncio.to_thread(_update_summary_and_plot, self.workdir, self.state)
 
-    def _initial_nodes(self) -> list[_HypothesisNode]:
+    def _initial_nodes(self) -> list[HypothesisNode]:
         nodes = _build_initial_nodes(self.workdir, self.config, self.state)
         for node in nodes:
             self._store.upsert_node(node)
         self._store.write_all()
         return nodes
 
-    def _create_child_spec(self, parent: _HypothesisNode, child_spec: dict) -> TaskSpec:
+    def _create_child_spec(self, parent: HypothesisNode, child_spec: dict) -> TaskSpec:
         name = child_spec.get("name", f"exp_{self._store.node_counter}")
         child_spec["change_summary"] = _change_summary_for_spec(child_spec)
         actual_parent = self._resolve_parent(parent, child_spec)
-        node = _HypothesisNode(
+        node = HypothesisNode(
             node_id=f"{self._store.node_counter:03d}_{name}",
             name=name,
             parent_id=actual_parent.node_id,
@@ -479,9 +479,9 @@ class AutoresearchAdapter:
 
     def _resolve_parent(
         self,
-        default_parent: _HypothesisNode,
+        default_parent: HypothesisNode,
         child_spec: dict,
-    ) -> _HypothesisNode:
+    ) -> HypothesisNode:
         """Resolve the actual parent node for a child experiment.
 
         When ``goto`` is absent or null (experiment starts from the anchor

--- a/tools/autoresearch/utils/workflow/analysis_ops.py
+++ b/tools/autoresearch/utils/workflow/analysis_ops.py
@@ -13,6 +13,13 @@ import logging
 from datetime import datetime
 from pathlib import Path
 
+from spdl.autoresearch.core import (
+    AnalysisResult,
+    AutoresearchError,
+    FailureKind,
+    FailurePhase,
+    HypothesisNode,
+)
 from spdl.tools.autoresearch.plot_progress import (
     _load_tsv,
     _plot_hypothesis_tree,
@@ -22,13 +29,6 @@ from spdl.tools.autoresearch.plot_progress import (
 from ..platform import AutoresearchPlatform
 from ..platform.agents import _parse_agent_result
 from ..state import _append_master_row, _read_master_table, write_state
-from ..types import (
-    _AnalysisResult,
-    _AutoresearchError,
-    _HypothesisNode,
-    FailureKind,
-    FailurePhase,
-)
 from .common import (
     _compare_value,
     _current_best_metric,
@@ -53,8 +53,8 @@ def _analyze_job(
     status: str,
     progress_seen: bool = False,
 ) -> object:
-    """Analyze a completed job. Returns _AnalysisResult."""
-    assert isinstance(node, _HypothesisNode)
+    """Analyze a completed job. Returns AnalysisResult."""
+    assert isinstance(node, HypothesisNode)
 
     knowledge = platform.agent._load_knowledge()
     pipeline_code = _read_pipeline_code(config, workdir)
@@ -72,7 +72,7 @@ def _analyze_job(
     try:
         evidence = platform.evidence.collect(job_id, metrics_dir)
     except Exception as error:
-        raise _AutoresearchError(
+        raise AutoresearchError(
             _make_failure(
                 FailureKind.METRICS_COLLECTION_FAILED,
                 FailurePhase.METRICS,
@@ -101,7 +101,7 @@ def _analyze_job(
     try:
         analysis = platform.agent.run(prompt, workdir, f"analyze_{run_id}")
     except Exception as error:
-        raise _AutoresearchError(
+        raise AutoresearchError(
             _make_failure(
                 FailureKind.ANALYSIS_FAILED,
                 FailurePhase.ANALYSIS,
@@ -136,7 +136,7 @@ def _analyze_job(
         best_type == "none" or (cur_type == best_type and cur_val < best_val)
     )
 
-    return _AnalysisResult(
+    return AnalysisResult(
         structured=structured,
         duration=float(duration)
         if isinstance(duration, (int, float)) and duration > 0
@@ -148,7 +148,7 @@ def _analyze_job(
 
 def _append_master_result_row(
     workdir: Path,
-    node: _HypothesisNode,
+    node: HypothesisNode,
     status: str,
     duration: object,
     structured: dict | None,
@@ -185,8 +185,8 @@ def _update_on_complete(
     result: object,
 ) -> None:
     """Update autoresearch state after a node completes."""
-    assert isinstance(node, _HypothesisNode)
-    assert isinstance(result, _AnalysisResult)
+    assert isinstance(node, HypothesisNode)
+    assert isinstance(result, AnalysisResult)
 
     exp = node.spec
     best_type, best_val = _current_best_metric(state)

--- a/tools/autoresearch/utils/workflow/failures.py
+++ b/tools/autoresearch/utils/workflow/failures.py
@@ -16,9 +16,9 @@ resulting ``FailureRecord`` on the node.
 
    flowchart LR
        Operation["workflow operation"]
-       Error["_AutoresearchError"]
+       Error["AutoresearchError"]
        Adapter["AutoresearchAdapter"]
-       Node["_HypothesisNode.failure"]
+       Node["HypothesisNode.failure"]
        Store["failure.json / history"]
 
        Operation -->|"expected failure"| Error
@@ -34,13 +34,14 @@ from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import NoReturn
 
-from ..platform import _MetricsEvidence
-from ..types import (
-    _AutoresearchError,
+from spdl.autoresearch.core import (
+    AutoresearchError,
     FailureKind,
     FailurePhase,
     FailureRecord,
 )
+
+from ..platform import _MetricsEvidence
 
 __all__ = [
     "_FAILURE_POLICIES",
@@ -223,7 +224,7 @@ def _raise_failure(
     exception: BaseException | None = None,
     job_id: str | None = None,
 ) -> NoReturn:
-    raise _AutoresearchError(
+    raise AutoresearchError(
         _make_failure(
             kind,
             phase,

--- a/tools/autoresearch/utils/workflow/planning_ops.py
+++ b/tools/autoresearch/utils/workflow/planning_ops.py
@@ -13,10 +13,11 @@ import logging
 import re
 from pathlib import Path
 
+from spdl.autoresearch.core import AnalysisResult, HypothesisNode
+
 from ..platform import AutoresearchPlatform
 from ..platform.agents import _parse_agent_result
 from ..state import _read_master_table, write_state
-from ..types import _AnalysisResult, _HypothesisNode
 from .common import _current_best_metric, _read_pipeline_code
 from .policy import (
     _change_summary_for_spec,
@@ -259,8 +260,8 @@ def _plan_followups(
     tree: dict,
 ) -> list[dict]:
     """Plan follow-up experiments. Returns experiment spec dicts."""
-    assert isinstance(parent_node, _HypothesisNode)
-    assert isinstance(result, _AnalysisResult)
+    assert isinstance(parent_node, HypothesisNode)
+    assert isinstance(result, AnalysisResult)
 
     if parent_node.spec.get("_is_headspace"):
         return []
@@ -304,15 +305,15 @@ def _plan_followups(
 
 
 def _build_initial_nodes(workdir: Path, config: dict, state: dict) -> list:
-    """Create initial _HypothesisNode objects for baseline, headspace, and MTP."""
-    nodes: list[_HypothesisNode] = []
+    """Create initial HypothesisNode objects for baseline, headspace, and MTP."""
+    nodes: list[HypothesisNode] = []
     history_names = {entry.get("name") for entry in state.get("history", [])}
     tried_practices = set(state.get("best_practices_tried", []))
     base_launch = config.get("base_launch_command", "")
 
     if "baseline" not in history_names:
         nodes.append(
-            _HypothesisNode(
+            HypothesisNode(
                 node_id="000_baseline",
                 name="baseline",
                 spec={
@@ -337,7 +338,7 @@ def _build_initial_nodes(workdir: Path, config: dict, state: dict) -> list:
     )
     if not headspace_succeeded:
         nodes.append(
-            _HypothesisNode(
+            HypothesisNode(
                 node_id="000_headspace",
                 name="headspace_cache",
                 spec={
@@ -359,7 +360,7 @@ def _build_initial_nodes(workdir: Path, config: dict, state: dict) -> list:
 
     if "mtp" not in tried_practices:
         nodes.append(
-            _HypothesisNode(
+            HypothesisNode(
                 node_id="001_mtp",
                 name="mtp",
                 spec={

--- a/tools/autoresearch/utils/workflow/policy.py
+++ b/tools/autoresearch/utils/workflow/policy.py
@@ -11,7 +11,6 @@ or filesystem writes. Keep predictable decisions here so they can be unit tested
 without infrastructure.
 
 Design note
-===========
 
 If a behavior is deterministic and can be expressed from specs, nodes, state,
 or metrics already in memory, prefer adding it here instead of burying it in
@@ -22,7 +21,7 @@ or LLM calls.
 .. mermaid::
 
    flowchart LR
-       Inputs["TaskSpec / _HypothesisNode / state"]
+       Inputs["TaskSpec / HypothesisNode / state"]
        Policy["pure policy helpers"]
        Decisions["workflow decisions"]
        Tests["unit tests"]
@@ -41,9 +40,12 @@ import re
 import shlex
 from collections.abc import Iterable, Mapping
 
-from spdl.autoresearch.core import TaskSpec
-
-from ..types import _HypothesisNode, _TERMINAL_STATUSES, FailureKind
+from spdl.autoresearch.core import (
+    FailureKind,
+    HypothesisNode,
+    TaskSpec,
+    TERMINAL_STATUSES,
+)
 
 __all__ = [
     "_build_change_set",
@@ -95,25 +97,25 @@ def _normalize_status(status: str) -> str:
     return "running"
 
 
-def _is_headspace_node(node: _HypothesisNode) -> bool:
+def _is_headspace_node(node: HypothesisNode) -> bool:
     return bool(node.spec.get("_is_headspace")) or "headspace" in node.name
 
 
 def _initial_experiments_finished(
-    tree: Mapping[str, _HypothesisNode],
+    tree: Mapping[str, HypothesisNode],
     required_names: frozenset[str] = _REQUIRED_INITIAL_EXPERIMENTS,
 ) -> bool:
     by_name = {node.name: node for node in tree.values()}
     return all(
-        (node := by_name.get(name)) is not None and node.status in _TERMINAL_STATUSES
+        (node := by_name.get(name)) is not None and node.status in TERMINAL_STATUSES
         for name in required_names
     )
 
 
 def _select_planning_node(
-    completed_node: _HypothesisNode,
-    tree: Mapping[str, _HypothesisNode],
-) -> _HypothesisNode | None:
+    completed_node: HypothesisNode,
+    tree: Mapping[str, HypothesisNode],
+) -> HypothesisNode | None:
     """Pick the non-headspace completed node that should trigger planning.
 
     Only successfully completed nodes can be planning parents.  Failed nodes
@@ -233,7 +235,7 @@ def _build_change_set(
 
 def _is_duplicate_spec(
     spec: dict,
-    nodes: Iterable[_HypothesisNode],
+    nodes: Iterable[HypothesisNode],
     base_launch_command: str = "",
 ) -> bool:
     """Check whether *spec* duplicates a non-failed node in *nodes*.
@@ -382,7 +384,7 @@ def _first_interesting_flag(command: str) -> str | None:
     return None
 
 
-def _record_failed_best_practice_attempt(state: dict, node: _HypothesisNode) -> None:
+def _record_failed_best_practice_attempt(state: dict, node: HypothesisNode) -> None:
     tags = node.spec.get("best_practices_tags", [])
     if not tags:
         return
@@ -399,7 +401,7 @@ def _record_failed_best_practice_attempt(state: dict, node: _HypothesisNode) -> 
     state["best_practices_tried"] = sorted(tried)
 
 
-def _retry_policy_for_failure(node: _HypothesisNode, config: dict) -> dict | None:
+def _retry_policy_for_failure(node: HypothesisNode, config: dict) -> dict | None:
     failure = node.failure
     if failure is None:
         return None
@@ -426,7 +428,7 @@ def _retry_policy_for_failure(node: _HypothesisNode, config: dict) -> dict | Non
     }
 
 
-def _is_startup_failed_retry(node: _HypothesisNode) -> bool:
+def _is_startup_failed_retry(node: HypothesisNode) -> bool:
     failure = node.failure
     return bool(
         node.spec.get("_startup_retry_of")
@@ -435,7 +437,7 @@ def _is_startup_failed_retry(node: _HypothesisNode) -> bool:
     )
 
 
-def _startup_retry_spec(node: _HypothesisNode, config: dict) -> dict | None:
+def _startup_retry_spec(node: HypothesisNode, config: dict) -> dict | None:
     """Return a repair experiment for retryable startup failures.
 
     Failed must-run experiments still count as terminal once attempts are
@@ -474,7 +476,7 @@ def _startup_retry_spec(node: _HypothesisNode, config: dict) -> dict | None:
     return retry
 
 
-def _spec_from_node(node: _HypothesisNode) -> TaskSpec:
+def _spec_from_node(node: HypothesisNode) -> TaskSpec:
     node.spec["change_summary"] = _change_summary_for_spec(node.spec)
     return TaskSpec(
         id=node.node_id,
@@ -484,14 +486,14 @@ def _spec_from_node(node: _HypothesisNode) -> TaskSpec:
     )
 
 
-def _node_from_spec(spec: TaskSpec) -> _HypothesisNode:
+def _node_from_spec(spec: TaskSpec) -> HypothesisNode:
     node_data = spec.payload.get("node", {})
     if not isinstance(node_data, dict):
         raise ValueError(f"Work spec {spec.id} has no node payload")
-    return _HypothesisNode.from_dict(node_data)
+    return HypothesisNode.from_dict(node_data)
 
 
-def _update_spec_from_node(spec: TaskSpec, node: _HypothesisNode) -> None:
+def _update_spec_from_node(spec: TaskSpec, node: HypothesisNode) -> None:
     spec.id = node.node_id
     spec.priority = node.priority
     spec.kind = _KIND_EXPERIMENT

--- a/tools/autoresearch/utils/workflow/source_ops.py
+++ b/tools/autoresearch/utils/workflow/source_ops.py
@@ -13,8 +13,14 @@ import logging
 import re
 from pathlib import Path
 
+from spdl.autoresearch.core import (
+    AutoresearchError,
+    FailureKind,
+    FailurePhase,
+    HypothesisNode,
+)
+
 from ..platform import AutoresearchPlatform
-from ..types import _AutoresearchError, _HypothesisNode, FailureKind, FailurePhase
 from .common import _read_pipeline_code
 from .failures import _make_failure, _raise_failure
 
@@ -103,7 +109,7 @@ def _apply_code_changes(
     try:
         output = platform.agent.run(prompt, workdir, f"apply_{run_id}")
     except Exception as error:
-        raise _AutoresearchError(
+        raise AutoresearchError(
             _make_failure(
                 FailureKind.CODE_CHANGE_FAILED,
                 FailurePhase.CODE_CHANGE,
@@ -124,7 +130,7 @@ def _apply_code_changes(
         try:
             output = platform.agent.run(retry_prompt, workdir, f"apply_{run_id}_retry")
         except Exception as error:
-            raise _AutoresearchError(
+            raise AutoresearchError(
                 _make_failure(
                     FailureKind.CODE_CHANGE_FAILED,
                     FailurePhase.CODE_CHANGE,
@@ -163,7 +169,7 @@ def _apply_code_changes(
         try:
             commit_hash = platform.workspace.commit(scm, source_dir, msg)
         except Exception as error:
-            raise _AutoresearchError(
+            raise AutoresearchError(
                 _make_failure(
                     FailureKind.CODE_CHANGE_FAILED,
                     FailurePhase.CODE_CHANGE,
@@ -190,7 +196,7 @@ def _prepare_node(
     parent: object | None,
 ) -> bool:
     """Prepare a node: restore source, apply code changes, and build."""
-    assert isinstance(node, _HypothesisNode)
+    assert isinstance(node, HypothesisNode)
 
     exp = node.spec
     run_id = node.node_id
@@ -200,7 +206,7 @@ def _prepare_node(
     source_dir = config.get("source_dir", "")
     anchor = state.get("anchor_commit", "")
     parent_ok = (
-        isinstance(parent, _HypothesisNode)
+        isinstance(parent, HypothesisNode)
         and parent.status == "completed"
         and not parent.spec.get("_is_headspace")
     )
@@ -235,7 +241,7 @@ def _prepare_node(
         try:
             platform.workspace.commit(scm, source_dir, msg)
         except Exception as error:
-            raise _AutoresearchError(
+            raise AutoresearchError(
                 _make_failure(
                     FailureKind.CODE_CHANGE_FAILED,
                     FailurePhase.CODE_CHANGE,
@@ -249,7 +255,7 @@ def _prepare_node(
         try:
             image = platform.artifacts.build(build_cmd, workdir, source_dir)
         except Exception as error:
-            raise _AutoresearchError(
+            raise AutoresearchError(
                 _make_failure(
                     FailureKind.BUILD_FAILED,
                     FailurePhase.BUILD,
@@ -281,7 +287,7 @@ def _launch_node(
     workdir: Path,
 ) -> str | None:
     """Launch a job for a node. Returns job_id or raises structured failure."""
-    assert isinstance(node, _HypothesisNode)
+    assert isinstance(node, HypothesisNode)
 
     exp = node.spec
     launch_cmd = exp.get("launch_command", "") or config.get("base_launch_command", "")
@@ -300,7 +306,7 @@ def _launch_node(
     try:
         job_id = platform.execution.launch(launch_cmd, workdir)
     except Exception as error:
-        raise _AutoresearchError(
+        raise AutoresearchError(
             _make_failure(
                 FailureKind.LAUNCH_FAILED,
                 FailurePhase.LAUNCH,

--- a/tools/autoresearch/utils/workflow/store.py
+++ b/tools/autoresearch/utils/workflow/store.py
@@ -7,7 +7,6 @@
 """Persistent autoresearch workflow state and monitoring views.
 
 Design note
-===========
 
 This module owns files under ``<workdir>/engine`` and the persistent
 ``state.json`` view written by ``state.py``. ``checkpoint.json`` is the resume
@@ -50,10 +49,9 @@ import os
 import time
 from pathlib import Path
 
-from spdl.autoresearch.core import TaskSpec
+from spdl.autoresearch.core import HypothesisNode, TaskSpec
 
 from ..state import SCHEMA_VERSION, write_state
-from ..types import _HypothesisNode
 from .policy import (
     _extract_counter,
     _node_from_spec,
@@ -89,7 +87,7 @@ class _AutoresearchStore:
         self.state = state
         self.engine_dir = workdir / "engine"
         self.nodes_dir = self.engine_dir / "nodes"
-        self.tree: dict[str, _HypothesisNode] = {}
+        self.tree: dict[str, HypothesisNode] = {}
         self.queued: list[TaskSpec] = []
         self.running: list[TaskSpec] = []
         self.status = "running"
@@ -146,21 +144,21 @@ class _AutoresearchStore:
             self.upsert_node(_node_from_spec(spec))
         self.write_all()
 
-    def update_spec(self, spec: TaskSpec, node: _HypothesisNode) -> None:
+    def update_spec(self, spec: TaskSpec, node: HypothesisNode) -> None:
         _update_spec_from_node(spec, node)
         self.upsert_node(node)
         self._replace_spec(spec, self.queued)
         self._replace_spec(spec, self.running)
         self.write_all()
 
-    def upsert_node(self, node: _HypothesisNode) -> None:
+    def upsert_node(self, node: HypothesisNode) -> None:
         existing = self.tree.get(node.node_id)
         if existing is not None and existing.children and not node.children:
             node.children = existing.children
         self.tree[node.node_id] = node
         self.node_counter = max(self.node_counter, _extract_counter(node.node_id) + 1)
 
-    def add_child(self, parent: _HypothesisNode, spec: TaskSpec) -> None:
+    def add_child(self, parent: HypothesisNode, spec: TaskSpec) -> None:
         node = _node_from_spec(spec)
         self.upsert_node(node)
         stored_parent = self.tree.get(parent.node_id)
@@ -265,7 +263,7 @@ class _AutoresearchStore:
             + "\n",
         )
 
-    def _persist_node(self, node: _HypothesisNode) -> None:
+    def _persist_node(self, node: HypothesisNode) -> None:
         node_dir = self.nodes_dir / node.node_id
         node_dir.mkdir(parents=True, exist_ok=True)
         (node_dir / "spec.json").write_text(json.dumps(node.spec, indent=2) + "\n")


### PR DESCRIPTION
Summary:

Move the core domain types module from `spdl/tools/autoresearch/utils/types.py` to `spdl/autoresearch/_types.py` and expose all types as public API.

Make `FailureKind`, `FailurePhase`, `FailureRecord`, `AutoresearchError`, `HypothesisNode`, `AnalysisResult`, and `TERMINAL_STATUSES` public (drop underscore prefix). Add Google-style docstrings with `Args:` sections to `FailureRecord`, `HypothesisNode`, and `AnalysisResult`. Re-export all through `spdl/autoresearch/__init__.py`.

Reviewed By: kiminoue7

Differential Revision: D105866947
