### PR TITLE
Add default engine-state persistence helpers to core

### DIFF
--- a/src/spdl/autoresearch/core/__init__.py
+++ b/src/spdl/autoresearch/core/__init__.py
@@ -9,20 +9,32 @@
 Provides the foundational building blocks for running automated experiment
 workflows: domain types for tracking experiments and failures, a
 bounded-concurrency async orchestrator, a workflow protocol for domain
-adapters, and serializable task types.
+adapters, serializable task types, and default JSON-backed engine-state
+persistence helpers.
 
 Example::
 
+    from pathlib import Path
+
     from spdl.autoresearch.core import (
-        Orchestrator, TaskSpec, TaskResult, WorkflowProtocol,
+        Orchestrator, TaskResult, TaskSpec, WorkflowProtocol,
+        load_or_init, write_engine_state,
     )
 
     class MyWorkflow(WorkflowProtocol):
+        def __init__(self, workdir: Path) -> None:
+            self.workdir = workdir
+
         def load(self) -> list[TaskSpec]:
-            return []  # or resume from checkpoint
+            return load_or_init(self.workdir, self._initial_specs)
 
         def checkpoint(self, queued, running, status) -> None:
-            ...  # persist scheduler state for resumption
+            write_engine_state(
+                self.workdir,
+                queued=queued,
+                running=running,
+                status=status,
+            )
 
         def make_coro(self, spec: TaskSpec) -> ...:
             # Called for each dequeued TaskSpec.  Return a coroutine
@@ -42,11 +54,15 @@ Example::
             # Filter or transform children before they enter the queue.
             return result.children
 
-    engine = Orchestrator(workflow=MyWorkflow(), max_concurrency=4)
-    await engine.run([TaskSpec(id="exp_001", priority=0)])
+        def _initial_specs(self) -> list[TaskSpec]:
+            return [TaskSpec(id="exp_001", priority=0)]
+
+    engine = Orchestrator(workflow=MyWorkflow(Path("/tmp/run")), max_concurrency=4)
+    await engine.run()
 """
 
 from ._orchestrator import Orchestrator, TaskResult, TaskSpec, WorkflowProtocol
+from ._persistence import load_or_init, read_engine_state, write_engine_state
 from ._types import (
     AnalysisResult,
     AutoresearchError,
@@ -69,4 +85,7 @@ __all__ = [
     "TaskSpec",
     "TERMINAL_STATUSES",
     "WorkflowProtocol",
+    "load_or_init",
+    "read_engine_state",
+    "write_engine_state",
 ]

--- a/src/spdl/autoresearch/core/_persistence.py
+++ b/src/spdl/autoresearch/core/_persistence.py
@@ -1,0 +1,189 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Default JSON-backed engine-state persistence helpers.
+
+The :py:class:`~spdl.autoresearch.core.Orchestrator` lets each workflow
+own how it persists queued/running specs and run status. Most workflows
+need the same straightforward thing: write the lists to a JSON file in
+the workdir on every checkpoint, and read them back on restart.
+
+This module provides that default. A workflow's ``checkpoint`` and
+``load`` methods can call :py:func:`write_engine_state` and
+:py:func:`load_or_init` directly; everything else (domain-specific
+state, monitoring views, summaries) stays in the workflow.
+
+Example::
+
+    from spdl.autoresearch.core import (
+        TaskSpec, WorkflowProtocol,
+        load_or_init, write_engine_state,
+    )
+
+    class MyWorkflow(WorkflowProtocol):
+        def __init__(self, workdir):
+            self.workdir = workdir
+
+        def load(self) -> list[TaskSpec]:
+            return load_or_init(self.workdir, self._initial_specs)
+
+        def checkpoint(self, queued, running, status) -> None:
+            write_engine_state(
+                self.workdir,
+                queued=queued,
+                running=running,
+                status=status,
+            )
+
+        def _initial_specs(self) -> list[TaskSpec]:
+            return [TaskSpec(id="exp_001")]
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from collections.abc import Callable
+from pathlib import Path
+
+from ._orchestrator import TaskSpec
+
+__all__ = [
+    "load_or_init",
+    "read_engine_state",
+    "write_engine_state",
+]
+
+
+_ENGINE_STATE_FILENAME = "engine_state.json"
+
+
+def write_engine_state(
+    workdir: Path,
+    *,
+    queued: list[TaskSpec],
+    running: list[TaskSpec],
+    status: str,
+) -> None:
+    """Persist the orchestrator's queued, running, and status fields.
+
+    Writes ``<workdir>/engine_state.json`` (creating ``<workdir>`` if
+    needed). Specs are serialized via :py:meth:`TaskSpec.to_dict`, so
+    they round-trip through :py:func:`read_engine_state`.
+
+    The write is atomic from a reader's perspective: the JSON payload
+    is written to a sibling temp file under ``<workdir>`` and then
+    moved into place via :py:func:`os.replace`. If the process is
+    interrupted mid-write, ``engine_state.json`` either still holds
+    the previous valid checkpoint or — on the very first checkpoint —
+    is simply absent. It is never observed truncated or partially
+    written, so :py:func:`read_engine_state` cannot fail with
+    ``json.JSONDecodeError`` from corrupt content on resume.
+
+    Args:
+        workdir: Directory in which to persist the JSON file.
+        queued: Specs currently waiting in the priority queue.
+        running: Specs currently scheduled as coroutines.
+        status: One of ``"running"``, ``"stopped"``, or ``"interrupted"``,
+            matching the values
+            :py:meth:`Orchestrator.run <spdl.autoresearch.core.Orchestrator.run>`
+            passes to ``checkpoint``.
+
+    Returns:
+        ``None``.
+    """
+    workdir.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "status": status,
+        "queued": [spec.to_dict() for spec in queued],
+        "running": [spec.to_dict() for spec in running],
+    }
+    path = workdir / _ENGINE_STATE_FILENAME
+    tmp = path.with_name(f"{path.name}.tmp.{os.getpid()}")
+    try:
+        tmp.write_text(json.dumps(payload, indent=2) + "\n")
+        os.replace(tmp, path)
+    except BaseException:
+        tmp.unlink(missing_ok=True)
+        raise
+
+
+def read_engine_state(
+    workdir: Path,
+) -> tuple[list[TaskSpec], list[TaskSpec], str] | None:
+    """Read the orchestrator's queued, running, and status fields.
+
+    Inverse of :py:func:`write_engine_state`. Returns ``None`` if no
+    engine-state file exists in ``workdir`` (a fresh run).
+
+    Args:
+        workdir: Directory previously passed to
+            :py:func:`write_engine_state`.
+
+    Returns:
+        A ``(queued, running, status)`` tuple when the file exists, or
+        ``None`` for a fresh workdir.
+
+    Raises:
+        ValueError: If the file is malformed or contains entries that
+            are not ``TaskSpec`` objects.
+    """
+    path = workdir / _ENGINE_STATE_FILENAME
+    if not path.exists():
+        return None
+    data = json.loads(path.read_text())
+    if not isinstance(data, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+    queued = _specs_from_field(data, "queued", path)
+    running = _specs_from_field(data, "running", path)
+    status = str(data.get("status", "running"))
+    return queued, running, status
+
+
+def load_or_init(
+    workdir: Path,
+    initial_factory: Callable[[], list[TaskSpec]],
+) -> list[TaskSpec]:
+    """Resume from checkpoint, or seed initial specs on a fresh run.
+
+    A drop-in body for a workflow's ``load()`` method::
+
+        def load(self) -> list[TaskSpec]:
+            return load_or_init(self.workdir, self._initial_specs)
+
+    Args:
+        workdir: Directory previously passed to
+            :py:func:`write_engine_state`.
+        initial_factory: Zero-argument callable that builds the starting
+            specs for a fresh run. Only invoked when no engine-state
+            file is present.
+
+    Returns:
+        Queued specs concatenated with running specs (the running specs
+        re-enter the queue on resume so the orchestrator can re-launch
+        them), or whatever ``initial_factory()`` returns.
+    """
+    state = read_engine_state(workdir)
+    if state is None:
+        return initial_factory()
+    queued, running, _ = state
+    return queued + running
+
+
+def _specs_from_field(
+    data: dict,
+    field: str,
+    path: Path,
+) -> list[TaskSpec]:
+    raw = data.get(field, [])
+    if not isinstance(raw, list):
+        raise ValueError(f"{path} field {field!r} must be a list")
+    specs: list[TaskSpec] = []
+    for index, item in enumerate(raw):
+        if not isinstance(item, dict):
+            raise ValueError(f"{path} {field}[{index}] must be a TaskSpec object")
+        specs.append(TaskSpec.from_dict(item))
+    return specs

--- a/tests/autoresearch/persistence_test.py
+++ b/tests/autoresearch/persistence_test.py
@@ -1,0 +1,168 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+import unittest.mock
+from pathlib import Path
+
+from spdl.autoresearch.core import (
+    load_or_init,
+    read_engine_state,
+    TaskSpec,
+    write_engine_state,
+)
+
+__all__: list[str] = []
+
+
+class _PersistenceTest(unittest.TestCase):
+    def test_round_trip_preserves_spec_fields(self) -> None:
+        """write_engine_state followed by read_engine_state preserves all TaskSpec fields."""
+        with tempfile.TemporaryDirectory() as tmp:
+            workdir = Path(tmp)
+            queued = [
+                TaskSpec(
+                    id="exp_001",
+                    priority=-1.5,
+                    kind="experiment",
+                    payload={"node": {"node_id": "exp_001"}, "extra": [1, 2, 3]},
+                ),
+                TaskSpec(id="exp_002", priority=0.0, kind="default", payload={}),
+            ]
+            running = [TaskSpec(id="exp_003", priority=2.0, kind="experiment")]
+
+            write_engine_state(
+                workdir, queued=queued, running=running, status="running"
+            )
+            result = read_engine_state(workdir)
+
+            self.assertIsNotNone(result)
+            assert result is not None  # for type checker
+            got_queued, got_running, status = result
+            self.assertEqual(status, "running")
+            self.assertEqual([spec.id for spec in got_queued], ["exp_001", "exp_002"])
+            self.assertEqual(got_queued[0].priority, -1.5)
+            self.assertEqual(got_queued[0].kind, "experiment")
+            self.assertEqual(
+                got_queued[0].payload,
+                {"node": {"node_id": "exp_001"}, "extra": [1, 2, 3]},
+            )
+            self.assertEqual([spec.id for spec in got_running], ["exp_003"])
+
+    def test_read_returns_none_when_missing(self) -> None:
+        """read_engine_state on a fresh workdir returns None instead of raising."""
+        with tempfile.TemporaryDirectory() as tmp:
+            self.assertIsNone(read_engine_state(Path(tmp)))
+
+    def test_status_round_trips(self) -> None:
+        """All three orchestrator status values survive persistence."""
+        with tempfile.TemporaryDirectory() as tmp:
+            workdir = Path(tmp)
+            for status in ("running", "stopped", "interrupted"):
+                write_engine_state(workdir, queued=[], running=[], status=status)
+                result = read_engine_state(workdir)
+                assert result is not None
+                self.assertEqual(result[2], status)
+
+    def test_write_creates_workdir(self) -> None:
+        """write_engine_state creates the workdir if it does not yet exist."""
+        with tempfile.TemporaryDirectory() as tmp:
+            workdir = Path(tmp) / "nested" / "fresh"
+            self.assertFalse(workdir.exists())
+            write_engine_state(workdir, queued=[], running=[], status="running")
+            self.assertTrue((workdir / "engine_state.json").exists())
+
+    def test_load_or_init_uses_factory_on_fresh_run(self) -> None:
+        """load_or_init calls the factory exactly once when no checkpoint exists."""
+        with tempfile.TemporaryDirectory() as tmp:
+            workdir = Path(tmp)
+            calls: list[int] = []
+
+            def factory() -> list[TaskSpec]:
+                calls.append(1)
+                return [TaskSpec(id="seed", priority=0.0)]
+
+            specs = load_or_init(workdir, factory)
+
+            self.assertEqual(len(calls), 1)
+            self.assertEqual([spec.id for spec in specs], ["seed"])
+
+    def test_load_or_init_resumes_from_checkpoint(self) -> None:
+        """load_or_init returns queued+running and skips the factory on resume."""
+        with tempfile.TemporaryDirectory() as tmp:
+            workdir = Path(tmp)
+            queued = [TaskSpec(id="q1", priority=-1.0)]
+            running = [TaskSpec(id="r1", priority=0.0)]
+            write_engine_state(
+                workdir, queued=queued, running=running, status="interrupted"
+            )
+
+            def factory() -> list[TaskSpec]:
+                self.fail("factory must not be invoked when checkpoint exists")
+
+            specs = load_or_init(workdir, factory)
+
+            self.assertEqual([spec.id for spec in specs], ["q1", "r1"])
+
+    def test_read_rejects_malformed_json_object(self) -> None:
+        """A non-object JSON file raises ValueError instead of silently misparsing."""
+        with tempfile.TemporaryDirectory() as tmp:
+            workdir = Path(tmp)
+            (workdir / "engine_state.json").write_text("[]\n")
+            with self.assertRaises(ValueError):
+                read_engine_state(workdir)
+
+    def test_read_rejects_non_list_field(self) -> None:
+        """A non-list queued/running field raises ValueError."""
+        with tempfile.TemporaryDirectory() as tmp:
+            workdir = Path(tmp)
+            (workdir / "engine_state.json").write_text(
+                json.dumps({"status": "running", "queued": "oops", "running": []})
+            )
+            with self.assertRaises(ValueError):
+                read_engine_state(workdir)
+
+    def test_write_does_not_truncate_existing_checkpoint_on_failure(self) -> None:
+        """A failing write leaves the previous engine_state.json intact.
+
+        Simulates a mid-write interruption by patching the temp file's
+        ``write_text`` to raise after the previous checkpoint has been
+        written successfully. The reader must still see the previous
+        valid checkpoint, never a truncated or partial file.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            workdir = Path(tmp)
+            write_engine_state(
+                workdir,
+                queued=[TaskSpec(id="prev", priority=0.0)],
+                running=[],
+                status="running",
+            )
+
+            original_write_text = Path.write_text
+
+            def _fail_on_tmp(self: Path, *args: object, **kwargs: object) -> int:
+                if ".tmp." in self.name:
+                    raise OSError("simulated mid-write failure")
+                return original_write_text(self, *args, **kwargs)  # type: ignore[arg-type]
+
+            with unittest.mock.patch.object(Path, "write_text", _fail_on_tmp):
+                with self.assertRaises(OSError):
+                    write_engine_state(
+                        workdir,
+                        queued=[TaskSpec(id="new", priority=0.0)],
+                        running=[],
+                        status="running",
+                    )
+
+            result = read_engine_state(workdir)
+            assert result is not None
+            queued, _, _ = result
+            self.assertEqual([spec.id for spec in queued], ["prev"])


### PR DESCRIPTION
Summary:
Adds three small helpers to `spdl.autoresearch.core` that workflows can opt into instead of writing their own JSON serialization for queued/running specs:

- `write_engine_state(workdir, *, queued, running, status)` writes `<workdir>/engine_state.json` using the existing `TaskSpec.to_dict`.
- `read_engine_state(workdir)` returns a `(queued, running, status)` tuple, or `None` when no checkpoint exists.
- `load_or_initial(workdir, initial_factory)` is a one-liner body for `WorkflowProtocol.load()`: resume from checkpoint if present, otherwise call the factory.

A workflow's persistence boilerplate now collapses to:

```python
def load(self):
    return load_or_initial(self.workdir, self._initial_specs)

def checkpoint(self, queued, running, status):
    write_engine_state(self.workdir, queued=queued, running=running, status=status)
```

Pure additions: nothing in the existing engine, `pipeline_optimization`, or its `_WorkflowStateStore` is touched yet. Workflows that already own their own persistence keep working unchanged. The `MyWorkflow` doc snippet in `core/__init__.py` is updated to use the new helpers so the documented example matches the recommended pattern.

This is step 2 of the autoresearch refactor that makes workflows pluggable; subsequent steps wire `pipeline_optimization` to use these helpers and add the framework dispatcher.

Reviewed By: gl3lan

Differential Revision: D106302235


