### PR TITLE
Add WorkflowSpec contract and framework dispatcher (#1463)

### DIFF
--- a/src/spdl/autoresearch/__init__.py
+++ b/src/spdl/autoresearch/__init__.py
@@ -8,9 +8,17 @@
 
 Provides reusable infrastructure for running automated research loops:
 
-- :py:mod:`~spdl.autoresearch.core`: a domain-neutral async work scheduler.
+- :py:mod:`~spdl.autoresearch.core`: a domain-neutral async work scheduler
+  and the :py:class:`~spdl.autoresearch.core.WorkflowProtocol` /
+  :py:class:`~spdl.autoresearch.core.WorkflowSpec` contracts that pluggable
+  workflows implement.
 - :py:mod:`~spdl.autoresearch.pipeline_optimization`:
   concrete workflow implementation for SPDL data loading pipeline optimization.
+
+The framework dispatcher (private) lives under ``spdl.autoresearch._app``.
+Users interact with it through the ``spdl-autoresearch`` CLI rather than by
+importing these helpers directly; importing from ``spdl.autoresearch._app``
+is reserved for framework code and tests.
 """
 
 __all__: list[str] = []

--- a/src/spdl/autoresearch/_app/__init__.py
+++ b/src/spdl/autoresearch/_app/__init__.py
@@ -1,0 +1,17 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Framework dispatcher for the pluggable autoresearch CLI.
+
+The ``spdl-autoresearch`` binary delegates to :py:func:`_main.main` in
+this package. The dispatcher resolves a workflow factory specifier
+(``module.path:factory``), parses framework-level CLI arguments, and
+either launches an interactive supervisor agent or drives the engine
+directly. Workflow-specific argv (everything after ``--``) is forwarded
+to the factory, which builds a :py:class:`~spdl.autoresearch.core.WorkflowSpec`.
+"""
+
+__all__: list[str] = []

--- a/src/spdl/autoresearch/_app/_engine.py
+++ b/src/spdl/autoresearch/_app/_engine.py
@@ -1,0 +1,120 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Framework engine: parse argv, build workflow, drive the orchestrator.
+
+The engine phase is what the supervisor (or a developer running directly)
+ends up invoking. It parses the framework engine flags, splits off the
+workflow argv tail, resolves the workflow factory, calls
+:py:meth:`WorkflowSpec.setup` and :py:meth:`WorkflowSpec.build_workflow`,
+and runs the :py:class:`~spdl.autoresearch.core.Orchestrator` to
+completion.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+from pathlib import Path
+
+from spdl.autoresearch.core import Orchestrator, WorkflowSpec
+
+from ._spec import _record_workflow_factory, _resolve_workflow
+
+__all__ = [
+    "_parse_engine_args",
+    "_run_engine",
+]
+
+
+def _parse_engine_args(
+    argv: list[str] | None = None,
+) -> tuple[argparse.Namespace, list[str]]:
+    """Parse the framework engine argv.
+
+    Splits arguments at the first ``--`` token. Tokens before are
+    framework engine flags; tokens after are forwarded to the workflow
+    factory.
+
+    Args:
+        argv: Argv list (excluding ``argv[0]``). Defaults to ``sys.argv[1:]``.
+
+    Returns:
+        ``(namespace, workflow_argv)``.
+    """
+    framework_argv, workflow_argv = _split_at_double_dash(argv)
+    parser = _build_parser()
+    ns = parser.parse_args(framework_argv)
+    return ns, workflow_argv
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Drive the autoresearch orchestrator for a workflow.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--workflow",
+        required=True,
+        help="Workflow factory specifier in 'module.path:factory_name' form.",
+    )
+    parser.add_argument(
+        "--workdir",
+        required=True,
+        help="Experiment workdir.",
+    )
+    parser.add_argument(
+        "--max-concurrency",
+        type=int,
+        default=None,
+        help=(
+            "Maximum concurrent engine coroutines. When omitted, the "
+            "workflow's WorkflowSpec.max_concurrency is used as the "
+            "default."
+        ),
+    )
+    parser.add_argument(
+        "--platform",
+        default="auto",
+        help="Execution platform: 'auto', a registered provider name, or 'local'.",
+    )
+    return parser
+
+
+def _split_at_double_dash(
+    argv: list[str] | None,
+) -> tuple[list[str], list[str]]:
+    if argv is None:
+        argv = sys.argv[1:]
+    if "--" in argv:
+        index = argv.index("--")
+        return argv[:index], argv[index + 1 :]
+    return argv, []
+
+
+def _run_engine(argv: list[str] | None = None) -> None:
+    """Resolve the workflow, build the spec, and drive the orchestrator.
+
+    Args:
+        argv: Argv list (excluding ``argv[0]``). Defaults to ``sys.argv[1:]``.
+    """
+    ns, workflow_argv = _parse_engine_args(argv)
+    workdir = Path(ns.workdir)
+    factory = _resolve_workflow(ns.workflow)
+    spec: WorkflowSpec = factory(workflow_argv, workdir)
+    # Record the workflow specifier so later operator commands (e.g.
+    # ``autoresearch <workdir> summary``) can re-resolve the same factory
+    # without requiring the user to repeat ``--workflow ...``. This is a
+    # framework concern; the workflow itself does not need to participate.
+    _record_workflow_factory(workdir, ns.workflow)
+    spec.setup(workdir)
+    workflow = spec.build_workflow(workdir)
+    max_concurrency = (
+        ns.max_concurrency if ns.max_concurrency is not None else spec.max_concurrency
+    )
+    engine = Orchestrator(workflow=workflow, max_concurrency=max_concurrency)
+    asyncio.run(engine.run())

--- a/src/spdl/autoresearch/_app/_main.py
+++ b/src/spdl/autoresearch/_app/_main.py
@@ -1,0 +1,39 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Top-level entry point for the autoresearch framework binary.
+
+The single ``spdl-autoresearch`` binary supports two modes, dispatched by
+the first positional argument:
+
+- ``engine`` — run the orchestrator directly. Used by the supervisor
+  when it execs the engine subprocess, and by developers running the
+  engine without the agent wrapper.
+- (default) — run the interactive supervisor wrapper, which builds the
+  engine command and ``execvp``\\s a coding agent.
+"""
+
+from __future__ import annotations
+
+import sys
+
+__all__ = ["main"]
+
+
+def main(argv: list[str] | None = None) -> None:
+    """Dispatch to the supervisor or engine entry point.
+
+    Args:
+        argv: Argv list (excluding ``argv[0]``). Defaults to ``sys.argv[1:]``.
+    """
+    from ._engine import _run_engine
+
+    args = list(sys.argv[1:] if argv is None else argv)
+    if args and args[0] == "engine":
+        _run_engine(args[1:])
+        return
+    # Supervisor path is wired up in step 5; for now defer to the engine.
+    _run_engine(args)

--- a/src/spdl/autoresearch/_app/_spec.py
+++ b/src/spdl/autoresearch/_app/_spec.py
@@ -1,0 +1,140 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Workflow factory specifier resolution and workdir round-tripping.
+
+A workflow specifier is a string of the form ``module.path:factory_name``
+(torchx-style). The dispatcher accepts a specifier on the command line
+(``--workflow ...``) and resolves it to a callable via
+:py:func:`_resolve_workflow`. On a fresh run, the workflow records the
+specifier in the workdir via :py:func:`_record_workflow_factory` so later
+commands such as ``autoresearch <wd> summary`` can re-instantiate the
+workflow without the original CLI args.
+
+Resolution order
+================
+
+1. Treat the specifier as ``module.path:factory_name`` and import the
+   module via :py:func:`importlib.import_module`. This is the primary
+   path; any importable Python callable can be used.
+2. If the specifier contains no ``:``, fall back to the entry-points
+   group ``spdl.autoresearch.workflows`` for short-name sugar (for
+   example, ``--workflow pipeline_optimization``).
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+from importlib.metadata import entry_points
+from pathlib import Path
+
+from spdl.autoresearch.core import WorkflowFactory
+
+__all__ = [
+    "_read_workflow_factory",
+    "_record_workflow_factory",
+    "_resolve_workflow",
+]
+
+_ENTRY_POINTS_GROUP: str = "spdl.autoresearch.workflows"
+# Entry-points group used for short-name workflow lookup.
+
+_WORKFLOW_FACTORY_FILENAME: str = "workflow_factory.json"
+# Filename inside the workdir that records the workflow factory specifier.
+
+
+def _resolve_workflow(spec: str) -> WorkflowFactory:
+    """Resolve a workflow factory specifier to a callable.
+
+    Accepts either ``module.path:factory_name`` (preferred) or a short
+    name registered under the
+    :py:data:`spdl.autoresearch.workflows <_ENTRY_POINTS_GROUP>` entry
+    points group.
+
+    Args:
+        spec: Workflow specifier supplied via ``--workflow``.
+
+    Returns:
+        A callable matching :py:data:`spdl.autoresearch.core.WorkflowFactory`.
+
+    Raises:
+        ValueError: If ``spec`` is empty or syntactically invalid.
+        ModuleNotFoundError: If the named module cannot be imported.
+        AttributeError: If the named factory attribute does not exist.
+        LookupError: If a short name does not match any registered entry
+            point.
+    """
+    if not spec:
+        raise ValueError("workflow specifier must be a non-empty string")
+    if ":" in spec:
+        module_path, _, factory_name = spec.partition(":")
+        if not module_path or not factory_name:
+            raise ValueError(
+                f"workflow specifier {spec!r} must be 'module.path:factory_name'"
+            )
+        module = importlib.import_module(module_path)
+        try:
+            factory = getattr(module, factory_name)
+        except AttributeError as exc:
+            raise AttributeError(
+                f"module {module_path!r} has no attribute {factory_name!r}"
+            ) from exc
+        return factory  # type: ignore[no-any-return]
+    return _resolve_via_entry_points(spec)
+
+
+def _resolve_via_entry_points(short_name: str) -> WorkflowFactory:
+    eps = entry_points(group=_ENTRY_POINTS_GROUP)
+    matches = [ep for ep in eps if ep.name == short_name]
+    if not matches:
+        raise LookupError(
+            f"no workflow registered as {short_name!r} under entry-points "
+            f"group {_ENTRY_POINTS_GROUP!r}"
+        )
+    return matches[0].load()  # type: ignore[no-any-return]
+
+
+def _record_workflow_factory(workdir: Path, spec: str) -> None:
+    """Record the workflow factory specifier inside the workdir.
+
+    Writes ``<workdir>/workflow_factory.json`` so that subsequent
+    invocations targeting the same workdir (for example,
+    ``autoresearch <wd> summary``) can re-resolve the workflow without
+    requiring the original ``--workflow`` argument.
+
+    Args:
+        workdir: Directory the workflow run targets.
+        spec: Workflow specifier in the same form accepted by
+            :py:func:`_resolve_workflow`.
+    """
+    workdir.mkdir(parents=True, exist_ok=True)
+    path = workdir / _WORKFLOW_FACTORY_FILENAME
+    path.write_text(json.dumps({"spec": spec}, indent=2) + "\n")
+
+
+def _read_workflow_factory(workdir: Path) -> str | None:
+    """Read the workflow factory specifier previously recorded in ``workdir``.
+
+    Args:
+        workdir: Directory the workflow run targets.
+
+    Returns:
+        The recorded specifier, or ``None`` if no record exists.
+
+    Raises:
+        ValueError: If the record file exists but is malformed.
+    """
+    path = workdir / _WORKFLOW_FACTORY_FILENAME
+    if not path.exists():
+        return None
+    data = json.loads(path.read_text())
+    if not isinstance(data, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+    spec = data.get("spec")
+    if not isinstance(spec, str) or not spec:
+        raise ValueError(f"{path} must contain a non-empty 'spec' string")
+    return spec

--- a/src/spdl/autoresearch/_app/_supervisor.py
+++ b/src/spdl/autoresearch/_app/_supervisor.py
@@ -1,0 +1,196 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Framework supervisor: parse argv, build engine command, exec coding agent.
+
+The supervisor phase is the entry point an interactive user hits. It
+parses framework-level CLI arguments (workdir, agent, platform, etc.),
+builds the supervisor prompt by combining framework scaffolding with the
+workflow-supplied prompt fragments, builds the engine command line by
+appending :py:meth:`WorkflowSpec.engine_argv_tail` to a framework-owned
+prefix, and ``execvp``\\s the coding agent so the agent can drive the
+engine and watch progress.
+
+The supervisor never imports workflow code directly. It only consumes
+the workflow through :py:class:`~spdl.autoresearch.core.WorkflowSpec`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import shlex
+import sys
+from pathlib import Path
+
+from spdl.autoresearch.core import WorkflowSpec
+
+__all__ = [
+    "_build_engine_command",
+    "_build_supervisor_prompt",
+    "_parse_supervisor_args",
+]
+
+
+def _parse_supervisor_args(
+    argv: list[str] | None = None,
+) -> tuple[argparse.Namespace, list[str]]:
+    """Parse the framework supervisor argv.
+
+    Splits arguments at the first ``--`` token: tokens before ``--`` are
+    framework flags (workdir, agent, platform, etc.), tokens after
+    ``--`` are forwarded to the workflow factory verbatim.
+
+    Args:
+        argv: Argv list (excluding ``argv[0]``). Defaults to ``sys.argv[1:]``.
+
+    Returns:
+        ``(namespace, workflow_argv)`` where ``namespace`` carries the
+        parsed framework flags and ``workflow_argv`` is the workflow tail.
+    """
+    framework_argv, workflow_argv = _split_at_double_dash(argv)
+    parser = _build_parser()
+    ns = parser.parse_args(framework_argv)
+    return ns, workflow_argv
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Run an autoresearch workflow under an interactive supervisor.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "workdir",
+        nargs="?",
+        help="Experiment workdir. Required for fresh runs and resumes.",
+    )
+    parser.add_argument(
+        "--workflow",
+        help=(
+            "Workflow factory specifier in 'module.path:factory_name' form, "
+            "or a short name registered under the "
+            "'spdl.autoresearch.workflows' entry-points group."
+        ),
+    )
+    parser.add_argument(
+        "--agent",
+        choices=("auto", "claude", "codex"),
+        default="auto",
+        help="Interactive supervisor agent.",
+    )
+    parser.add_argument(
+        "--platform",
+        default="auto",
+        help="Execution platform: 'auto', a registered provider name, or 'local'.",
+    )
+    parser.add_argument(
+        "--max-concurrency",
+        type=int,
+        default=3,
+        help="Maximum concurrent engine coroutines.",
+    )
+    parser.add_argument(
+        "--engine-command",
+        help=(
+            "Override the engine command shown to the supervisor. Defaults "
+            "to '<argv0> engine ...' so the framework binary re-invokes "
+            "itself in engine mode."
+        ),
+    )
+    parser.add_argument(
+        "--dangerously-skip-permissions",
+        action="store_true",
+        help="Pass --dangerously-skip-permissions to Claude engine invocations.",
+    )
+    return parser
+
+
+def _split_at_double_dash(
+    argv: list[str] | None,
+) -> tuple[list[str], list[str]]:
+    if argv is None:
+        argv = sys.argv[1:]
+    if "--" in argv:
+        index = argv.index("--")
+        return argv[:index], argv[index + 1 :]
+    return argv, []
+
+
+def _build_engine_command(
+    *,
+    engine_command_override: str | None,
+    workflow_spec: str,
+    workdir: Path,
+    framework_flags: list[str],
+    workflow_argv_tail: list[str],
+) -> list[str]:
+    """Assemble the full engine command line.
+
+    The supervisor renders this command into the agent prompt; the agent
+    then runs it in the background to start the engine.
+
+    Args:
+        engine_command_override: Value of ``--engine-command``, or
+            ``None`` to default to ``<argv0> engine``.
+        workflow_spec: Workflow specifier to forward via ``--workflow``.
+        workdir: Workdir to forward to the engine.
+        framework_flags: Framework-owned flags (such as
+            ``--max-concurrency 3 --platform auto``).
+        workflow_argv_tail: Workflow-specific flags returned by
+            :py:meth:`WorkflowSpec.engine_argv_tail`.
+
+    Returns:
+        A token list suitable for shell quoting and display.
+    """
+    if engine_command_override:
+        prefix = shlex.split(engine_command_override)
+    else:
+        prefix = [sys.argv[0], "engine"]
+    command = list(prefix)
+    command.extend(["--workflow", workflow_spec])
+    command.extend(["--workdir", str(workdir)])
+    command.extend(framework_flags)
+    if workflow_argv_tail:
+        command.append("--")
+        command.extend(workflow_argv_tail)
+    return command
+
+
+def _build_supervisor_prompt(
+    spec: WorkflowSpec,
+    *,
+    workdir: Path | None,
+    engine_command_text: str,
+) -> str:
+    """Combine framework scaffolding with workflow prompt and known config.
+
+    Args:
+        spec: Workflow spec returned by the factory.
+        workdir: Workdir resolved from CLI, or ``None`` if not supplied.
+        engine_command_text: Pre-rendered engine command (shell-quoted).
+
+    Returns:
+        Markdown prompt for the supervisor agent.
+    """
+    workflow_md = spec.description() or ""
+    known = spec.supervisor_known_config()
+    missing = spec.supervisor_missing_config()
+    known_block = (
+        "\n".join(f"- {key}: {value}" for key, value in known.items())
+        if known
+        else "- (none)"
+    )
+    missing_block = "\n".join(f"- {item}" for item in missing) if missing else "- none"
+    workdir_text = str(workdir) if workdir else "(missing)"
+    context = (
+        "## Supervisor Launch Context\n\n"
+        f"Workdir: {workdir_text}\n\n"
+        f"Known configuration:\n{known_block}\n\n"
+        f"Missing required configuration:\n{missing_block}\n\n"
+        "Engine command template:\n\n"
+        f"```bash\n{engine_command_text}\n```\n"
+    )
+    sections = [section for section in (workflow_md, context) if section]
+    return "\n\n---\n\n".join(sections)

--- a/src/spdl/autoresearch/core/__init__.py
+++ b/src/spdl/autoresearch/core/__init__.py
@@ -72,6 +72,7 @@ from ._types import (
     HypothesisNode,
     TERMINAL_STATUSES,
 )
+from ._workflow import WorkflowFactory, WorkflowSpec
 
 __all__ = [
     "AnalysisResult",
@@ -84,7 +85,9 @@ __all__ = [
     "TaskResult",
     "TaskSpec",
     "TERMINAL_STATUSES",
+    "WorkflowFactory",
     "WorkflowProtocol",
+    "WorkflowSpec",
     "load_or_init",
     "read_engine_state",
     "write_engine_state",

--- a/src/spdl/autoresearch/core/_workflow.py
+++ b/src/spdl/autoresearch/core/_workflow.py
@@ -1,0 +1,161 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Pluggable-workflow contract for the autoresearch framework dispatcher.
+
+The framework dispatcher (``spdl.autoresearch._app``) drives two phases:
+
+1. **Supervisor phase** — a coding-agent process is launched against a
+   markdown prompt. The agent collects missing config, then ``execvp``s
+   the engine binary.
+2. **Engine phase** — the orchestrator drives a
+   :py:class:`~spdl.autoresearch.core.WorkflowProtocol` adapter to
+   completion.
+
+A workflow factory (``Callable[[list[str], Path | None], WorkflowSpec]``)
+returns a :py:class:`WorkflowSpec` that exposes both phases. The
+framework calls supervisor-phase methods to render the supervisor prompt
+and the engine command line, and engine-phase methods (``setup`` then
+``build_workflow``) once the engine starts.
+
+This module only defines the contract. Concrete workflows live elsewhere
+(for example, ``spdl.autoresearch.pipeline_optimization``).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+from typing import Protocol, TypeAlias
+
+from ._orchestrator import WorkflowProtocol
+
+__all__ = [
+    "WorkflowFactory",
+    "WorkflowSpec",
+]
+
+
+class WorkflowSpec(Protocol):
+    """Pluggable workflow contract returned by a workflow factory.
+
+    Combines supervisor-phase metadata (used by the framework to render
+    the supervisor prompt and build the engine command) with engine-phase
+    lifecycle hooks (used to initialise the workdir and build the
+    :py:class:`~spdl.autoresearch.core.WorkflowProtocol` adapter).
+
+    A workflow factory is any callable matching :py:data:`WorkflowFactory`
+    that returns a value satisfying this protocol.
+
+    Attributes:
+        max_concurrency: Maximum concurrent coroutines the orchestrator
+            should run for this workflow.
+    """
+
+    max_concurrency: int
+
+    # --- Supervisor phase (consumed by framework supervisor) ---
+
+    def engine_argv_tail(self) -> list[str]:
+        """Return the workflow-specific flags for the engine command.
+
+        Appended after the framework's own arguments when the supervisor
+        builds the engine invocation. The returned list typically encodes
+        domain config such as ``--build-command`` or ``--source-dir``.
+
+        Returns:
+            A list of CLI tokens to forward to the engine subprocess.
+        """
+        ...
+
+    def description(self) -> str | None:
+        """Return free-form domain context for the supervisor.
+
+        Describes the workflow domain, the meaning of its config
+        fields, and what happens during a run. The framework joins this
+        with its own supervisor instructions and the launch context
+        (known config, missing config, engine command).
+
+        This is NOT the place for supervisor instructions (monitoring,
+        troubleshooting, SIGINT handling, status meanings, queue
+        surgery). Those are framework-owned and identical across every
+        workflow. Use :py:meth:`supervisor_known_config` /
+        :py:meth:`supervisor_missing_config` for the structured "what
+        to ask the user" surface; use this method for the prose around
+        those bullets — what each field means, what good values look
+        like, what the engine will do with them.
+
+        Return ``None`` (or an empty string) to contribute nothing.
+
+        Returns:
+            Markdown context, or ``None``.
+        """
+        ...
+
+    def supervisor_known_config(self) -> dict[str, str]:
+        """Return key/value pairs for the supervisor's "known config" block.
+
+        Rendered as a bullet list inside the supervisor prompt so the
+        agent can summarise what is already set. Empty values are still
+        rendered to make missing-but-named fields visible.
+
+        Returns:
+            A mapping of config name to display value.
+        """
+        ...
+
+    def supervisor_missing_config(self) -> list[str]:
+        """Return human-readable names of required values not yet supplied.
+
+        An empty list signals the workflow is ready to run the engine
+        without further user interaction.
+
+        Returns:
+            A list of missing-config labels (for example,
+            ``["pipeline script", "build command"]``).
+        """
+        ...
+
+    # --- Engine phase (consumed by framework engine) ---
+
+    def setup(self, workdir: Path) -> None:
+        """Perform fresh-run workdir initialisation, idempotent on resume.
+
+        Called once at the start of each engine invocation. Workflows
+        detect re-runs internally (for example, by checking for
+        ``config.json``) and should be safe to call repeatedly. Fresh
+        runs typically record the factory spec in the workdir so later
+        commands can re-instantiate the workflow without the original
+        argv.
+
+        Args:
+            workdir: Directory the engine will run against.
+        """
+        ...
+
+    def build_workflow(self, workdir: Path) -> WorkflowProtocol:
+        """Construct the engine-side adapter.
+
+        Called after :py:meth:`setup`. The returned object is what the
+        :py:class:`~spdl.autoresearch.core.Orchestrator` drives.
+
+        Args:
+            workdir: Directory the engine will run against.
+
+        Returns:
+            An object satisfying
+            :py:class:`~spdl.autoresearch.core.WorkflowProtocol`.
+        """
+        ...
+
+
+WorkflowFactory: TypeAlias = Callable[[list[str], "Path | None"], WorkflowSpec]
+# Callable that constructs a :py:class:`WorkflowSpec`.
+
+# Receives ``(argv, workdir)`` where ``argv`` is the workflow-owned tail of
+# the framework CLI (everything after ``--``) and ``workdir`` may be
+# ``None`` during the supervisor phase, before the user has supplied a
+# workdir.

--- a/tests/autoresearch/app_test.py
+++ b/tests/autoresearch/app_test.py
@@ -1,0 +1,253 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from collections.abc import Callable
+from pathlib import Path
+from typing import get_origin
+
+from spdl.autoresearch._app._engine import _parse_engine_args
+from spdl.autoresearch._app._spec import (
+    _read_workflow_factory,
+    _record_workflow_factory,
+    _resolve_workflow,
+)
+from spdl.autoresearch._app._supervisor import (
+    _build_engine_command,
+    _parse_supervisor_args,
+)
+
+__all__: list[str] = []
+
+
+def _identity_factory(argv: list[str], workdir: Path | None) -> object:
+    """A trivial factory used as a resolution target by the tests below."""
+    return (argv, workdir)
+
+
+class _ResolveWorkflowTest(unittest.TestCase):
+    def test_module_factory_form(self) -> None:
+        """_resolve_workflow imports module.path:factory_name and returns the callable."""
+        factory = _resolve_workflow(f"{__name__}:_identity_factory")
+        self.assertIs(factory, _identity_factory)
+
+    def test_empty_specifier_raises(self) -> None:
+        """An empty string is rejected with ValueError, not silently importing."""
+        with self.assertRaises(ValueError):
+            _resolve_workflow("")
+
+    def test_malformed_specifier_raises(self) -> None:
+        """A specifier with a colon but missing one half is rejected."""
+        for bad in (":factory", "module.path:", ":"):
+            with self.subTest(bad=bad):
+                with self.assertRaises(ValueError):
+                    _resolve_workflow(bad)
+
+    def test_unknown_module_raises_import_error(self) -> None:
+        """A non-existent module surfaces ModuleNotFoundError to the caller."""
+        with self.assertRaises(ModuleNotFoundError):
+            _resolve_workflow("definitely.not.a.real.module:create")
+
+    def test_missing_attribute_raises(self) -> None:
+        """An existing module with a missing attribute raises AttributeError."""
+        with self.assertRaises(AttributeError):
+            _resolve_workflow(f"{__name__}:does_not_exist")
+
+    def test_short_name_lookup_misses_cleanly(self) -> None:
+        """Short-name lookup raises LookupError when no entry point matches."""
+        with self.assertRaises(LookupError):
+            _resolve_workflow("not_registered_workflow_xyz")
+
+
+class _WorkflowFactoryRecordTest(unittest.TestCase):
+    def test_round_trip(self) -> None:
+        """_record_workflow_factory followed by _read_workflow_factory returns the spec."""
+        with tempfile.TemporaryDirectory() as tmp:
+            workdir = Path(tmp)
+            _record_workflow_factory(workdir, "pkg.mod:factory")
+            self.assertEqual(_read_workflow_factory(workdir), "pkg.mod:factory")
+
+    def test_read_returns_none_when_missing(self) -> None:
+        """_read_workflow_factory on a fresh workdir returns None instead of raising."""
+        with tempfile.TemporaryDirectory() as tmp:
+            self.assertIsNone(_read_workflow_factory(Path(tmp)))
+
+    def test_read_rejects_malformed_record(self) -> None:
+        """Reading a malformed record file raises ValueError."""
+        with tempfile.TemporaryDirectory() as tmp:
+            workdir = Path(tmp)
+            (workdir / "workflow_factory.json").write_text("[]\n")
+            with self.assertRaises(ValueError):
+                _read_workflow_factory(workdir)
+
+    def test_record_creates_workdir(self) -> None:
+        """_record_workflow_factory creates the workdir if it does not yet exist."""
+        with tempfile.TemporaryDirectory() as tmp:
+            workdir = Path(tmp) / "nested"
+            _record_workflow_factory(workdir, "pkg.mod:factory")
+            self.assertEqual(_read_workflow_factory(workdir), "pkg.mod:factory")
+
+
+class _ArgvSplitTest(unittest.TestCase):
+    def test_supervisor_splits_at_double_dash(self) -> None:
+        """Tokens after '--' are forwarded as the workflow tail, not parsed by the framework."""
+        ns, tail = _parse_supervisor_args(
+            [
+                "/tmp/workdir",
+                "--workflow",
+                "pkg.mod:factory",
+                "--max-concurrency",
+                "5",
+                "--",
+                "--pipeline-script",
+                "x.py",
+            ]
+        )
+        self.assertEqual(ns.workdir, "/tmp/workdir")
+        self.assertEqual(ns.workflow, "pkg.mod:factory")
+        self.assertEqual(ns.max_concurrency, 5)
+        self.assertEqual(tail, ["--pipeline-script", "x.py"])
+
+    def test_supervisor_workdir_optional(self) -> None:
+        """The supervisor accepts no workdir during initial config gathering."""
+        ns, tail = _parse_supervisor_args(["--workflow", "pkg.mod:factory"])
+        self.assertIsNone(ns.workdir)
+        self.assertEqual(tail, [])
+
+    def test_engine_requires_workflow_and_workdir(self) -> None:
+        """The engine refuses to start without --workflow and --workdir."""
+        with self.assertRaises(SystemExit):
+            _parse_engine_args(["--workdir", "/tmp/wd"])
+        with self.assertRaises(SystemExit):
+            _parse_engine_args(["--workflow", "pkg.mod:factory"])
+
+    def test_engine_passes_tail_through(self) -> None:
+        """The engine surfaces the workflow tail unchanged to the caller."""
+        ns, tail = _parse_engine_args(
+            [
+                "--workflow",
+                "pkg.mod:factory",
+                "--workdir",
+                "/tmp/wd",
+                "--",
+                "--build-command",
+                "make",
+            ]
+        )
+        self.assertEqual(ns.workflow, "pkg.mod:factory")
+        self.assertEqual(ns.workdir, "/tmp/wd")
+        self.assertEqual(tail, ["--build-command", "make"])
+
+    def test_engine_max_concurrency_defaults_to_none(self) -> None:
+        """Omitting --max-concurrency leaves ns.max_concurrency as None.
+
+        The engine treats this as "use the workflow-supplied default" so
+        the WorkflowSpec.max_concurrency value is honored when the user
+        does not override it on the CLI.
+        """
+        ns, _ = _parse_engine_args(
+            ["--workflow", "pkg.mod:factory", "--workdir", "/tmp/wd"]
+        )
+        self.assertIsNone(ns.max_concurrency)
+
+    def test_engine_max_concurrency_accepts_explicit_value(self) -> None:
+        """An explicit --max-concurrency value is preserved as an int."""
+        ns, _ = _parse_engine_args(
+            [
+                "--workflow",
+                "pkg.mod:factory",
+                "--workdir",
+                "/tmp/wd",
+                "--max-concurrency",
+                "7",
+            ]
+        )
+        self.assertEqual(ns.max_concurrency, 7)
+
+
+class _EngineCommandTest(unittest.TestCase):
+    def test_default_uses_argv0_engine(self) -> None:
+        """Without an override, the engine prefix is 'sys.argv[0] engine'."""
+        cmd = _build_engine_command(
+            engine_command_override=None,
+            workflow_spec="pkg.mod:factory",
+            workdir=Path("/tmp/wd"),
+            framework_flags=["--max-concurrency", "3"],
+            workflow_argv_tail=["--build-command", "make"],
+        )
+        # argv[0] varies under buck test; only assert structural shape.
+        self.assertEqual(cmd[1], "engine")
+        self.assertEqual(
+            cmd[2:],
+            [
+                "--workflow",
+                "pkg.mod:factory",
+                "--workdir",
+                "/tmp/wd",
+                "--max-concurrency",
+                "3",
+                "--",
+                "--build-command",
+                "make",
+            ],
+        )
+
+    def test_override_replaces_prefix(self) -> None:
+        """An --engine-command override replaces the default argv[0] prefix."""
+        cmd = _build_engine_command(
+            engine_command_override="buck run //x:engine --",
+            workflow_spec="pkg.mod:factory",
+            workdir=Path("/tmp/wd"),
+            framework_flags=[],
+            workflow_argv_tail=[],
+        )
+        self.assertEqual(
+            cmd,
+            [
+                "buck",
+                "run",
+                "//x:engine",
+                "--",
+                "--workflow",
+                "pkg.mod:factory",
+                "--workdir",
+                "/tmp/wd",
+            ],
+        )
+
+    def test_no_tail_omits_double_dash(self) -> None:
+        """An empty workflow tail does not append a stray '--'."""
+        cmd = _build_engine_command(
+            engine_command_override=None,
+            workflow_spec="pkg.mod:factory",
+            workdir=Path("/tmp/wd"),
+            framework_flags=[],
+            workflow_argv_tail=[],
+        )
+        self.assertNotIn("--", cmd[2:])
+
+
+class _CoreWorkflowExportTest(unittest.TestCase):
+    def test_workflow_spec_is_protocol(self) -> None:
+        """``WorkflowSpec`` re-exported from core is a ``Protocol`` subclass.
+
+        ``Protocol`` subclasses are flagged with ``_is_protocol = True`` by
+        the typing machinery; this guards against accidentally weakening
+        ``WorkflowSpec`` to a regular class (which would silently change
+        the runtime semantics for workflow authors).
+        """
+        from spdl.autoresearch.core import WorkflowSpec
+
+        self.assertTrue(getattr(WorkflowSpec, "_is_protocol", False))
+
+    def test_workflow_factory_is_callable_alias(self) -> None:
+        """``WorkflowFactory`` re-exported from core is a ``Callable`` alias."""
+        from spdl.autoresearch.core import WorkflowFactory
+
+        self.assertIs(get_origin(WorkflowFactory), Callable)


### PR DESCRIPTION
Summary:

Adds the pluggable-workflow contract (`WorkflowSpec` + `WorkflowFactory`) to `spdl.autoresearch.core` and a private framework dispatcher under `spdl.autoresearch._app`.

New `core/_workflow.py` defines two types:

- `WorkflowSpec` — a `Protocol` returned by a workflow factory. Carries supervisor-phase metadata (`engine_argv_tail`, `supervisor_prompt`, `supervisor_known_config`, `supervisor_missing_config`) and engine-phase lifecycle hooks (`setup`, `build_workflow`).
- `WorkflowFactory = Callable[[list[str], Path | None], WorkflowSpec]` — what `--workflow module.path:factory` resolves to.

New `_app/` package contains the framework dispatcher:

- `_spec.py` — workflow factory resolution. Accepts `module.path:factory` (primary) or a short name registered under the `spdl.autoresearch.workflows` entry-points group. Includes private helpers `_record_workflow_factory(workdir, spec)` / `_read_workflow_factory(workdir)` so a workdir self-describes which factory built it.
- `_supervisor.py` — framework supervisor: argparse for framework flags (`--workflow`, `--workdir`, `--agent`, `--platform`, `--max-concurrency`, `--engine-command`, `--dangerously-skip-permissions`), splits argv at `--` so workflow flags forward verbatim, builds the engine command and supervisor prompt.
- `_engine.py` — framework engine: parses engine-only argv, resolves factory, records the workflow factory specifier in the workdir itself, then calls `setup()` + `build_workflow()` and drives `Orchestrator`. Recording the factory is a framework concern, so workflows do not need to import or call private `_app` helpers — keeps the workflow-author surface restricted to `spdl.autoresearch.core`.
- `_main.py` — top-level `main()` dispatcher. First positional `engine` runs the engine; otherwise (in later steps) the supervisor.

The factory-resolution helpers (`_resolve_workflow`, `_record_workflow_factory`, `_read_workflow_factory`) are deliberately framework-private (underscore-prefixed) and not re-exported through `spdl.autoresearch.__init__`. Workflows outside the framework do not need them; the `_app` dispatcher is the only legitimate caller.

`_app/` is private (underscore-prefixed) and so does not get its own `public_api` BUCK target.

Reviewed By: gl3lan

Differential Revision: D106302535


