### PR TITLE
Wire framework dispatcher into the autoresearch CLI (#1465)

### DIFF
--- a/tools/autoresearch/README.md
+++ b/tools/autoresearch/README.md
@@ -130,6 +130,15 @@ Press **Ctrl+C** to stop the engine gracefully. The runner persists queued and r
 
 Re-run the same command to resume — the engine re-checks job status and picks up where it left off.
 
+## Buck Binary Targets
+
+Two binaries are provided:
+
+- `:autoresearch` — bare framework binary. Eventually accepts an arbitrary user-supplied workflow via `--workflow module.path:factory`. Today it falls back to the bundled pipeline-optimization workflow when `--workflow` is not supplied, so the legacy invocations under `examples/*/fb/autoresearch.sh` continue to work.
+- `:autoresearch_with_pipeline_opt` — convenience binary that bundles the pipeline-optimization workflow alongside the framework. The default if you want the out-of-the-box SPDL pipeline-optimization behavior at Meta.
+
+When the entry point eventually merges into the unified `spdl` CLI, the framework dispatcher allows the workflow implementation to evolve (or be supplied by the user) without rebuilding the CLI binary.
+
 ## Quick Start
 
 ### Option 1: Supervised CLI

--- a/tools/autoresearch/cli.py
+++ b/tools/autoresearch/cli.py
@@ -7,13 +7,46 @@
 
 """Entry point for ``spdl autoresearch``.
 
-Thin wrapper that delegates to the SPDL pipeline optimization
-implementation in ``spdl.autoresearch.pipeline_optimization``.
+Thin wrapper that dispatches to either the framework dispatcher
+(``spdl.autoresearch._app._main``) or the legacy pipeline-optimization
+supervisor depending on argv shape:
+
+- ``autoresearch engine ...`` — engine subcommand handled by the
+  framework dispatcher. Used by the supervisor when it execs the engine
+  subprocess and by developers running the engine directly.
+- ``autoresearch ... --workflow ...`` — framework dispatcher path.
+- otherwise — legacy ``pipeline_optimization.main`` supervisor path.
+  Preserves byte-for-byte behavior for the ``examples/*/fb/autoresearch.sh``
+  scripts and the bundled ``autoresearch_with_pipeline_opt`` binary's
+  default invocation.
+
+Step 6 of the refactor promotes ``--workflow`` to a real argument on the
+bare ``autoresearch`` binary and migrates the example scripts to the new
+flag shape; step 8 retires the legacy path entirely.
 """
 
 from __future__ import annotations
 
-from spdl.autoresearch.pipeline_optimization import main
+import sys
+
+
+def main() -> None:
+    """Dispatch to the framework engine, framework supervisor, or legacy CLI."""
+    args = sys.argv[1:]
+    if args and args[0] == "engine":
+        from spdl.autoresearch._app._main import main as framework_main
+
+        framework_main()
+        return
+    if any(a == "--workflow" or a.startswith("--workflow=") for a in args):
+        from spdl.autoresearch._app._main import main as framework_main
+
+        framework_main()
+        return
+    from spdl.autoresearch.pipeline_optimization import main as legacy_main
+
+    legacy_main()
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Summary:

Sets up the bare-vs-bundled binary structure and teaches `tools/autoresearch/cli.py` to dispatch between the new framework path and the legacy pipeline-optimization supervisor without changing any user-facing behavior.

Changes:

- New Buck target `:autoresearch_with_pipeline_opt` is the bundled binary that includes the pipeline-optimization workflow alongside the framework dispatcher. The bare `:autoresearch` target keeps its existing user-facing behavior. Both currently use the same `cli.py` shim.
- `cli.py` now delegates by argv shape: `autoresearch engine ...` or any invocation containing `--workflow ...` is routed to the framework dispatcher (`spdl.autoresearch._app._main`); everything else falls through to the legacy `pipeline_optimization.main` supervisor. The `examples/*/fb/autoresearch.sh` scripts hit the legacy path and continue to work unmodified.
- `tools/autoresearch/README.md` documents the bare vs bundled binary distinction.

Step 6 promotes `--workflow` to a real argument on the bare binary and migrates the example scripts to the new flag shape; step 8 retires the legacy path entirely.

Reviewed By: gl3lan

Differential Revision: D106302888


