### PR TITLE
Add create_workflow factory for pipeline_optimization (#1464)

### DIFF
--- a/src/spdl/autoresearch/pipeline_optimization/__init__.py
+++ b/src/spdl/autoresearch/pipeline_optimization/__init__.py
@@ -6,11 +6,19 @@
 
 """SPDL pipeline optimization implementation of autoresearch.
 
-Provides the complete workflow for automatically optimizing SPDL data loading
-pipelines: supervisor CLI, engine runner, experiment adapter, platform
-providers, and CLI commands.
+Provides the complete workflow for automatically optimizing SPDL data
+loading pipelines. Two public entry points:
+
+- :py:func:`create_workflow` is a
+  :py:data:`~spdl.autoresearch.core.WorkflowFactory`. Pass
+  ``--workflow spdl.autoresearch.pipeline_optimization:create_workflow``
+  to the framework dispatcher (or rely on the bundled binary's default).
+- :py:func:`main` is the legacy supervisor-CLI entry point that the
+  ``autoresearch`` Buck binary currently dispatches to. Subsequent
+  refactor steps replace this with the framework dispatcher.
 """
 
 from ._cli import main
+from ._factory import create_workflow
 
-__all__ = ["main"]
+__all__ = ["create_workflow", "main"]

--- a/src/spdl/autoresearch/pipeline_optimization/_factory.py
+++ b/src/spdl/autoresearch/pipeline_optimization/_factory.py
@@ -1,0 +1,265 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Workflow factory for the SPDL pipeline-optimization autoresearch workflow.
+
+Exposes :py:func:`create_workflow`, a
+:py:data:`~spdl.autoresearch.core.WorkflowFactory` that the framework
+dispatcher resolves via ``--workflow
+spdl.autoresearch.pipeline_optimization:create_workflow``.
+
+The factory parses pipeline-optimization-specific flags
+(``--pipeline-script``, ``--build-command``, ``--base-launch-command``,
+``--source-dir``, ``--notes``, etc.), records the workflow factory
+specifier in the workdir on a fresh run, performs first-run workdir
+initialisation and pipeline instrumentation when ``setup()`` is called,
+and constructs a
+:py:class:`~spdl.autoresearch.pipeline_optimization._ops._adapter.PipelineOptimizationWorkflow`
+adapter on demand.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from spdl.autoresearch._common._log import setup_logging
+from spdl.autoresearch._common._state import read_config, read_state, write_state
+from spdl.autoresearch.core import WorkflowProtocol, WorkflowSpec
+
+from ._ops import PipelineOptimizationWorkflow
+from ._platform import AutoresearchPlatform, create_platform
+from ._prompts import load_prompt_directory
+
+__all__ = [
+    "create_workflow",
+]
+
+
+def create_workflow(
+    argv: list[str],
+    workdir: Path | None,
+) -> WorkflowSpec:
+    """Build a :py:class:`~spdl.autoresearch.core.WorkflowSpec` from argv.
+
+    Args:
+        argv: Workflow-specific argv tail forwarded by the framework
+            dispatcher (everything after ``--`` on the framework CLI).
+        workdir: Workdir resolved by the framework, or ``None`` during
+            the supervisor phase before the user has supplied one.
+
+    Returns:
+        A :py:class:`~spdl.autoresearch.core.WorkflowSpec` exposing the
+        supervisor- and engine-phase hooks the framework dispatcher
+        consumes.
+    """
+    ns = _parse_args(argv)
+    return _PipelineOptimizationSpec(ns, workdir)
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        prog="spdl.autoresearch.pipeline_optimization",
+        description=(
+            "Workflow-specific arguments for the SPDL pipeline-optimization "
+            "autoresearch workflow."
+        ),
+    )
+    parser.add_argument("--pipeline-script", help="Pipeline script to optimize.")
+    parser.add_argument("--build-command", help="Command to build the job image.")
+    parser.add_argument(
+        "--base-launch-command",
+        help="Base job launch command. Use $IMAGE for the image placeholder.",
+    )
+    parser.add_argument(
+        "--source-dir",
+        help="Source directory containing the pipeline code to modify in place.",
+    )
+    parser.add_argument("--notes", help="Free-form notes about the experiment.")
+    parser.add_argument("--max-iterations", type=int, default=10)
+    parser.add_argument("--patience", type=int, default=3)
+    parser.add_argument("--poll-interval", type=int, default=120)
+    parser.add_argument("--max-concurrency", type=int, default=3)
+    parser.add_argument("--job-timeout", type=int, default=1800)
+    parser.add_argument(
+        "--platform",
+        default="auto",
+        help=(
+            "Job execution platform provider. 'auto' uses the best available "
+            "provider discovered in this environment."
+        ),
+    )
+    parser.add_argument(
+        "--local-execution-mode",
+        choices=("full", "dataloader_only", "dry_run"),
+        default="full",
+        help="How the local platform launches experiment commands.",
+    )
+    parser.add_argument(
+        "--skip-instrument",
+        action="store_true",
+        help="Skip automatic TTFB/step-time instrumentation on fresh runs.",
+    )
+    parser.add_argument(
+        "--dangerously-skip-permissions",
+        action="store_true",
+        help="Pass --dangerously-skip-permissions to Claude invocations.",
+    )
+    parser.add_argument(
+        "--agent",
+        choices=("claude", "codex"),
+        default="claude",
+        help="Coding agent used by the engine workflow.",
+    )
+    return parser.parse_args(argv)
+
+
+class _PipelineOptimizationSpec:
+    """Concrete :py:class:`~spdl.autoresearch.core.WorkflowSpec` for pipeline opt.
+
+    Carries the parsed argparse namespace plus the workdir resolved by
+    the framework. Implements supervisor-phase metadata methods
+    (engine argv tail, supervisor prompt, known/missing config) and
+    engine-phase lifecycle hooks (``setup``, ``build_workflow``).
+    """
+
+    def __init__(
+        self,
+        ns: argparse.Namespace,
+        workdir: Path | None,
+    ) -> None:
+        self._ns = ns
+        self._workdir = workdir
+        self.max_concurrency: int = ns.max_concurrency
+
+    # --- Supervisor phase ---
+
+    def engine_argv_tail(self) -> list[str]:
+        """Render the workflow-specific tail of the engine command."""
+        tokens: list[str] = []
+        for flag, value in (
+            ("--pipeline-script", self._ns.pipeline_script),
+            ("--build-command", self._ns.build_command),
+            ("--base-launch-command", self._ns.base_launch_command),
+            ("--source-dir", self._ns.source_dir),
+            ("--notes", self._ns.notes),
+            ("--max-iterations", self._ns.max_iterations),
+            ("--patience", self._ns.patience),
+            ("--poll-interval", self._ns.poll_interval),
+            ("--max-concurrency", self._ns.max_concurrency),
+            ("--job-timeout", self._ns.job_timeout),
+            ("--platform", self._ns.platform),
+            ("--local-execution-mode", self._ns.local_execution_mode),
+            ("--agent", self._ns.agent),
+        ):
+            if value is None or value == "":
+                continue
+            tokens.extend([flag, str(value)])
+        if self._ns.dangerously_skip_permissions:
+            tokens.append("--dangerously-skip-permissions")
+        if self._ns.skip_instrument:
+            tokens.append("--skip-instrument")
+        return tokens
+
+    def description(self) -> str | None:
+        """Concatenate the supervisor and platform prompt directories."""
+        sections = [
+            section
+            for section in (
+                load_prompt_directory("supervisor"),
+                load_prompt_directory("platform"),
+            )
+            if section
+        ]
+        return "\n\n---\n\n".join(sections) if sections else None
+
+    def supervisor_known_config(self) -> dict[str, str]:
+        return {
+            "pipeline_script": self._ns.pipeline_script or "",
+            "source_dir": self._ns.source_dir or "",
+            "build_command": self._ns.build_command or "",
+            "base_launch_command": self._ns.base_launch_command or "",
+            "local_execution_mode": self._ns.local_execution_mode,
+        }
+
+    def supervisor_missing_config(self) -> list[str]:
+        missing: list[str] = []
+        for attr, label in (
+            ("pipeline_script", "pipeline script"),
+            ("source_dir", "source directory"),
+            ("build_command", "build command"),
+            ("base_launch_command", "launch command template"),
+        ):
+            if not getattr(self._ns, attr):
+                missing.append(label)
+        return missing
+
+    # --- Engine phase ---
+
+    def setup(self, workdir: Path) -> None:
+        """Initialise the workdir on a fresh run; idempotent on resume.
+
+        On a fresh run, runs first-time workdir initialisation (and
+        pipeline instrumentation unless ``--skip-instrument``). The
+        framework records the workflow factory specifier in the workdir
+        separately, before this method is called.
+        """
+        config_file = workdir / "config.json"
+        is_fresh = not config_file.exists()
+
+        platform = create_platform(
+            {
+                "platform": self._ns.platform,
+                "agent": self._ns.agent,
+                "local_execution_mode": self._ns.local_execution_mode,
+                "source_dir": self._ns.source_dir or "",
+            },
+            workdir,
+        )
+
+        if is_fresh:
+            if not self._ns.base_launch_command:
+                raise SystemExit(
+                    "Fresh run requires --base-launch-command on the workflow tail."
+                )
+            self._init_fresh(workdir, platform)
+        setup_logging(workdir)
+
+    def build_workflow(self, workdir: Path) -> WorkflowProtocol:
+        """Construct the engine-side adapter."""
+        config = read_config(workdir)
+        state = read_state(workdir)
+        platform = create_platform(config, workdir)
+        state["status"] = "looping"
+        write_state(workdir, state)
+        self.max_concurrency = int(config.get("max_concurrency", 3))
+        return PipelineOptimizationWorkflow(
+            workdir=workdir,
+            config=config,
+            state=state,
+            platform=platform,
+        )
+
+    def _init_fresh(self, workdir: Path, platform: AutoresearchPlatform) -> None:
+        # Delegates to the existing _run.py helpers without copying their
+        # bodies; importing here keeps _run.py the single source of truth
+        # until step 8 retires it. The argparse namespaces have the same
+        # field names so this passthrough is a safe no-op rewrite.
+        from . import _run
+
+        _run._init_workdir(self._ns, workdir, platform)
+        if not self._ns.skip_instrument:
+            config = read_config(workdir)
+            _run._instrument_pipeline(workdir, config, platform)
+            scm_type = config.get("scm", "")
+            source_dir = config.get("source_dir", "")
+            if scm_type and source_dir:
+                state = read_state(workdir)
+                state["anchor_commit"] = platform.workspace.current(  # type: ignore[attr-defined]
+                    scm_type,
+                    source_dir,
+                )
+                write_state(workdir, state)

--- a/tests/autoresearch/factory_test.py
+++ b/tests/autoresearch/factory_test.py
@@ -1,0 +1,126 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+import unittest
+
+from spdl.autoresearch.pipeline_optimization import create_workflow
+
+__all__: list[str] = []
+
+
+def _full_argv() -> list[str]:
+    return [
+        "--pipeline-script",
+        "/tmp/pipeline.py",
+        "--source-dir",
+        "/tmp/src",
+        "--build-command",
+        "make image",
+        "--base-launch-command",
+        "torchx run --image $IMAGE",
+        "--notes",
+        "smoke",
+        "--max-iterations",
+        "5",
+        "--patience",
+        "2",
+        "--job-timeout",
+        "300",
+    ]
+
+
+class _CreateWorkflowTest(unittest.TestCase):
+    def test_returns_workflow_spec(self) -> None:
+        """create_workflow returns an object exposing the WorkflowSpec surface."""
+        spec = create_workflow(_full_argv(), None)
+        for attr in (
+            "engine_argv_tail",
+            "description",
+            "supervisor_known_config",
+            "supervisor_missing_config",
+            "setup",
+            "build_workflow",
+        ):
+            self.assertTrue(callable(getattr(spec, attr)), attr)
+        self.assertEqual(spec.max_concurrency, 3)
+
+    def test_engine_argv_tail_round_trips_supplied_flags(self) -> None:
+        """Every value passed in survives in engine_argv_tail in flag/value order."""
+        spec = create_workflow(_full_argv(), None)
+        tail = spec.engine_argv_tail()
+        self.assertEqual(tail[tail.index("--pipeline-script") + 1], "/tmp/pipeline.py")
+        self.assertEqual(tail[tail.index("--source-dir") + 1], "/tmp/src")
+        self.assertEqual(tail[tail.index("--build-command") + 1], "make image")
+        self.assertEqual(
+            tail[tail.index("--base-launch-command") + 1],
+            "torchx run --image $IMAGE",
+        )
+        self.assertEqual(tail[tail.index("--max-iterations") + 1], "5")
+        self.assertEqual(tail[tail.index("--patience") + 1], "2")
+        self.assertEqual(tail[tail.index("--max-concurrency") + 1], "3")
+        self.assertEqual(tail[tail.index("--job-timeout") + 1], "300")
+        self.assertEqual(tail[tail.index("--platform") + 1], "auto")
+
+    def test_engine_argv_tail_omits_unset_options(self) -> None:
+        """Unset optional flags are not emitted at all."""
+        spec = create_workflow([], None)
+        tail = spec.engine_argv_tail()
+        self.assertNotIn("--pipeline-script", tail)
+        self.assertNotIn("--build-command", tail)
+        self.assertNotIn("--base-launch-command", tail)
+        self.assertNotIn("--source-dir", tail)
+        self.assertNotIn("--notes", tail)
+
+    def test_engine_argv_tail_emits_boolean_flags(self) -> None:
+        """Boolean flags appear by themselves with no value when set."""
+        spec = create_workflow(
+            [
+                "--skip-instrument",
+                "--dangerously-skip-permissions",
+            ],
+            None,
+        )
+        tail = spec.engine_argv_tail()
+        self.assertIn("--skip-instrument", tail)
+        self.assertIn("--dangerously-skip-permissions", tail)
+
+    def test_supervisor_missing_config_lists_required_fields(self) -> None:
+        """A bare invocation reports all four required fields as missing."""
+        spec = create_workflow([], None)
+        missing = spec.supervisor_missing_config()
+        self.assertIn("pipeline script", missing)
+        self.assertIn("source directory", missing)
+        self.assertIn("build command", missing)
+        self.assertIn("launch command template", missing)
+
+    def test_supervisor_missing_config_empty_when_all_supplied(self) -> None:
+        """A fully-configured invocation reports no missing fields."""
+        spec = create_workflow(_full_argv(), None)
+        self.assertEqual(spec.supervisor_missing_config(), [])
+
+    def test_supervisor_known_config_reflects_argv(self) -> None:
+        """supervisor_known_config exposes the parsed values for the supervisor prompt."""
+        spec = create_workflow(_full_argv(), None)
+        known = spec.supervisor_known_config()
+        self.assertEqual(known["pipeline_script"], "/tmp/pipeline.py")
+        self.assertEqual(known["build_command"], "make image")
+        self.assertEqual(known["local_execution_mode"], "full")
+
+    def test_max_concurrency_reflects_argv(self) -> None:
+        """A non-default --max-concurrency is visible on spec.max_concurrency."""
+        spec = create_workflow([*_full_argv(), "--max-concurrency", "7"], None)
+        self.assertEqual(spec.max_concurrency, 7)
+
+    def test_description_contains_supervisor_and_platform_content(self) -> None:
+        """description() joins the supervisor and platform prompt directories."""
+        spec = create_workflow(_full_argv(), None)
+        description = spec.description()
+        self.assertIsNotNone(description)
+        assert description is not None  # for type checker
+        self.assertIn("---", description)
+        self.assertIn("Automated SPDL Pipeline Optimization", description)


### PR DESCRIPTION
Summary:

Wires `pipeline_optimization` into the framework workflow contract from D106302535. New `pipeline_optimization/_factory.py` exposes:

- `create_workflow(argv, workdir) -> WorkflowSpec`: a `WorkflowFactory` callable resolvable as `--workflow spdl.autoresearch.pipeline_optimization:create_workflow`.

`_PipelineOptimizationSpec` implements every `WorkflowSpec` method:

- `engine_argv_tail()` renders the same flag set today's `_run.py` accepts (`--pipeline-script`, `--source-dir`, `--build-command`, `--base-launch-command`, `--notes`, `--max-iterations`, `--patience`, `--poll-interval`, `--max-concurrency`, `--job-timeout`, `--platform`, `--local-execution-mode`, `--agent`, `--skip-instrument`, `--dangerously-skip-permissions`).
- `description()` joins the `prompts/supervisor` and `prompts/platform` directories.
- `supervisor_known_config()` and `supervisor_missing_config()` surface the parsed values for the supervisor prompt scaffolding.
- `setup(workdir)` runs first-time workdir initialisation (and pipeline instrumentation unless `--skip-instrument`). The framework records the workflow factory specifier in the workdir separately, before this method is called — the workflow has no reason to know about that bookkeeping.
- `build_workflow(workdir)` constructs `PipelineOptimizationWorkflow` against the persisted config + state and the resolved platform.

`pipeline_optimization` does NOT depend on any private API of `spdl.autoresearch._app`. The factory imports only from `spdl.autoresearch.core` (the public surface) and `spdl.autoresearch._common` (sibling utilities). This means a new workflow can be authored in any package — including outside the `spdl` library — by depending only on `core:public_api`, with no `__PRIVATE_IMP_DO_NOT_USE__` references required.

`pipeline_optimization/__init__.py` re-exports `create_workflow` alongside the legacy `main`. Both work simultaneously through this and the next two steps; step 5 flips the `autoresearch` binary to use the framework dispatcher with this factory as the default workflow.

Reviewed By: gl3lan

Differential Revision: D106302744


