### PR TITLE
Add WorkflowProtocol.summarize and wire `summary` subcommand (#1467)

### DIFF
--- a/src/spdl/autoresearch/_app/_engine.py
+++ b/src/spdl/autoresearch/_app/_engine.py
@@ -18,12 +18,15 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import logging
 import sys
 from pathlib import Path
 
 from spdl.autoresearch.core import Orchestrator, WorkflowSpec
 
 from ._spec import _record_workflow_factory, _resolve_workflow
+
+_LG: logging.Logger = logging.getLogger(__name__)
 
 __all__ = [
     "_parse_engine_args",
@@ -99,6 +102,12 @@ def _split_at_double_dash(
 def _run_engine(argv: list[str] | None = None) -> None:
     """Resolve the workflow, build the spec, and drive the orchestrator.
 
+    On a clean engine exit, the framework writes
+    ``<workdir>/report.md`` with the result of
+    :py:meth:`WorkflowProtocol.summarize <spdl.autoresearch.core.WorkflowProtocol.summarize>`
+    so operators have a final summary without needing to invoke a
+    separate command.
+
     Args:
         argv: Argv list (excluding ``argv[0]``). Defaults to ``sys.argv[1:]``.
     """
@@ -118,3 +127,24 @@ def _run_engine(argv: list[str] | None = None) -> None:
     )
     engine = Orchestrator(workflow=workflow, max_concurrency=max_concurrency)
     asyncio.run(engine.run())
+    _write_final_report(workdir, workflow)
+
+
+def _write_final_report(workdir: Path, workflow: object) -> None:
+    """Write the workflow's final summary to ``<workdir>/report.md``.
+
+    Best-effort: if ``summarize`` raises (for example, the workflow's
+    persisted state is missing), the engine still exits cleanly and a
+    warning is logged rather than crashing the process.
+    """
+    summarize = getattr(workflow, "summarize", None)
+    if summarize is None:
+        return
+    try:
+        report = summarize(workdir)
+        (workdir / "report.md").write_text(report)
+    except Exception:  # noqa: BLE001 — final-report failures must not crash exit
+        _LG.warning(
+            "Failed to write final report",
+            exc_info=True,
+        )

--- a/src/spdl/autoresearch/_app/_main.py
+++ b/src/spdl/autoresearch/_app/_main.py
@@ -6,25 +6,58 @@
 
 """Top-level entry point for the autoresearch framework binary.
 
-The single ``spdl-autoresearch`` binary supports two modes, dispatched by
-the first positional argument:
+The single ``spdl-autoresearch`` binary supports three subcommands,
+parsed by :mod:`argparse`:
 
 - ``engine`` — run the orchestrator directly. Used by the supervisor
   when it execs the engine subprocess, and by developers running the
   engine without the agent wrapper.
-- (default) — run the interactive supervisor wrapper, which builds the
-  engine command and ``execvp``\\s a coding agent.
+- ``summary <workdir>`` — re-resolve the workflow factory recorded in
+  ``<workdir>/workflow_factory.json`` and print
+  ``workflow.summarize(workdir)`` to stdout.
+- (default, no subcommand) — run the interactive supervisor wrapper,
+  which builds the engine command and ``execvp``\\s a coding agent.
 """
 
 from __future__ import annotations
 
+import argparse
 import sys
+from pathlib import Path
+
+from spdl.autoresearch._app._spec import _read_workflow_factory, _resolve_workflow
 
 __all__ = ["main"]
 
 
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="spdl autoresearch",
+        description="Autoresearch framework dispatcher.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    subparsers = parser.add_subparsers(dest="command")
+
+    subparsers.add_parser(
+        "engine",
+        help="Run the orchestrator engine directly.",
+        add_help=False,
+    )
+
+    summary_parser = subparsers.add_parser(
+        "summary",
+        help="Print the workflow summary for an existing workdir.",
+    )
+    summary_parser.add_argument(
+        "workdir",
+        help="Experiment workdir containing workflow_factory.json.",
+    )
+
+    return parser
+
+
 def main(argv: list[str] | None = None) -> None:
-    """Dispatch to the supervisor or engine entry point.
+    """Dispatch to the supervisor, engine, or summary entry point.
 
     Args:
         argv: Argv list (excluding ``argv[0]``). Defaults to ``sys.argv[1:]``.
@@ -33,7 +66,26 @@ def main(argv: list[str] | None = None) -> None:
     from ._supervisor import _run_supervisor
 
     args = list(sys.argv[1:] if argv is None else argv)
-    if args and args[0] == "engine":
-        _run_engine(args[1:])
-        return
-    _run_supervisor(args)
+    ns, remaining = _build_parser().parse_known_args(args)
+
+    if ns.command == "engine":
+        _run_engine(remaining)
+    elif ns.command == "summary":
+        _run_summary(ns.workdir)
+    else:
+        _run_supervisor(args)
+
+
+def _run_summary(workdir_str: str) -> None:
+    """Print the workflow's summary for an existing workdir."""
+    workdir = Path(workdir_str).resolve()
+    spec_str = _read_workflow_factory(workdir)
+    if spec_str is None:
+        raise SystemExit(
+            f"No workflow factory recorded in {workdir}. "
+            f"Run the engine against this workdir first."
+        )
+    factory = _resolve_workflow(spec_str)
+    spec = factory([], workdir)
+    workflow = spec.build_workflow(workdir)
+    print(workflow.summarize(workdir))

--- a/src/spdl/autoresearch/_common/_state.py
+++ b/src/spdl/autoresearch/_common/_state.py
@@ -57,7 +57,10 @@ def read_config(workdir: Path) -> dict:
 
 
 def _read_master_table(workdir: Path) -> str:
-    return (workdir / "master_table.tsv").read_text()
+    path = workdir / "master_table.tsv"
+    if not path.exists():
+        return ""
+    return path.read_text()
 
 
 def _escape_tsv(value: str) -> str:

--- a/src/spdl/autoresearch/core/__init__.py
+++ b/src/spdl/autoresearch/core/__init__.py
@@ -54,6 +54,10 @@ Example::
             # Filter or transform children before they enter the queue.
             return result.children
 
+        def summarize(self, workdir: Path) -> str:
+            # Render workdir state as markdown. Safe to call any time.
+            return _render_summary(workdir)
+
         def _initial_specs(self) -> list[TaskSpec]:
             return [TaskSpec(id="exp_001", priority=0)]
 

--- a/src/spdl/autoresearch/core/_orchestrator.py
+++ b/src/spdl/autoresearch/core/_orchestrator.py
@@ -44,6 +44,7 @@ import logging
 import signal
 from collections.abc import Coroutine
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Any, Protocol
 
 _LG: logging.Logger = logging.getLogger(__name__)
@@ -132,7 +133,7 @@ class WorkflowProtocol(Protocol):
     """Protocol for domain-specific adapters that drive the work engine.
 
     Implementations must provide ``load``, ``checkpoint``, ``make_coro``,
-    and ``on_result``.
+    ``on_result``, and ``summarize``.
     """
 
     def load(self) -> list[TaskSpec]:
@@ -173,6 +174,23 @@ class WorkflowProtocol(Protocol):
         Called after a work coroutine finishes.  The adapter can filter
         duplicates, update persistent state, or transform the result's
         children before they enter the priority queue.
+        """
+        ...
+
+    def summarize(self, workdir: Path) -> str:
+        """Return a human-readable summary of the workdir state.
+
+        Required. Must be safe to call at any time — before any run, in
+        the middle of a run, after a paused or interrupted run, and
+        after a clean exit. The framework calls this method to handle
+        ``autoresearch summary <wd>`` invocations on demand and writes
+        the result to ``<wd>/report.md`` automatically when the engine
+        exits cleanly.
+
+        Implementations should render the summary deterministically
+        from durable workdir state (master tables, summary files,
+        recorded failures), without invoking long-running operations
+        such as coding-agent calls.
         """
         ...
 

--- a/src/spdl/autoresearch/pipeline_optimization/_ops/_adapter.py
+++ b/src/spdl/autoresearch/pipeline_optimization/_ops/_adapter.py
@@ -54,7 +54,7 @@ from collections.abc import Coroutine
 from pathlib import Path
 from typing import Any
 
-from spdl.autoresearch._common._state import _append_master_row
+from spdl.autoresearch._common._state import _append_master_row, _read_master_table
 from spdl.autoresearch.core import (
     AnalysisResult,
     AutoresearchError,
@@ -73,7 +73,12 @@ from ._analysis_ops import (
     _update_on_complete,
     _update_summary_and_plot,
 )
-from ._failures import _failure_note, _make_failure, _unexpected_failure
+from ._failures import (
+    _failure_note,
+    _make_failure,
+    _read_failures,
+    _unexpected_failure,
+)
 from ._planning_ops import _build_initial_nodes, _plan_followups
 from ._policy import (
     _change_summary_for_spec,
@@ -165,6 +170,23 @@ class PipelineOptimizationWorkflow:
 
     def make_coro(self, spec: TaskSpec) -> Coroutine[Any, Any, TaskResult]:
         return self.run_experiment(spec)
+
+    def summarize(self, workdir: Path) -> str:
+        """Return a deterministic markdown summary of the workdir state.
+
+        Reads ``master_table.tsv``, the live ``summary.md`` file, and the
+        recorded failures (via :py:func:`_read_failures`) without
+        invoking the coding agent. Safe to call at any time.
+        """
+        sections = ["# Autoresearch summary", "", f"Workdir: `{workdir}`", ""]
+        master_table = _read_master_table(workdir)
+        if master_table:
+            sections.extend(["## Master table", "", master_table, ""])
+        summary_path = workdir / "summary.md"
+        if summary_path.exists():
+            sections.extend(["## Live summary", "", summary_path.read_text(), ""])
+        sections.extend(["## Failures", "", _read_failures(workdir), ""])
+        return "\n".join(sections)
 
     async def on_result(self, spec: TaskSpec, result: TaskResult) -> list[TaskSpec]:
         children = []

--- a/src/spdl/autoresearch/pipeline_optimization/prompts/supervisor/launch.md
+++ b/src/spdl/autoresearch/pipeline_optimization/prompts/supervisor/launch.md
@@ -56,13 +56,20 @@ python run.py <workdir>
 
 Config is persisted in `<workdir>/config.json` from the first run.
 
-## Step 3: Generate Final Report
+## Step 3: Read the Final Report
 
-After the engine finishes:
+When the engine exits cleanly the framework writes
+`<workdir>/report.md` automatically — read it and surface the key
+findings to the user. You can also re-render the same report at any
+time during a run via:
 
 ```bash
-python cmd.py report <workdir>
+spdl autoresearch summary <workdir>
 ```
+
+The `summary` subcommand prints a deterministic snapshot of the workdir
+state (master table, live summary, recorded failures); it does not
+invoke a coding agent.
 
 ## What the Engine Does
 

--- a/tests/autoresearch/factory_test.py
+++ b/tests/autoresearch/factory_test.py
@@ -6,8 +6,12 @@
 
 from __future__ import annotations
 
+import json
+import tempfile
 import unittest
+from pathlib import Path
 
+from spdl.autoresearch._common._state import MASTER_TABLE_HEADERS, write_state
 from spdl.autoresearch.pipeline_optimization import create_workflow
 
 __all__: list[str] = []
@@ -124,3 +128,75 @@ class _CreateWorkflowTest(unittest.TestCase):
         assert description is not None  # for type checker
         self.assertIn("---", description)
         self.assertIn("Automated SPDL Pipeline Optimization", description)
+
+
+def _write_minimal_workdir(workdir: Path) -> None:
+    """Create the minimum files PipelineOptimizationWorkflow.summarize reads."""
+    workdir.mkdir(parents=True, exist_ok=True)
+    (workdir / "config.json").write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "pipeline_script": "",
+                "source_dir": "",
+                "scm": "",
+                "build_command": "",
+                "base_launch_command": "",
+                "stopping_criteria": {"max_iterations": 1, "patience": 1},
+                "max_concurrency": 1,
+                "job_timeout_s": 60,
+                "poll_interval": 0,
+                "platform": "auto",
+                "agent": "claude",
+                "local_execution_mode": "full",
+            }
+        )
+    )
+    write_state(
+        workdir,
+        {
+            "iteration": 0,
+            "status": "looping",
+            "baseline_job": None,
+            "current_best": None,
+            "best_metric": None,
+            "plateau_count": 0,
+            "best_practices_tried": [],
+            "history": [],
+        },
+    )
+    (workdir / "master_table.tsv").write_text("\t".join(MASTER_TABLE_HEADERS) + "\n")
+
+
+class _SummarizeTest(unittest.TestCase):
+    def test_summarize_returns_markdown_for_empty_workdir(self) -> None:
+        """summarize handles a freshly initialised workdir without raising."""
+        with tempfile.TemporaryDirectory() as tmp:
+            workdir = Path(tmp)
+            _write_minimal_workdir(workdir)
+            spec = create_workflow([], workdir)
+            workflow = spec.build_workflow(workdir)
+
+            output = workflow.summarize(workdir)
+
+            self.assertIn("# Autoresearch summary", output)
+            self.assertIn(str(workdir), output)
+            self.assertIn("## Failures", output)
+
+    def test_summarize_includes_master_table_and_live_summary(self) -> None:
+        """summarize renders master-table rows and summary.md content."""
+        with tempfile.TemporaryDirectory() as tmp:
+            workdir = Path(tmp)
+            _write_minimal_workdir(workdir)
+            with open(workdir / "master_table.tsv", "a") as f:
+                f.write("run_001\tbaseline\t0.5\n")
+            (workdir / "summary.md").write_text("Best SM util improved to 85%")
+            spec = create_workflow([], workdir)
+            workflow = spec.build_workflow(workdir)
+
+            output = workflow.summarize(workdir)
+
+            self.assertIn("## Master table", output)
+            self.assertIn("run_001", output)
+            self.assertIn("## Live summary", output)
+            self.assertIn("Best SM util improved to 85%", output)

--- a/tests/autoresearch/orchestrator_test.py
+++ b/tests/autoresearch/orchestrator_test.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import asyncio
 import unittest
+from pathlib import Path
 
 from spdl.autoresearch.core import Orchestrator, TaskResult, TaskSpec
 
@@ -43,6 +44,9 @@ class _FakeAdapter:
 
     async def on_result(self, spec: TaskSpec, result: TaskResult) -> list[TaskSpec]:
         return result.children
+
+    def summarize(self, workdir: Path) -> str:
+        return f"_FakeAdapter summary at {workdir}"
 
 
 class OrchestratorTest(unittest.IsolatedAsyncioTestCase):


### PR DESCRIPTION
Summary:

Collapses two operator paths (`status` and `report`) into a single required `WorkflowProtocol.summarize(workdir) -> str` primitive that workflows must implement, then wires the framework dispatcher to invoke it both on demand and automatically at engine completion.

Changes:

- `core/_orchestrator.py`: `WorkflowProtocol` gains a required `summarize(workdir)` method. The docstring states the contract clearly: must be safe to call at any time (no run yet, mid-run, paused, finished) and must render deterministically from durable workdir state without invoking long-running operations such as coding-agent calls.
- `core/__init__.py`: the `MyWorkflow` example snippet adds the new method.
- `pipeline_optimization/_ops/_adapter.py`: `PipelineOptimizationWorkflow.summarize` returns a markdown summary built from the master table, the live `summary.md` if present, and the recorded failures. No coding-agent invocation, so this is fast and side-effect-free.
- `_app/_engine.py`: after `Orchestrator.run()` returns cleanly the framework writes `<workdir>/report.md` with `workflow.summarize(workdir)` automatically. Wrapped in best-effort error handling so a `summarize` failure cannot crash a clean engine exit.
- `_app/_main.py`: new `autoresearch <workdir> summary` subcommand re-resolves the workflow factory recorded in the workdir during `setup()` and prints the summary to stdout.
- `pipeline_optimization/prompts/supervisor/launch.md`: drops the `python cmd.py report` instruction and points the supervisor at `<workdir>/report.md` (auto-written) plus the `spdl-autoresearch <workdir> summary` subcommand for any-time inspection.
- `tests/autoresearch/orchestrator_test.py`: `_FakeAdapter` adds a stub `summarize` so it satisfies the updated protocol.
- `tests/autoresearch/factory_test.py`: new `_SummarizeTest` exercises `PipelineOptimizationWorkflow.summarize` against a freshly initialised workdir and asserts the rendered output contains the expected sections.

Reviewed By: gl3lan

Differential Revision: D106303484


