### PR TITLE
[autoresearch] Change `WorkflowSpec.max_concurrency` from attribute t…

### DIFF
--- a/src/spdl/autoresearch/core/_workflow.py
+++ b/src/spdl/autoresearch/core/_workflow.py
@@ -50,12 +50,12 @@ class WorkflowSpec(Protocol):
     A workflow factory is any callable matching :py:data:`WorkflowFactory`
     that returns a value satisfying this protocol.
 
-    Attributes:
-        max_concurrency: Maximum concurrent coroutines the orchestrator
-            should run for this workflow.
     """
 
-    max_concurrency: int
+    @property
+    def max_concurrency(self) -> int:
+        """Maximum concurrent coroutines the orchestrator should run."""
+        ...
 
     # --- Supervisor phase (consumed by framework supervisor) ---
 

--- a/src/spdl/autoresearch/pipeline_optimization/_factory.py
+++ b/src/spdl/autoresearch/pipeline_optimization/_factory.py
@@ -133,7 +133,11 @@ class _PipelineOptimizationSpec:
     ) -> None:
         self._ns = ns
         self._workdir = workdir
-        self.max_concurrency: int = ns.max_concurrency
+        self._max_concurrency: int = ns.max_concurrency
+
+    @property
+    def max_concurrency(self) -> int:
+        return self._max_concurrency
 
     # --- Supervisor phase ---
 
@@ -235,7 +239,7 @@ class _PipelineOptimizationSpec:
         platform = create_platform(config, workdir)
         state["status"] = "looping"
         write_state(workdir, state)
-        self.max_concurrency = int(config.get("max_concurrency", 3))
+        self._max_concurrency = int(config.get("max_concurrency", 3))
         return PipelineOptimizationWorkflow(
             workdir=workdir,
             config=config,


### PR DESCRIPTION
…o property

The Sphinx documentation build cannot extract the `max_concurrency` attribute from the `WorkflowSpec` protocol because bare protocol attributes are not discoverable by the autodoc machinery. Changing it to an `@property` makes it a method-like descriptor that Sphinx can introspect and document.

Changes:
- `core/_workflow.py`: replaced `max_concurrency: int` bare attribute with an `@property` method on the `WorkflowSpec` protocol.
- `pipeline_optimization/_factory.py`: converted `_PipelineOptimizationSpec.max_concurrency` from a plain attribute to a property backed by `_max_concurrency`.