### PR TITLE
Harden autoresearch prompts against wrong-file replacement in CPU ode experiments

### DIFF
--- a/src/spdl/autoresearch/pipeline_optimization/_ops/_planning_ops.py
+++ b/src/spdl/autoresearch/pipeline_optimization/_ops/_planning_ops.py
@@ -181,6 +181,7 @@ def _get_plan(
         KNOWLEDGE=knowledge,
         MASTER_TABLE=_read_master_table(workdir),
         LAST_ANALYSIS=last_analysis[:8000],
+        PIPELINE_SCRIPT=config.get("pipeline_script", "(unknown)"),
         PIPELINE_CODE=pipeline_code or "(not provided)",
         ITERATION=str(iteration),
         MAX_ITERATIONS=str(max_iter),

--- a/src/spdl/autoresearch/pipeline_optimization/_ops/_source_ops.py
+++ b/src/spdl/autoresearch/pipeline_optimization/_ops/_source_ops.py
@@ -52,14 +52,46 @@ def _extract_top_level_names(source: str) -> set[str]:
     return names
 
 
+def _extract_import_modules(source: str) -> set[str]:
+    """Extract imported module names from ``import`` / ``from … import`` lines.
+
+    Returns dotted module paths (e.g. ``{"torch", "torch.distributed",
+    "spdl.io"}``).  Used to detect wholesale file replacement where the
+    agent outputs a different module's content.
+    """
+    modules: set[str] = set()
+    for match in re.finditer(r"^(?:import|from)\s+([\w.]+)", source, re.MULTILINE):
+        modules.add(match.group(1))
+    return modules
+
+
 def _validate_preserved_symbols(original_code: str, modified_code: str) -> list[str]:
     """Return names of top-level symbols present in *original_code* but
     missing from *modified_code*.  An empty list means all symbols are
     preserved.
+
+    Also detects wrong-file replacement by checking whether a majority
+    of the original file's imported modules were dropped — a strong
+    signal that the agent output the content of a different file.
     """
     original_names = _extract_top_level_names(original_code)
     modified_names = _extract_top_level_names(modified_code)
-    return sorted(original_names - modified_names)
+    missing = original_names - modified_names
+
+    # Detect wrong-file replacement: if more than half of the original
+    # imported modules disappeared, the agent almost certainly output
+    # the content of a different file (e.g. utils/pipeline.py instead
+    # of the training script).
+    original_imports = _extract_import_modules(original_code)
+    modified_imports = _extract_import_modules(modified_code)
+    dropped_imports = original_imports - modified_imports
+    if original_imports and len(dropped_imports) > len(original_imports) // 2:
+        missing.add(
+            f"imports:dropped {len(dropped_imports)}/{len(original_imports)} "
+            f"({', '.join(sorted(dropped_imports))})"
+        )
+
+    return sorted(missing)
 
 
 def _build_apply_prompt(

--- a/src/spdl/autoresearch/pipeline_optimization/prompts/apply_changes.md
+++ b/src/spdl/autoresearch/pipeline_optimization/prompts/apply_changes.md
@@ -26,7 +26,13 @@ __PIPELINE_CODE__
    - If the change can be applied by wrapping or monkey-patching the imported function within this file, do that.
    - If the change truly cannot be expressed as a modification to this file, output the file UNCHANGED and add a comment `# AUTORESEARCH: change requires modifying a different file` at the top.
    **NEVER output the content of a different file** — the engine will overwrite `__PIPELINE_SCRIPT__` with your output, destroying all existing functions (main, parse_args, init_logging, train, etc.) and causing ImportError crashes.
-3. **Preserve ALL existing top-level symbols**: The output file MUST contain every function, class, and module-level variable that exists in the input. Other modules import symbols from this file (e.g., `init_logging`, `main`, `parse_args`). Dropping any of them causes `ImportError` at runtime. Before outputting, mentally verify that every `def` and `class` from the input appears in your output.
+3. **Preserve ALL existing top-level symbols**: The output file MUST contain every function, class, and module-level variable that exists in the input. Other modules import symbols from this file (e.g., `init_logging`, `main`, `parse_args`, `train`). Dropping any of them causes `ImportError` at runtime.
+
+   **VERIFICATION CHECKLIST** (do this before outputting):
+   - List every `def` and `class` from the input file. Confirm each one appears in your output.
+   - If your output is missing `train()`, `main()`, `parse_args()`, or `init_logging()`, you are almost certainly outputting the content of a different file (e.g., `utils/pipeline.py`) instead of modifying the pipeline script. STOP and re-read the input file.
+   - If your output no longer imports `torch.distributed`, `DDP`, or `torchvision`, you are outputting the wrong file.
+   - The training loop, model creation, optimizer setup, and DDP wrapping must remain intact.
 4. Preserve all existing functionality that is not explicitly being changed (instrumentation, logging, model setup, training loop structure).
 5. **CRITICAL**: You MUST output the complete modified file content inside a single fenced code block with the `python` language tag. Do NOT output a diff, do NOT output partial snippets, do NOT skip the code block. The output MUST contain exactly one block in this format:
 

--- a/src/spdl/autoresearch/pipeline_optimization/prompts/knowledge/knowledge.md
+++ b/src/spdl/autoresearch/pipeline_optimization/prompts/knowledge/knowledge.md
@@ -133,6 +133,99 @@ Build the entire pipeline (demux → decode_packets_nvdec → to_torch) in the m
 - **Use a dedicated `ThreadPoolExecutor` for the decode stage** — do NOT share the pipeline's default thread pool. Create `ThreadPoolExecutor(max_workers=C)` and pass it via `executor=` to the decode `.pipe()` call. This avoids contention between NVDEC decode threads (which need their own CUDA contexts) and CPU fetch/processing threads
 
 
+### CPU FFmpeg Video Decoding (reverse of GPU decode)
+
+When the pipeline uses GPU NVDEC decode and you want to switch to CPU FFmpeg decode (e.g., to bypass the NVDEC hardware decoder slot limit), replace the NVDEC decode chain with CPU FFmpeg decode + GPU transfer.
+
+**GPU decode pipeline (current):** `demux_video → decode_packets_nvdec → to_torch` (output on GPU)
+**CPU decode pipeline (replacement):** `demux_video → decode_packets → convert_frames → to_torch → transfer_tensor` (output on CPU, then transferred to GPU)
+
+#### Key APIs and their exact signatures
+
+**`spdl.io.decode_packets`** — CPU FFmpeg decode:
+```python
+spdl.io.decode_packets(
+    packets,                           # VideoPackets from demux_video()
+    filter_desc: str | None = <default>,  # FFmpeg filter graph string
+    decode_config: DecodeConfig | None = None,
+    *,
+    num_frames: int = -1,              # keyword-only
+) -> VideoFrames
+```
+
+The `filter_desc` parameter controls pixel format conversion and scaling. By default it converts to `rgb24`. Use `spdl.io.get_video_filter_desc()` to construct filter strings with scaling:
+
+```python
+filter_desc = spdl.io.get_video_filter_desc(
+    scale_width=112,
+    scale_height=112,
+    pix_fmt="rgb24",
+)
+frames = spdl.io.decode_packets(packets, filter_desc=filter_desc)
+```
+
+**`spdl.io.convert_frames`** — convert decoded frames to buffer:
+```python
+spdl.io.convert_frames(
+    frames,                    # VideoFrames from decode_packets()
+    storage: CPUStorage | None = None,
+) -> CPUBuffer
+```
+
+**IMPORTANT**: `convert_frames` does NOT accept `filter_desc`. Filtering (scaling, pixel format) is done at `decode_packets` time via the `filter_desc` parameter. Passing `filter_desc` to `convert_frames` will raise a `TypeError`.
+
+The output buffer shape for video is `[N, C, H, W]` — this is already channels-first when the input was decoded with an rgb24 filter.
+
+**`spdl.io.to_torch`** — convert buffer to torch tensor:
+```python
+tensor = spdl.io.to_torch(buffer)  # CPU tensor, shape matches buffer layout
+```
+
+**`spdl.io.transfer_tensor`** — transfer CPU tensors to GPU:
+```python
+spdl.io.transfer_tensor(batch, /, *, num_caches: int = 4)
+```
+
+Handles nested structures (dict, list, tuple, dataclass). Uses `LOCAL_RANK` env var to determine target GPU device. Creates a dedicated CUDA stream per thread for overlapping transfer with compute.
+
+#### Replacing NVDEC with CPU decode (in-place pattern)
+
+The simplest approach is to modify the existing decode callable's `__call__` method. Replace the NVDEC decode body:
+
+```python
+# BEFORE (NVDEC):
+buffer = spdl.io.decode_packets_nvdec(
+    packets, device_config=self.cuda_cfg,
+    scale_width=self.width, scale_height=self.height, pix_fmt="rgb",
+)
+tensor = spdl.io.to_torch(buffer)  # [T, C, H, W] on GPU
+
+# AFTER (CPU FFmpeg):
+filter_desc = spdl.io.get_video_filter_desc(
+    scale_width=self.width, scale_height=self.height, pix_fmt="rgb24",
+)
+frames = spdl.io.decode_packets(packets, filter_desc=filter_desc)
+buffer = spdl.io.convert_frames(frames)
+tensor = spdl.io.to_torch(buffer)  # [T, C, H, W] on CPU
+```
+
+After the decode callable, add GPU transfer. Since CPU decode produces CPU tensors, add `transfer_tensor` as a pipeline stage **after collate but before the sink**:
+
+```python
+.pipe(collate)
+.pipe(spdl.io.transfer_tensor, executor=ThreadPoolExecutor(max_workers=1))
+.add_sink(buffer_size=3)
+```
+
+Remove `cuda_config` setup code that was only used for NVDEC. Keep the `device` variable if the label tensor needs to be on GPU.
+
+#### Common mistakes to avoid
+
+1. **Do NOT pass `filter_desc` to `convert_frames()`** — it only accepts `(frames, storage=None)`.
+2. **Do NOT forget GPU transfer** — CPU decode produces CPU tensors; add `transfer_tensor` stage.
+3. **Do NOT modify the wrong file** — if the decode callable is in a utility module (e.g., `utils/pipeline.py`) and the engine modifies the training script, define a new decode callable in the training script and override the pipeline construction call.
+4. **Do NOT remove BUCK dependencies** — the training script needs its model/training deps (torchvision, DDP, etc.) even when changing the pipeline.
+
 ### Headspace Analysis in the Loop
 
 The autoresearch loop runs CacheDataLoader analysis automatically as part of the first iteration, alongside other experiments like MTP. CacheDataLoader results must NOT be treated as a real training run — they are excluded from the running best and plateau detection.

--- a/src/spdl/autoresearch/pipeline_optimization/prompts/plan_next.md
+++ b/src/spdl/autoresearch/pipeline_optimization/prompts/plan_next.md
@@ -39,7 +39,7 @@ __LAST_ANALYSIS__
 __HISTORY_JSON__
 ```
 
-### Pipeline Source Code
+### Pipeline Source Code (`__PIPELINE_SCRIPT__`)
 ```python
 __PIPELINE_CODE__
 ```
@@ -112,6 +112,7 @@ Before you can consider stopping, ALL of the following must have been attempted 
    - **NOT compatible with MTP (subprocess mode)** — `VideoPackets` are not picklable and cannot cross process boundaries. GPU video decode must run as a pure multithreaded pipeline in the main process (using `PipelineBuilder.build(num_threads=N)`). `gpu_video_decode` is an **independent optimization path** from `mtp` — they are mutually exclusive alternatives, not stackable. The GPU decode experiment must apply its changes to the original instrumented pipeline (not on top of MTP changes). Do NOT set `goto` to an MTP commit.
    - **Use a dedicated `ThreadPoolExecutor` for the NVDEC decode stage** — do NOT share the pipeline's default thread pool. Create `ThreadPoolExecutor(max_workers=C)` and pass it via `executor=` to the decode `.pipe()` call. This prevents NVDEC decode threads (which need their own CUDA contexts) from competing with CPU fetch threads.
    - Write the `description` field with explicit instructions, e.g.: "Replace `spdl.io.decode_packets(packets)` + `convert_frames` + `transfer_buffer` with `spdl.io.decode_packets_nvdec(packets, device_config=cuda_cfg, pix_fmt='rgb')`. Remove the `transfer_buffer`/`transfer_tensor` stage since data is already on GPU. Set decode concurrency to 7. Use a dedicated `ThreadPoolExecutor(7)` for the decode stage via `executor=ThreadPoolExecutor(7)`. Create `cuda_cfg` using `spdl.io.cuda_config(device_index, allocator=(torch.cuda.caching_allocator_alloc, torch.cuda.caching_allocator_delete))`. Use pure multithreading (no subprocess MTP)."
+   - **Reverse direction (NVDEC → CPU FFmpeg)**: If the pipeline already uses `decode_packets_nvdec` and the NVDEC hardware decoder slots are the bottleneck (e.g., only 7 slots on H100), try switching to CPU FFmpeg decode to bypass the hardware limit. **Follow the "CPU FFmpeg Video Decoding" section in the knowledge base** for the correct API signatures. Key: use `decode_packets(packets, filter_desc=get_video_filter_desc(scale_width=W, scale_height=H, pix_fmt="rgb24"))` → `convert_frames(frames)` → `to_torch(buffer)`, then add `transfer_tensor` as a pipeline stage after collate. **CRITICAL**: `convert_frames` does NOT accept `filter_desc` — filtering is done at `decode_packets` time.
 
 If the "Not yet tried" list is non-empty, you MUST prioritize those practices. If a practice doesn't apply to this pipeline (e.g., already uses continuous mode, or doesn't do video decoding for gpu_video_decode), explain why in your reasoning and still tag it so the orchestrator knows it was considered.
 
@@ -186,7 +187,16 @@ Output your reasoning, then a JSON block:
 ```
 
 Rules:
-- **Single-file constraint**: The engine can only modify the pipeline script file shown in "Pipeline Source Code" above. All code changes described in the `"description"` field MUST be expressible as modifications to **this file only**. If `build_pipeline()` or other target functions are defined in a separate module (e.g., `utils/pipeline.py`) that is imported by the pipeline script, the description MUST instruct the apply agent to modify the pipeline script itself — for example, by inlining the function, overriding the import, or wrapping the call. Do NOT write descriptions that say "In utils/pipeline.py, change..." — the apply agent will output the wrong file's content and destroy the pipeline script, causing `ImportError` crashes. Instead, write descriptions that target the functions and code visible in the pipeline script source code above.
+- **Single-file constraint (CRITICAL — read carefully)**: The engine can ONLY modify the file `__PIPELINE_SCRIPT__`. All code changes described in the `"description"` field MUST be expressible as modifications to **this file only**. The apply agent receives this file's content and must output the modified version — if the description references a different file (e.g., `utils/pipeline.py`, `pipeline.py`), the apply agent will output that other file's content instead, **destroying `__PIPELINE_SCRIPT__`** and causing `ImportError` crashes (the training loop, model setup, and DDP initialization are deleted).
+
+  **How to handle imported pipeline code**: If `build_pipeline()` or other target functions are defined in a separate module that is imported by the pipeline script, the description MUST instruct the apply agent to:
+  1. Keep ALL existing imports, functions, and classes in the pipeline script.
+  2. Add any new imports needed (e.g., `import spdl.io`, `from concurrent.futures import ThreadPoolExecutor`).
+  3. Define new classes/functions (e.g., `CpuDecode`) directly in the pipeline script.
+  4. Either (a) override the imported `build_pipeline` by defining a local replacement that uses the new code, or (b) apply the change as a post-import monkey-patch.
+  5. Update the call site (e.g., in `main()`) to use the new local function.
+
+  **NEVER** write descriptions that say "In utils/pipeline.py, change..." or "Modify the NvdecDecode class in the utils module" — these direct the apply agent to the wrong file. Instead, say "In `__PIPELINE_SCRIPT__`, define a new `CpuDecode` class and a new `build_pipeline_cpu()` function, then update `main()` to call `build_pipeline_cpu()` instead of the imported `build_pipeline`."
 - **`changes`** is the experiment's identity for dedup. List every modification as a short, canonical, snake_case identifier. For code changes use identifiers like `"torch_compile"`, `"fused_adamw"`, `"mtp"`, `"priority_executor"`, `"cache_dataloader"`. For parameter changes use `"param_name=value"` format like `"batch_size=48"`, `"num_workers=16"`. Combination experiments list all changes (e.g. `["mtp", "torch_compile"]`). Parameter changes are also auto-detected from launch command diffs, but code changes **must** be listed explicitly. The orchestrator rejects experiments whose change set matches a non-failed existing node.
 - **Do NOT propose experiments that are semantically identical to existing ones**, even under a different name. Before proposing, check the Master Table for any run that used the same launch parameters (batch_size, num_workers, etc.) and code changes. If a configuration has been tested — regardless of what it was named — do not re-test it.
 - Use `$IMAGE` as placeholder for the job image (the orchestrator substitutes it)


### PR DESCRIPTION
We observed cases where the coding agent replaced the training script (`video_classification.py`) with pipeline module content (`utils/pipeline.py`), destroying the `train()`, `main()`, and DDP setup. The agent also hallucinated API parameters (passing `filter_desc` to `convert_frames()` which doesn't accept it).

Four fixes:

1. Pass `PIPELINE_SCRIPT` path to the planning prompt so the agent sees which file it's describing changes for (was missing entirely from `_planning_ops.py`).

2. Rewrite the single-file constraint in `plan_next.md` with concrete step-by-step instructions for inlining imported pipeline code, and explicit "NEVER say 'In utils/pipeline.py'" guidance.

3. Add a complete "CPU FFmpeg Video Decoding" knowledge section with exact API signatures for `decode_packets`, `convert_frames`, `get_video_filter_desc`, and `transfer_tensor`, plus before/after code and a "common mistakes" checklist.

4. Add generic wrong-file detection in `_validate_preserved_symbols`: extract all imported module names from original and modified code, and reject the change if more than half of the original imports disappeared — a strong signal the agent output a different file's content.