### PR TITLE
Wire framework supervisor + document `--workflow` syntax (#1466)

### DIFF
--- a/src/spdl/autoresearch/_app/_main.py
+++ b/src/spdl/autoresearch/_app/_main.py
@@ -30,10 +30,10 @@ def main(argv: list[str] | None = None) -> None:
         argv: Argv list (excluding ``argv[0]``). Defaults to ``sys.argv[1:]``.
     """
     from ._engine import _run_engine
+    from ._supervisor import _run_supervisor
 
     args = list(sys.argv[1:] if argv is None else argv)
     if args and args[0] == "engine":
         _run_engine(args[1:])
         return
-    # Supervisor path is wired up in step 5; for now defer to the engine.
-    _run_engine(args)
+    _run_supervisor(args)

--- a/src/spdl/autoresearch/_app/_supervisor.py
+++ b/src/spdl/autoresearch/_app/_supervisor.py
@@ -21,16 +21,18 @@ the workflow through :py:class:`~spdl.autoresearch.core.WorkflowSpec`.
 from __future__ import annotations
 
 import argparse
+import os
 import shlex
 import sys
 from pathlib import Path
 
+from spdl.autoresearch._common._supervisor import _resolve_supervisor_agent
 from spdl.autoresearch.core import WorkflowSpec
 
+from ._spec import _resolve_workflow
+
 __all__ = [
-    "_build_engine_command",
-    "_build_supervisor_prompt",
-    "_parse_supervisor_args",
+    "_run_supervisor",
 ]
 
 
@@ -194,3 +196,59 @@ def _build_supervisor_prompt(
     )
     sections = [section for section in (workflow_md, context) if section]
     return "\n\n---\n\n".join(sections)
+
+
+def _run_supervisor(argv: list[str] | None = None) -> None:
+    """Resolve workflow, render supervisor prompt, exec the coding agent.
+
+    Replaces the current process with the supervisor agent (Claude or
+    Codex) via :py:func:`os.execvp`, exactly mirroring the legacy
+    ``pipeline_optimization._cli`` path but without any pipeline-opt
+    knowledge in the framework.
+
+    Args:
+        argv: Argv list (excluding ``argv[0]``). Defaults to
+            ``sys.argv[1:]``.
+    """
+    ns, workflow_argv = _parse_supervisor_args(argv)
+    if not ns.workflow:
+        raise SystemExit(
+            "--workflow is required. Pass module.path:factory_name or a "
+            "short name registered under the spdl.autoresearch.workflows "
+            "entry-points group."
+        )
+    workdir = Path(ns.workdir).resolve() if ns.workdir else None
+    factory = _resolve_workflow(ns.workflow)
+    spec: WorkflowSpec = factory(workflow_argv, workdir)
+
+    supervisor = _resolve_supervisor_agent(ns.agent)
+    framework_flags = _supervisor_framework_flags(ns)
+    engine_command = _build_engine_command(
+        engine_command_override=ns.engine_command,
+        workflow_spec=ns.workflow,
+        workdir=workdir or Path("(missing)"),
+        framework_flags=framework_flags,
+        workflow_argv_tail=spec.engine_argv_tail(),
+    )
+    engine_command_text = " ".join(shlex.quote(part) for part in engine_command)
+    prompt = _build_supervisor_prompt(
+        spec, workdir=workdir, engine_command_text=engine_command_text
+    )
+    initial_request = (
+        f"Start supervising this autoresearch run.\n\n"
+        f"Workdir: {workdir or '(missing)'}\n\n"
+        f"Engine command:\n\n```bash\n{engine_command_text}\n```\n"
+    )
+    command = supervisor.command(prompt, initial_request)
+    os.execvp(command[0], command)
+
+
+def _supervisor_framework_flags(ns: argparse.Namespace) -> list[str]:
+    flags: list[str] = []
+    if ns.max_concurrency is not None:
+        flags.extend(["--max-concurrency", str(ns.max_concurrency)])
+    if ns.platform:
+        flags.extend(["--platform", ns.platform])
+    if ns.dangerously_skip_permissions:
+        flags.append("--dangerously-skip-permissions")
+    return flags

--- a/tools/autoresearch/README.md
+++ b/tools/autoresearch/README.md
@@ -139,6 +139,33 @@ Two binaries are provided:
 
 When the entry point eventually merges into the unified `spdl` CLI, the framework dispatcher allows the workflow implementation to evolve (or be supplied by the user) without rebuilding the CLI binary.
 
+## Pluggable Workflows (`--workflow`)
+
+The framework dispatcher accepts a workflow specifier in one of two forms:
+
+- `module.path:factory_name` — imports `module.path` and uses `factory_name` as the workflow factory. The factory must match `Callable[[list[str], Path | None], WorkflowSpec]`.
+- a short name registered under the `spdl.autoresearch.workflows` Python entry-points group — useful for OSS distribution where users register their workflow at install time via `pyproject.toml`.
+
+```toml
+# In your project's pyproject.toml
+[project.entry-points."spdl.autoresearch.workflows"]
+my_workflow = "my_pkg.my_module:create_workflow"
+```
+
+When invoking, framework arguments come before `--`, and arguments specific to the workflow factory come after `--`:
+
+```bash
+spdl-autoresearch /tmp/my_experiment \
+  --workflow spdl.autoresearch.pipeline_optimization:create_workflow \
+  --agent claude --platform auto --max-concurrency 3 \
+  -- \
+  --pipeline-script path/to/pipeline.py \
+  --build-command "make image" \
+  --base-launch-command "torchx run --image \$IMAGE"
+```
+
+The bundled `:autoresearch_with_pipeline_opt` binary injects `--workflow spdl.autoresearch.pipeline_optimization:create_workflow` automatically when none is supplied.
+
 ## Quick Start
 
 ### Option 1: Supervised CLI


### PR DESCRIPTION
Summary:

Makes the framework dispatcher's supervisor path actually usable end-to-end and documents the `--workflow module:factory` syntax for users.

Changes:

- `_app/_supervisor.py` gains `run_supervisor(argv)`, which parses the framework supervisor argv, requires `--workflow`, resolves the factory, builds the engine command and supervisor prompt, then `os.execvp`s the coding agent (Claude or Codex). This mirrors the existing `pipeline_optimization._cli` shape but is workflow-agnostic — it consumes the workflow only through `WorkflowSpec`.
- `_app/_main.py` now dispatches the non-engine path to `run_supervisor` instead of falling through to the engine.
- `_app/BUCK` picks up an explicit dep on the parent `spdl.autoresearch` private impl so `_supervisor.py` can import the existing `_resolve_supervisor_agent` helper from `_common`.
- `tools/autoresearch/README.md` adds a "Pluggable Workflows (`--workflow`)" section documenting the `module.path:factory` form and the `spdl.autoresearch.workflows` Python entry-points group, including a `pyproject.toml` example for OSS distribution.

The bare `:autoresearch` binary's behavior is unchanged for legacy invocations (the `cli.py` shim still falls back to `pipeline_optimization.main` when no `--workflow` is supplied). Users who pass `--workflow` now hit the framework path. Step 8 retires the legacy fallback.

Reviewed By: gl3lan

Differential Revision: D106303136


