### PR TITLE
[autoresearch] Fix utility function: optimize sample throughput instead of step time

### DIFF
--- a/src/spdl/autoresearch/pipeline_optimization/_ops/_analysis_ops.py
+++ b/src/spdl/autoresearch/pipeline_optimization/_ops/_analysis_ops.py
@@ -40,7 +40,7 @@ from ._common import (
     _read_pipeline_code,
 )
 from ._failures import _classify_terminal_job_failure, _failure_note, _make_failure
-from ._policy import _change_summary_for_spec
+from ._policy import _change_summary_for_spec, _format_best_metric
 
 _LG: logging.Logger = logging.getLogger(__name__)
 
@@ -137,7 +137,7 @@ def _analyze_job(
     )
     best_type, best_val = _current_best_metric(state)
     improved = cur_type != "none" and (
-        best_type == "none" or (cur_type == best_type and cur_val < best_val)
+        best_type == "none" or (cur_type == best_type and cur_val > best_val)
     )
 
     return AnalysisResult(
@@ -218,7 +218,7 @@ def _update_on_complete(
     if (
         not _is_headspace_entry({"name": node.name})
         and cur_type != "none"
-        and (best_type == "none" or (cur_type == best_type and cur_val < best_val))
+        and (best_type == "none" or (cur_type == best_type and cur_val > best_val))
     ):
         state["current_best"] = node.node_id
 
@@ -283,20 +283,24 @@ def _update_summary_and_plot(workdir: Path, state: dict) -> None:
     best_metric = state.get("best_metric")
     plateau = state.get("plateau_count", 0)
 
-    best_str = f"{best_metric:.0f}ms" if best_metric else "N/A"
+    best_type, best_val = _current_best_metric(state)
+    best_str = _format_best_metric(best_type, best_val)
     lines = [
         "# Autoresearch Progress\n",
         f"**Total experiments**: {len(history)}",
         f"**Current best**: {best}",
-        f"**Best steady step time**: {best_str}",
+        f"**Best metric**: {best_str}",
         f"**Plateau count**: {plateau}\n",
         "## Recent Results\n",
     ]
     for entry in history[-5:]:
         metrics = (entry.get("structured") or {}).get("metrics", {})
+        tput = metrics.get("throughput_samples_per_s")
         step = metrics.get("steady_step_time_ms") or metrics.get("step_time_ms")
         dur = metrics.get("duration_s")
         metric_parts = []
+        if tput is not None:
+            metric_parts.append(f"throughput={tput:.1f} samples/s")
         if step is not None:
             metric_parts.append(f"step={step}ms")
         if dur is not None:

--- a/src/spdl/autoresearch/pipeline_optimization/_ops/_common.py
+++ b/src/spdl/autoresearch/pipeline_optimization/_ops/_common.py
@@ -39,22 +39,28 @@ def _is_headspace_entry(entry: dict) -> bool:
 
 
 def _current_best_metric(state: dict) -> tuple[str, float]:
-    best_step = float("inf")
-    best_dur = float("inf")
+    """Scan history and return the best metric seen so far.
+
+    Higher values are always better (throughput is positive,
+    step_time/duration are negated by ``_compare_metric_value``).
+    """
+    best_type: str = "none"
+    best_val: float = float("-inf")
     for entry in state.get("history", []):
         if _is_headspace_entry(entry):
             continue
         structured = entry.get("structured") or {}
         metrics = structured.get("metrics", {})
-        step = metrics.get("steady_step_time_ms")
-        if isinstance(step, (int, float)) and step > 0:
-            best_step = min(best_step, float(step))
-        dur = metrics.get("duration_s")
-        if isinstance(dur, (int, float)) and dur > 0:
-            best_dur = min(best_dur, float(dur))
-
-    if best_step < float("inf"):
-        return ("step_ms", best_step)
-    if best_dur < float("inf"):
-        return ("duration_s", best_dur)
-    return ("none", float("inf"))
+        cur_type, cur_val = _compare_metric_value(metrics)
+        if cur_type == "none":
+            continue
+        # Prefer throughput over step_ms over duration_s.
+        # If types match, take the higher value (= better).
+        if best_type == "none" or (cur_type == best_type and cur_val > best_val):
+            best_type = cur_type
+            best_val = cur_val
+        elif cur_type == "throughput" and best_type != "throughput":
+            # Throughput always wins over fallback metrics.
+            best_type = cur_type
+            best_val = cur_val
+    return (best_type, best_val)

--- a/src/spdl/autoresearch/pipeline_optimization/_ops/_planning_ops.py
+++ b/src/spdl/autoresearch/pipeline_optimization/_ops/_planning_ops.py
@@ -21,8 +21,10 @@ from .._platform._agents import _parse_agent_result
 from ._common import _current_best_metric, _read_pipeline_code
 from ._policy import (
     _change_summary_for_spec,
+    _compare_metric_value,
     _extract_default_executor_concurrency,
     _extract_total_threads,
+    _format_best_metric,
     _validate_thread_budget as _policy_validate_thread_budget,
 )
 
@@ -65,8 +67,8 @@ def _thread_cap_for_experiment(state: dict, config: dict) -> int:
     results_below_cap = []
     for entry in state.get("history", []):
         metrics = (entry.get("structured") or {}).get("metrics", {})
-        step = metrics.get("steady_step_time_ms")
-        if not isinstance(step, (int, float)) or step <= 0:
+        metric_type, metric_val = _compare_metric_value(metrics)
+        if metric_type == "none":
             continue
         run_id = entry.get("run_id", "")
         name = entry.get("name", "")
@@ -81,14 +83,14 @@ def _thread_cap_for_experiment(state: dict, config: dict) -> int:
         if total is None:
             continue
         if total >= _MAX_THREADS_PER_RANK_DEFAULT:
-            results_at_cap.append(step)
+            results_at_cap.append(metric_val)
         else:
-            results_below_cap.append(step)
+            results_below_cap.append(metric_val)
 
     if not results_at_cap:
         return _MAX_THREADS_PER_RANK_DEFAULT
-    best_at_cap = min(results_at_cap)
-    if results_below_cap and best_at_cap < min(results_below_cap):
+    best_at_cap = max(results_at_cap)  # higher is better
+    if results_below_cap and best_at_cap > max(results_below_cap):
         return _MAX_THREADS_PER_RANK_EXTENDED
     return _MAX_THREADS_PER_RANK_DEFAULT
 
@@ -184,7 +186,7 @@ def _get_plan(
         MAX_ITERATIONS=str(max_iter),
         PATIENCE=str(patience),
         PLATEAU_COUNT=str(plateau_count),
-        BEST_METRIC=str(state.get("best_metric") or "N/A"),
+        BEST_METRIC=_format_best_metric(*_current_best_metric(state)),
         BEST_PRACTICES_TRIED=", ".join(state.get("best_practices_tried", [])) or "none",
         BEST_PRACTICES_REMAINING=", ".join(untried) or "none",
         BASE_LAUNCH_COMMAND=config.get("base_launch_command", ""),
@@ -271,8 +273,8 @@ def _plan_followups(
     iteration = state.get("iteration", 0) + 1
 
     _, cur_best = _current_best_metric(state)
-    prev_best_at_last_plan = state.get("_best_at_last_plan", float("inf"))
-    if cur_best < prev_best_at_last_plan:
+    prev_best_at_last_plan = state.get("_best_at_last_plan", float("-inf"))
+    if cur_best > prev_best_at_last_plan:
         state["plateau_count"] = 0
         state["best_metric"] = cur_best
     else:

--- a/src/spdl/autoresearch/pipeline_optimization/_ops/_policy.py
+++ b/src/spdl/autoresearch/pipeline_optimization/_ops/_policy.py
@@ -275,13 +275,39 @@ def _should_cancel_for_stall(
 
 
 def _compare_metric_value(metrics: Mapping[str, object]) -> tuple[str, float]:
+    """Extract the primary comparison metric from experiment results.
+
+    Returns ``(type, value)`` where *higher* values are always better.
+    Callers should use ``>`` to test for improvement.
+
+    Priority:
+    1. ``throughput_samples_per_s`` — reported by the analysis agent; directly
+       measures end-to-end training throughput.  Higher is better.
+    2. ``steady_step_time_ms`` — fallback when throughput is unavailable.
+       Negated so that lower step-time becomes higher metric value.
+    3. ``duration_s`` — last-resort fallback (also negated).
+    """
+    tput = metrics.get("throughput_samples_per_s")
+    if isinstance(tput, (int, float)) and tput > 0:
+        return ("throughput", float(tput))
     step = metrics.get("steady_step_time_ms")
     if isinstance(step, (int, float)) and step > 0:
-        return ("step_ms", float(step))
+        return ("step_ms", -float(step))
     duration = metrics.get("duration_s")
     if isinstance(duration, (int, float)) and duration > 0:
-        return ("duration_s", float(duration))
-    return ("none", float("inf"))
+        return ("duration_s", -float(duration))
+    return ("none", float("-inf"))
+
+
+def _format_best_metric(metric_type: str, value: float) -> str:
+    """Format the best metric value for display."""
+    if metric_type == "throughput":
+        return f"{value:.1f} samples/s"
+    if metric_type == "step_ms":
+        return f"{-value:.0f}ms"
+    if metric_type == "duration_s":
+        return f"{-value:.0f}s"
+    return "N/A"
 
 
 def _extract_total_threads(launch_cmd: str) -> int | None:

--- a/src/spdl/autoresearch/pipeline_optimization/prompts/analyze.md
+++ b/src/spdl/autoresearch/pipeline_optimization/prompts/analyze.md
@@ -67,6 +67,7 @@ __PIPELINE_CODE__
   "metrics": {
     "step_time_ms": <number or null>,
     "steady_step_time_ms": <number or null>,
+    "throughput_samples_per_s": <number or null>,
     "ttfb_s": <number or null>,
     "sm_utilization_pct": <number>,
     "steady_sm_utilization_pct": <number or null>,
@@ -85,6 +86,7 @@ __PIPELINE_CODE__
 }
 ```
 
+For `throughput_samples_per_s`: **this is the primary optimization metric** (higher is better). Calculate total sample throughput across all ranks from the job logs (e.g., "263.2 samples/s" at the end of training). If not directly available, compute as `batch_size * num_ranks * 1000 / steady_step_time_ms`. This metric correctly accounts for batch size changes — a smaller batch with a lower step time may still have worse throughput.
 For `steady_step_time_ms`: use the median step time after warmup. If per-step data is unavailable, estimate from sink QPS or set to null.
 For `steady_sm_utilization_pct`: use p50 or p75 SM util from system metrics. Prefer p75 for very short jobs (< 5 min).
 For `sm_utilization_pct`: still report the raw average for the master table, but note it's init-diluted.

--- a/src/spdl/autoresearch/pipeline_optimization/prompts/plan_next.md
+++ b/src/spdl/autoresearch/pipeline_optimization/prompts/plan_next.md
@@ -14,7 +14,7 @@ __KNOWLEDGE__
 **Cached image**: `__CACHED_IMAGE__`
 
 ### Progress
-- **Best steady step time so far**: __BEST_METRIC__ (lower is better; may be in ms or seconds depending on source)
+- **Best metric so far**: __BEST_METRIC__ (higher is better — throughput in samples/s when available, otherwise negated step time)
 - **Plateau count**: __PLATEAU_COUNT__ of __PATIENCE__ (consecutive iterations without improvement based on steady-state metrics)
 
 ### Best Practices Checklist
@@ -57,12 +57,15 @@ __NOTES__
 
 ## Instructions
 
-Based on the results so far, decide the next action. **Your goal is to minimize steady-state step time** (which directly determines production training throughput).
+Based on the results so far, decide the next action. **Your goal is to maximize sample throughput** (`throughput_samples_per_s`), which is the true measure of training speed.
+
+**IMPORTANT**: Do NOT optimize step time alone — reducing batch size lowers step time but may reduce total sample throughput. Always compare experiments by `throughput_samples_per_s`. A configuration with higher step time but higher throughput is BETTER.
 
 **Metric priority for comparing experiments:**
-1. **Steady-state step time** (`steady_step_time_ms`) — the most reliable metric. Median step time after discarding warmup steps.
-2. **Steady-state SM utilization** (`steady_sm_utilization_pct`) — proxy when step time is unavailable. Use p50/p75 from system metrics, NOT the raw average (which is diluted by the zero-utilization init phase).
-3. **Raw job duration** — least reliable for short experiments due to variable init times. Only use when neither of the above is available.
+1. **Sample throughput** (`throughput_samples_per_s`) — the primary metric. Total samples processed per second across all ranks. Higher is better.
+2. **Steady-state step time** (`steady_step_time_ms`) — secondary metric, only useful when comparing runs with the same batch size. Lower is better.
+3. **Steady-state SM utilization** (`steady_sm_utilization_pct`) — proxy when neither of the above is available.
+4. **Raw job duration** — least reliable for short experiments due to variable init times.
 
 Do NOT compare experiments using raw average SM utilization — it is misleading for short experiments where the initialization phase (zero GPU activity) significantly dilutes the average.
 


### PR DESCRIPTION
…ad of step time

The autoresearch engine was using `steady_step_time_ms` (lower is better) as the sole optimization metric. This is incorrect because reducing batch size lowers step time without improving — and potentially reducing — actual training throughput (samples/s).

Evidence from the video_classification experiment:
- `subclip_1s` (batch_size=16, step_time=443ms): **293 samples/s** ← actual best
- `batch_size_8` (batch_size=8, step_time=233ms): **263 samples/s** ← 10% worse throughput

The engine incorrectly ranked `batch_size_8` as the best run because 233ms < 443ms, even though it processes fewer samples per second.

Changes:
- Add `throughput_samples_per_s` as the primary optimization metric in the analysis JSON schema and prompt
- Change `_compare_metric_value` to prefer throughput (higher is better), falling back to negated step_time for backward compatibility
- Reverse all comparison operators from `<` (lower is better) to `>` (higher is better) throughout the comparison chain: `_current_best_metric`, `_analyze_job`, `_update_on_complete`, and `_plan_next_experiments`
- Add `_format_best_metric` helper for human-readable display of the metric value
- Update the planning prompt to instruct the LLM agent to maximize `throughput_samples_per_s` rather than minimize step time, with an explicit warning about the batch size pitfall
- Update summary display to show throughput alongside step time