### PR TITLE
Add sample throughput to progress visualization and refactor for workflow-agnostic architecture

### DIFF
--- a/src/spdl/autoresearch/_common/_state.py
+++ b/src/spdl/autoresearch/_common/_state.py
@@ -4,38 +4,25 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-"""Experiment state, config, and master table helpers."""
+"""Generic experiment state, config, and master-table I/O.
+
+This module provides workflow-agnostic file I/O for the autoresearch
+framework.  Workflow-specific schema defaults (``_normalize_config``,
+``_normalize_state``) live in
+``spdl.autoresearch.pipeline_optimization._ops._policy``.
+"""
 
 from __future__ import annotations
 
 import json
+from collections.abc import Callable
 from pathlib import Path
 
 SCHEMA_VERSION = 2
 
-MASTER_TABLE_HEADERS = [
-    "run_id",
-    "name",
-    "job_id",
-    "status",
-    "step_time_ms",
-    "steady_step_time_ms",
-    "ttfb_s",
-    "sm_util_pct",
-    "steady_sm_util_pct",
-    "data_readiness_pct",
-    "duration_s",
-    "changes",
-    "change_summary",
-    "notes",
-]
-
 __all__ = [
-    "MASTER_TABLE_HEADERS",
     "SCHEMA_VERSION",
     "_append_master_row",
-    "_normalize_config",
-    "_normalize_state",
     "_read_master_table",
     "read_config",
     "read_state",
@@ -43,17 +30,30 @@ __all__ = [
 ]
 
 
-def read_state(workdir: Path) -> dict:
-    return _normalize_state(json.loads((workdir / "state.json").read_text()))
+def read_state(
+    workdir: Path,
+    normalize: Callable[[dict], dict] | None = None,
+) -> dict:
+    state = json.loads((workdir / "state.json").read_text())
+    return normalize(state) if normalize else state
 
 
-def write_state(workdir: Path, state: dict) -> None:
-    state = _normalize_state(state)
+def write_state(
+    workdir: Path,
+    state: dict,
+    normalize: Callable[[dict], dict] | None = None,
+) -> None:
+    if normalize:
+        state = normalize(state)
     (workdir / "state.json").write_text(json.dumps(state, indent=2) + "\n")
 
 
-def read_config(workdir: Path) -> dict:
-    return _normalize_config(json.loads((workdir / "config.json").read_text()))
+def read_config(
+    workdir: Path,
+    normalize: Callable[[dict], dict] | None = None,
+) -> dict:
+    config = json.loads((workdir / "config.json").read_text())
+    return normalize(config) if normalize else config
 
 
 def _read_master_table(workdir: Path) -> str:
@@ -67,36 +67,7 @@ def _escape_tsv(value: str) -> str:
     return value.replace("\\", "\\\\").replace("\n", "\\n").replace("\t", "\\t")
 
 
-def _append_master_row(workdir: Path, row: dict) -> None:
+def _append_master_row(workdir: Path, row: dict, headers: list[str]) -> None:
     with open(workdir / "master_table.tsv", "a") as f:
-        values = [_escape_tsv(str(row.get(h, ""))) for h in MASTER_TABLE_HEADERS]
+        values = [_escape_tsv(str(row.get(h, ""))) for h in headers]
         f.write("\t".join(values) + "\n")
-
-
-def _normalize_config(config: dict) -> dict:
-    normalized = dict(config)
-    normalized.setdefault("schema_version", SCHEMA_VERSION)
-    normalized.setdefault("stopping_criteria", {})
-    normalized["stopping_criteria"].setdefault("max_iterations", 10)
-    normalized["stopping_criteria"].setdefault("patience", 3)
-    normalized.setdefault("platform", "auto")
-    normalized.setdefault("agent", "claude")
-    normalized.setdefault("local_execution_mode", "full")
-    normalized.setdefault("startup_failure_retries", 2)
-    normalized.setdefault("startup_retryable_experiments", ["mtp"])
-    return normalized
-
-
-def _normalize_state(state: dict) -> dict:
-    normalized = dict(state)
-    normalized.setdefault("schema_version", SCHEMA_VERSION)
-    normalized.setdefault("iteration", 0)
-    normalized.setdefault("status", "initialized")
-    normalized.setdefault("baseline_job", None)
-    normalized.setdefault("current_best", None)
-    normalized.setdefault("best_metric", None)
-    normalized.setdefault("plateau_count", 0)
-    normalized.setdefault("best_practices_tried", [])
-    normalized.setdefault("anchor_commit", "")
-    normalized.setdefault("history", [])
-    return normalized

--- a/src/spdl/autoresearch/_common/_visualization.py
+++ b/src/spdl/autoresearch/_common/_visualization.py
@@ -4,11 +4,13 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-"""Plot autoresearch optimization progress and hypothesis trees.
+"""Generic progress and hypothesis-tree plotting for autoresearch.
 
-Reads the master_table.tsv produced by autoresearch and generates charts:
-  1. Job duration (primary metric, lower is better) — Karpathy-style scatter
-  2. SM utilization (secondary metric) — scatter for context
+This module is workflow-agnostic.  Callers pass :class:`MetricSpec` objects
+that describe *which* columns to plot, their axis labels, units, and
+direction (higher-is-better vs lower-is-better).  The module handles all
+rendering: Karpathy-style scatter charts, running-best step lines,
+headspace reference lines, hypothesis trees, and crash markers.
 """
 
 from __future__ import annotations
@@ -17,6 +19,7 @@ import argparse
 import csv
 import json
 import sys
+from dataclasses import dataclass
 from pathlib import Path
 
 import matplotlib
@@ -25,6 +28,7 @@ matplotlib.use("Agg")
 import matplotlib.pyplot as plt  # noqa: E402
 
 __all__ = [
+    "MetricSpec",
     "_edge_label",
     "_load_tsv",
     "_plot_hypothesis_tree",
@@ -34,82 +38,113 @@ __all__ = [
 ]
 
 
+# ---------------------------------------------------------------------------
+# MetricSpec — the contract between workflow and visualization
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class MetricSpec:
+    """Describes one metric panel in the progress chart.
+
+    Workflows create a list of these and pass them to :func:`_plot_progress`.
+    The first metric in the list is used for the "kept" (green dot) criterion
+    and receives annotations on its data points.
+    """
+
+    key: str
+    """Column name in the experiment dict (must match a TSV column)."""
+
+    label: str
+    """Y-axis label displayed on the chart panel."""
+
+    lower_is_better: bool
+    """If *True* the running-best line decreases; if *False* it increases."""
+
+    unit: str = ""
+    """Unit suffix for headspace / annotation labels (e.g. ``"samples/s"``)."""
+
+    fmt: str = ".1f"
+    """Format spec applied to values in annotations and headspace labels."""
+
+
+# ---------------------------------------------------------------------------
+# TSV loading — generic, no hardcoded column names
+# ---------------------------------------------------------------------------
+
+_STRING_COLUMNS = frozenset(
+    {
+        "run_id",
+        "name",
+        "job_id",
+        "status",
+        "changes",
+        "change_summary",
+        "notes",
+    }
+)
+
+
 def _unescape(value: str) -> str:
     return value.replace("\\n", "\n").replace("\\t", "\t").replace("\\\\", "\\")
 
 
 def _load_tsv(tsv_path: Path) -> list[dict]:
-    experiments = []
+    """Load experiments from a ``master_table.tsv``.
+
+    String columns are unescaped; every other column is parsed as ``float``
+    (or ``None`` when the cell is empty or not numeric).  Two synthetic keys
+    are added to each row:
+
+    * ``status`` — visualisation status: ``VALID``, ``CRASH``, or ``HEADSPACE``
+    * ``description`` — human-readable name with underscores replaced by spaces
+    """
+    experiments: list[dict] = []
     with open(tsv_path) as f:
         reader = csv.DictReader(f, delimiter="\t")
         for row in reader:
-            sm_raw = row.get("sm_util_pct", "")
-            try:
-                sm = float(sm_raw)
-            except (ValueError, TypeError):
-                sm = 0.0
+            exp: dict = {}
+            for col, raw in row.items():
+                if col in _STRING_COLUMNS:
+                    exp[col] = _unescape(raw) if raw else ""
+                else:
+                    try:
+                        exp[col] = float(raw) if raw else None
+                    except (ValueError, TypeError):
+                        exp[col] = None
 
-            dur_raw = row.get("duration_s", "")
-            try:
-                duration = float(dur_raw)
-            except (ValueError, TypeError):
-                duration = None
-
-            status = row.get("status", "")
-            if status == "failed" or sm <= 0:
-                exp_status = "CRASH"
-            else:
-                exp_status = "VALID"
-
-            name = row.get("name", row.get("run_id", ""))
-
-            run_id = row.get("run_id", "")
+            name = exp.get("name") or exp.get("run_id") or ""
+            run_id = exp.get("run_id") or ""
+            raw_status = exp.get("status") or ""
+            sm = exp.get("sm_util_pct")
             is_headspace = run_id == "000h" or name == "headspace_cache"
 
-            step_raw = row.get("step_time_ms", "")
-            try:
-                step_time = float(step_raw)
-            except (ValueError, TypeError):
-                step_time = None
+            if is_headspace:
+                exp["status"] = "HEADSPACE"
+            elif raw_status == "failed" or (sm is not None and sm <= 0):
+                exp["status"] = "CRASH"
+            else:
+                exp["status"] = "VALID"
 
-            steady_step_raw = row.get("steady_step_time_ms", "")
-            try:
-                steady_step = float(steady_step_raw)
-            except (ValueError, TypeError):
-                steady_step = None
-
-            steady_sm_raw = row.get("steady_sm_util_pct", "")
-            try:
-                steady_sm = float(steady_sm_raw)
-            except (ValueError, TypeError):
-                steady_sm = None
-
-            experiments.append(
-                {
-                    "run_id": run_id,
-                    "name": name,
-                    "sm_util": sm,
-                    "steady_sm_util": steady_sm,
-                    "step_time_ms": step_time,
-                    "steady_step_time_ms": steady_step,
-                    "duration_s": duration,
-                    "status": "HEADSPACE" if is_headspace else exp_status,
-                    "description": _unescape(name).replace("_", " "),
-                    "change_summary": _unescape(row.get("change_summary", "")),
-                }
-            )
+            exp["description"] = str(name).replace("_", " ")
+            experiments.append(exp)
     return experiments
 
 
-def _format_label(exp: dict) -> str:
+# ---------------------------------------------------------------------------
+# Annotation / label helpers
+# ---------------------------------------------------------------------------
+
+
+def _format_label(exp: dict, metrics: list[MetricSpec]) -> str:
+    """Build a compact annotation string from the first few metrics."""
     name = exp["description"]
     parts = []
-    dur = exp.get("duration_s")
-    sm = exp.get("sm_util")
-    if dur:
-        parts.append(f"{dur / 60:.1f}m")
-    if sm and sm > 0:
-        parts.append(f"SM {sm:.0f}%")
+    for m in metrics:
+        val = exp.get(m.key)
+        if val is not None and val > 0:
+            val_str = format(val, m.fmt)
+            parts.append(f"{val_str} {m.unit}".rstrip())
     suffix = f" ({', '.join(parts)})" if parts else ""
     label = name + suffix
     if len(label) > 55:
@@ -117,20 +152,33 @@ def _format_label(exp: dict) -> str:
     return label
 
 
-def _mark_kept(experiments: list[dict]) -> None:
-    """Mark experiments that set a new best (lowest) duration.
-    Headspace runs are excluded — they are not real training runs."""
-    best_dur = float("inf")
+# ---------------------------------------------------------------------------
+# Kept-experiment marking
+# ---------------------------------------------------------------------------
+
+
+def _mark_kept(experiments: list[dict], metric: MetricSpec) -> None:
+    """Mark experiments that set a new best for *metric*.
+
+    Headspace runs are excluded — they are not real training runs.
+    """
+    best = float("inf") if metric.lower_is_better else 0.0
+    is_better = (lambda v, b: v < b) if metric.lower_is_better else (lambda v, b: v > b)
     for exp in experiments:
-        if exp["status"] not in ("VALID",):
+        if exp["status"] != "VALID":
             exp["kept"] = False
             continue
-        dur = exp.get("duration_s")
-        if dur is not None and dur < best_dur:
+        val = exp.get(metric.key)
+        if val is not None and is_better(val, best):
             exp["kept"] = True
-            best_dur = dur
+            best = val
         else:
             exp["kept"] = False
+
+
+# ---------------------------------------------------------------------------
+# Low-level plot helpers (take primitive ``y_key`` — no MetricSpec needed)
+# ---------------------------------------------------------------------------
 
 
 def _running_best(values: list[float], lower_is_better: bool) -> list[float]:
@@ -150,6 +198,7 @@ def _plot_kept_with_line(
     lower_is_better: bool,
     last_idx: int,
     show_annotations: bool,
+    annotation_metrics: list[MetricSpec] | None = None,
 ) -> None:
     kept_x = [e["idx"] for e in kept]
     kept_y = [e[y_key] for e in kept]
@@ -174,13 +223,13 @@ def _plot_kept_with_line(
         zorder=3,
         label="Running best",
     )
-    if show_annotations:
+    if show_annotations and annotation_metrics is not None:
         rotation = 30 if lower_is_better else -30
         xytext = (6, 6) if lower_is_better else (6, -6)
         va = "bottom" if lower_is_better else "top"
         for exp in kept:
             ax.annotate(
-                _format_label(exp),
+                _format_label(exp, annotation_metrics),
                 (exp["idx"], exp[y_key]),
                 textcoords="offset points",
                 xytext=xytext,
@@ -210,18 +259,29 @@ def _set_y_limits(
         ax.set_ylim(y_lo, hi + margin)
 
 
-def _plot_headspace_line(ax: plt.Axes, experiments: list[dict], y_key: str) -> None:
+def _plot_headspace_line(
+    ax: plt.Axes,
+    experiments: list[dict],
+    metric: MetricSpec,
+) -> None:
     """Draw a horizontal dashed line at the headspace (CacheDataLoader) value."""
     for exp in experiments:
-        if exp["status"] == "HEADSPACE" and exp.get(y_key):
+        if exp["status"] == "HEADSPACE" and exp.get(metric.key) is not None:
+            val = exp[metric.key]
+            kind = "floor" if metric.lower_is_better else "ceiling"
+            val_str = format(val, metric.fmt)
+            if metric.unit:
+                label = f"Headspace {kind} ({val_str} {metric.unit})"
+            else:
+                label = f"Headspace {kind} ({val_str})"
             ax.axhline(
-                y=exp[y_key],
+                y=val,
                 color="#3498db",
                 linestyle="--",
                 linewidth=1.5,
                 alpha=0.7,
                 zorder=1,
-                label=f"Headspace floor ({exp[y_key]:.0f}s)",
+                label=label,
             )
             break
 
@@ -272,15 +332,21 @@ def _collect_y_values(experiments, valid, y_key):
     return all_y
 
 
+# ---------------------------------------------------------------------------
+# Per-panel rendering
+# ---------------------------------------------------------------------------
+
+
 def _plot_metric(
     ax: plt.Axes,
     experiments: list[dict],
-    y_key: str,
-    ylabel: str,
-    lower_is_better: bool,
+    metric: MetricSpec,
     show_annotations: bool,
     show_legend: bool,
+    annotation_metrics: list[MetricSpec] | None = None,
 ) -> None:
+    y_key = metric.key
+    lower_is_better = metric.lower_is_better
     valid, crashes, kept, discarded = _partition_experiments(experiments, y_key)
 
     if crashes:
@@ -295,11 +361,11 @@ def _plot_metric(
             lower_is_better,
             experiments[-1]["idx"],
             show_annotations,
+            annotation_metrics,
         )
-    if lower_is_better:
-        _plot_headspace_line(ax, experiments, y_key)
+    _plot_headspace_line(ax, experiments, metric)
 
-    ax.set_ylabel(ylabel, fontsize=12)
+    ax.set_ylabel(metric.label, fontsize=12)
     if show_legend:
         loc = "upper right" if lower_is_better else "lower right"
         ax.legend(loc=loc, fontsize=9)
@@ -309,62 +375,61 @@ def _plot_metric(
     _set_y_limits(ax, all_y, lower_is_better, bool(crashes))
 
 
+# ---------------------------------------------------------------------------
+# Main progress chart
+# ---------------------------------------------------------------------------
+
+
 def _plot_progress(
     experiments: list[dict],
     output_path: str,
+    metrics: list[MetricSpec],
     title_prefix: str = "",
 ) -> None:
+    """Render the multi-panel progress chart.
+
+    Parameters
+    ----------
+    experiments:
+        Rows returned by :func:`_load_tsv`.
+    output_path:
+        Where to write the PNG.
+    metrics:
+        Ordered list of metric panels.  The first metric with data in the
+        experiments is used for the "kept" criterion and receives annotations.
+    title_prefix:
+        Optional string prepended to the chart title.
+    """
     for i, exp in enumerate(experiments):
         exp["idx"] = i
-    _mark_kept(experiments)
+
+    # Keep only metrics that have at least one valid data point.
+    active = [
+        m
+        for m in metrics
+        if any(e.get(m.key) is not None and e["status"] == "VALID" for e in experiments)
+    ]
+    if not active:
+        print(f"No metric data found, skipping {output_path}")
+        return
+
+    _mark_kept(experiments, active[0])
 
     n_total = len(experiments)
     n_kept = sum(1 for e in experiments if e.get("kept"))
-    has_duration = any(
-        e["duration_s"] is not None and e["status"] == "VALID" for e in experiments
-    )
-
-    has_step_time = any(
-        e.get("step_time_ms") is not None and e["status"] == "VALID"
-        for e in experiments
-    )
-    has_steady_step = any(
-        e.get("steady_step_time_ms") is not None and e["status"] == "VALID"
-        for e in experiments
-    )
-    has_steady_sm = any(
-        e.get("steady_sm_util") is not None and e["status"] == "VALID"
-        for e in experiments
-    )
-
-    # Determine subplot count
-    plots = []
-    if has_duration:
-        plots.append(("duration_s", "Duration (seconds, lower is better)", True))
-    if has_steady_step:
-        plots.append(
-            ("steady_step_time_ms", "Steady Step Time (ms, lower is better)", True)
-        )
-    elif has_step_time:
-        plots.append(("step_time_ms", "Step Time (ms, lower is better)", True))
-    if has_steady_sm:
-        plots.append(("steady_sm_util", "Steady-State SM Utilization %", False))
-    plots.append(("sm_util", "SM Utilization % (raw avg)", False))
-
-    n_plots = len(plots)
+    n_plots = len(active)
     fig, axes = plt.subplots(n_plots, 1, figsize=(16, 5 * n_plots), sharex=True)
     if n_plots == 1:
         axes = [axes]
 
-    for i, (y_key, ylabel, lower) in enumerate(plots):
+    for i, metric in enumerate(active):
         _plot_metric(
             axes[i],
             experiments,
-            y_key=y_key,
-            ylabel=ylabel,
-            lower_is_better=lower,
+            metric,
             show_annotations=(i == 0),
             show_legend=(i == 0),
+            annotation_metrics=active if i == 0 else None,
         )
     axes[-1].set_xlabel("Experiment #", fontsize=12)
 
@@ -377,6 +442,10 @@ def _plot_progress(
     plt.savefig(output_path, dpi=150, bbox_inches="tight")
     print(f"Saved to {output_path}")
 
+
+# ---------------------------------------------------------------------------
+# Hypothesis tree (unchanged — already workflow-agnostic)
+# ---------------------------------------------------------------------------
 
 _STATUS_COLORS = {
     "completed": "#2ecc71",
@@ -670,6 +739,39 @@ def _plot_hypothesis_tree(
     print(f"Hypothesis tree saved to {output_path}")
 
 
+# ---------------------------------------------------------------------------
+# CLI entry point — auto-detects metrics from the data
+# ---------------------------------------------------------------------------
+
+_LOWER_IS_BETTER_HINTS = frozenset({"time", "duration", "ttfb", "latency"})
+
+
+def _auto_detect_metrics(experiments: list[dict]) -> list[MetricSpec]:
+    """Infer :class:`MetricSpec` instances from the available data columns.
+
+    Used only by the standalone ``main()`` CLI.  Workflows should provide
+    their own explicit metric list instead.
+    """
+    skip = _STRING_COLUMNS | {"description", "idx", "kept"}
+    seen: set[str] = set()
+    metrics: list[MetricSpec] = []
+    for exp in experiments:
+        for key in exp:
+            if key in skip or key in seen:
+                continue
+            seen.add(key)
+            if any(
+                isinstance(e.get(key), (int, float))
+                for e in experiments
+                if e.get("status") == "VALID"
+            ):
+                lower = any(hint in key for hint in _LOWER_IS_BETTER_HINTS)
+                direction = "lower is better" if lower else "higher is better"
+                label = key.replace("_", " ").title()
+                metrics.append(MetricSpec(key, f"{label} ({direction})", lower))
+    return metrics
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("tsv", help="Path to master_table.tsv")
@@ -689,7 +791,8 @@ def main() -> None:
 
     output = args.output or str(tsv_path.parent / "progress.png")
     experiments = _load_tsv(tsv_path)
-    _plot_progress(experiments, output, args.title)
+    metrics = _auto_detect_metrics(experiments)
+    _plot_progress(experiments, output, metrics, args.title)
 
     tree_file = tsv_path.parent / "engine" / "tree.json"
     if tree_file.exists():

--- a/src/spdl/autoresearch/pipeline_optimization/_factory.py
+++ b/src/spdl/autoresearch/pipeline_optimization/_factory.py
@@ -17,8 +17,8 @@ The factory parses pipeline-optimization-specific flags
 specifier in the workdir on a fresh run, performs first-run workdir
 initialisation and pipeline instrumentation when ``setup()`` is called,
 and constructs a
-:py:class:`~spdl.autoresearch.pipeline_optimization._ops._adapter.PipelineOptimizationWorkflow`
-adapter on demand.
+:py:class:`~spdl.autoresearch.pipeline_optimization._workflow.PipelineOptimizationWorkflow`
+workflow on demand.
 """
 
 from __future__ import annotations
@@ -33,19 +33,21 @@ from datetime import datetime
 from pathlib import Path
 
 from spdl.autoresearch._common._log import setup_logging
-from spdl.autoresearch._common._state import (
-    MASTER_TABLE_HEADERS,
-    read_config,
-    read_state,
-    SCHEMA_VERSION,
-    write_state,
-)
+from spdl.autoresearch._common._state import SCHEMA_VERSION
 from spdl.autoresearch.core import (
     FailureKind,
     FailurePhase,
     FailureRecord,
     WorkflowProtocol,
     WorkflowSpec,
+)
+from spdl.autoresearch.pipeline_optimization._ops._analysis_ops import (
+    MASTER_TABLE_HEADERS,
+)
+from spdl.autoresearch.pipeline_optimization._ops._policy import (
+    read_config,
+    read_state,
+    write_state,
 )
 
 from ._ops import PipelineOptimizationWorkflow

--- a/src/spdl/autoresearch/pipeline_optimization/_ops/__init__.py
+++ b/src/spdl/autoresearch/pipeline_optimization/_ops/__init__.py
@@ -6,7 +6,7 @@
 
 """Autoresearch workflow layer."""
 
-from ._adapter import PipelineOptimizationWorkflow
+from .._workflow import PipelineOptimizationWorkflow
 from ._store import _WorkflowStateStore
 
 __all__ = [

--- a/src/spdl/autoresearch/pipeline_optimization/_ops/_analysis_ops.py
+++ b/src/spdl/autoresearch/pipeline_optimization/_ops/_analysis_ops.py
@@ -16,12 +16,12 @@ from pathlib import Path
 from spdl.autoresearch._common._state import (
     _append_master_row,
     _read_master_table,
-    write_state,
 )
 from spdl.autoresearch._common._visualization import (
     _load_tsv,
     _plot_hypothesis_tree,
     _plot_progress,
+    MetricSpec,
 )
 from spdl.autoresearch.core import (
     AnalysisResult,
@@ -40,9 +40,35 @@ from ._common import (
     _read_pipeline_code,
 )
 from ._failures import _classify_terminal_job_failure, _failure_note, _make_failure
-from ._policy import _change_summary_for_spec, _format_best_metric
+from ._policy import _change_summary_for_spec, _format_best_metric, write_state
+
+__all__: list[str] = [
+    "MASTER_TABLE_HEADERS",
+    "_analyze_job",
+    "_pipeline_opt_metrics",
+    "_update_on_complete",
+    "_update_summary_and_plot",
+]
 
 _LG: logging.Logger = logging.getLogger(__name__)
+
+MASTER_TABLE_HEADERS = [
+    "run_id",
+    "name",
+    "job_id",
+    "status",
+    "throughput_samples_per_s",
+    "step_time_ms",
+    "steady_step_time_ms",
+    "ttfb_s",
+    "sm_util_pct",
+    "steady_sm_util_pct",
+    "data_readiness_pct",
+    "duration_s",
+    "changes",
+    "change_summary",
+    "notes",
+]
 
 _STRUCTURAL_PRACTICES = {"mtp"}
 _STRUCTURAL_ATTEMPT_THRESHOLD = 3
@@ -169,6 +195,7 @@ def _append_master_result_row(
     }
     if structured and "metrics" in structured:
         metrics = structured["metrics"]
+        row["throughput_samples_per_s"] = metrics.get("throughput_samples_per_s", "")
         row["step_time_ms"] = metrics.get("step_time_ms", "")
         row["steady_step_time_ms"] = metrics.get("steady_step_time_ms", "")
         row["ttfb_s"] = metrics.get("ttfb_s", "")
@@ -178,7 +205,7 @@ def _append_master_result_row(
         row["notes"] = metrics.get("notes", "")
     if terminal_failure is not None and not row.get("notes"):
         row["notes"] = _failure_note(terminal_failure)
-    _append_master_row(workdir, row)
+    _append_master_row(workdir, row, MASTER_TABLE_HEADERS)
 
 
 def _update_on_complete(
@@ -276,11 +303,80 @@ def _append_findings(workdir: Path, name: str, structured: dict | None) -> None:
         f.writelines(lines)
 
 
+def _pipeline_opt_metrics(experiments: list[dict]) -> list[MetricSpec]:
+    """Build the metric spec list for the pipeline-optimization workflow.
+
+    This is where all workflow-specific metric knowledge lives: which columns
+    to plot, in what order, axis labels, units, direction, and the
+    steady-step vs raw-step fallback.
+    """
+
+    def _has(key: str) -> bool:
+        return any(
+            e.get(key) is not None and e.get("status") == "VALID" for e in experiments
+        )
+
+    metrics: list[MetricSpec] = [
+        MetricSpec(
+            "throughput_samples_per_s",
+            "Sample Throughput (samples/s, higher is better)",
+            lower_is_better=False,
+            unit="samples/s",
+            fmt=".0f",
+        ),
+    ]
+    if _has("steady_step_time_ms"):
+        metrics.append(
+            MetricSpec(
+                "steady_step_time_ms",
+                "Steady Step Time (ms, lower is better)",
+                lower_is_better=True,
+                unit="ms",
+                fmt=".0f",
+            )
+        )
+    elif _has("step_time_ms"):
+        metrics.append(
+            MetricSpec(
+                "step_time_ms",
+                "Step Time (ms, lower is better)",
+                lower_is_better=True,
+                unit="ms",
+                fmt=".0f",
+            )
+        )
+    metrics.extend(
+        [
+            MetricSpec(
+                "steady_sm_util_pct",
+                "Steady-State SM Utilization %",
+                lower_is_better=False,
+                unit="%",
+                fmt=".1f",
+            ),
+            MetricSpec(
+                "duration_s",
+                "Duration (seconds, lower is better)",
+                lower_is_better=True,
+                unit="s",
+                fmt=".0f",
+            ),
+            MetricSpec(
+                "sm_util_pct",
+                "SM Utilization % (raw avg)",
+                lower_is_better=False,
+                unit="%",
+                fmt=".1f",
+            ),
+        ]
+    )
+    return metrics
+
+
 def _update_summary_and_plot(workdir: Path, state: dict) -> None:
     """Regenerate summary.md, progress.png, and hypothesis_tree.png."""
     history = state.get("history", [])
     best = state.get("current_best", "N/A")
-    best_metric = state.get("best_metric")
     plateau = state.get("plateau_count", 0)
 
     best_type, best_val = _current_best_metric(state)
@@ -315,7 +411,8 @@ def _update_summary_and_plot(workdir: Path, state: dict) -> None:
         if tsv_path.exists():
             experiments = _load_tsv(tsv_path)
             if experiments:
-                _plot_progress(experiments, str(workdir / "progress.png"))
+                metrics = _pipeline_opt_metrics(experiments)
+                _plot_progress(experiments, str(workdir / "progress.png"), metrics)
     except Exception as error:
         _LG.warning("Failed to regenerate progress plot: %s", error)
 
@@ -328,6 +425,3 @@ def _update_summary_and_plot(workdir: Path, state: dict) -> None:
             )
     except Exception as error:
         _LG.warning("Failed to regenerate hypothesis tree plot: %s", error)
-
-
-__all__ = ["_analyze_job", "_update_on_complete", "_update_summary_and_plot"]

--- a/src/spdl/autoresearch/pipeline_optimization/_ops/_planning_ops.py
+++ b/src/spdl/autoresearch/pipeline_optimization/_ops/_planning_ops.py
@@ -13,7 +13,7 @@ import logging
 import re
 from pathlib import Path
 
-from spdl.autoresearch._common._state import _read_master_table, write_state
+from spdl.autoresearch._common._state import _read_master_table
 from spdl.autoresearch.core import AnalysisResult, HypothesisNode
 
 from .._platform import AutoresearchPlatform
@@ -26,6 +26,7 @@ from ._policy import (
     _extract_total_threads,
     _format_best_metric,
     _validate_thread_budget as _policy_validate_thread_budget,
+    write_state,
 )
 
 _LG: logging.Logger = logging.getLogger(__name__)

--- a/src/spdl/autoresearch/pipeline_optimization/_ops/_policy.py
+++ b/src/spdl/autoresearch/pipeline_optimization/_ops/_policy.py
@@ -39,7 +39,14 @@ from __future__ import annotations
 import re
 import shlex
 from collections.abc import Iterable, Mapping
+from pathlib import Path
 
+from spdl.autoresearch._common._state import (
+    read_config as _read_config_raw,
+    read_state as _read_state_raw,
+    SCHEMA_VERSION,
+    write_state as _write_state_raw,
+)
 from spdl.autoresearch.core import (
     FailureKind,
     HypothesisNode,
@@ -60,7 +67,12 @@ __all__ = [
     "_is_headspace_node",
     "_is_startup_failed_retry",
     "_node_from_spec",
+    "_normalize_config",
+    "_normalize_state",
     "_normalize_status",
+    "read_config",
+    "read_state",
+    "write_state",
     "_record_failed_best_practice_attempt",
     "_retry_policy_for_failure",
     "_select_planning_node",
@@ -531,3 +543,56 @@ def _extract_counter(node_id: str) -> int:
         return int(node_id.split("_", 1)[0])
     except (IndexError, ValueError):
         return 0
+
+
+# ---------------------------------------------------------------------------
+# Workflow-specific state / config schema defaults
+# ---------------------------------------------------------------------------
+
+
+def _normalize_config(config: dict) -> dict:
+    """Apply pipeline-optimization default values to a raw config dict."""
+    normalized = dict(config)
+    normalized.setdefault("schema_version", SCHEMA_VERSION)
+    normalized.setdefault("stopping_criteria", {})
+    normalized["stopping_criteria"].setdefault("max_iterations", 10)
+    normalized["stopping_criteria"].setdefault("patience", 3)
+    normalized.setdefault("platform", "auto")
+    normalized.setdefault("agent", "claude")
+    normalized.setdefault("local_execution_mode", "full")
+    normalized.setdefault("startup_failure_retries", 2)
+    normalized.setdefault("startup_retryable_experiments", ["mtp"])
+    return normalized
+
+
+def _normalize_state(state: dict) -> dict:
+    """Apply pipeline-optimization default values to a raw state dict."""
+    normalized = dict(state)
+    normalized.setdefault("schema_version", SCHEMA_VERSION)
+    normalized.setdefault("iteration", 0)
+    normalized.setdefault("status", "initialized")
+    normalized.setdefault("baseline_job", None)
+    normalized.setdefault("current_best", None)
+    normalized.setdefault("best_metric", None)
+    normalized.setdefault("plateau_count", 0)
+    normalized.setdefault("best_practices_tried", [])
+    normalized.setdefault("anchor_commit", "")
+    normalized.setdefault("history", [])
+    return normalized
+
+
+# ---------------------------------------------------------------------------
+# Workflow-bound I/O wrappers (thin wrappers around generic _common._state)
+# ---------------------------------------------------------------------------
+
+
+def read_state(workdir: Path) -> dict:
+    return _read_state_raw(workdir, normalize=_normalize_state)
+
+
+def write_state(workdir: Path, state: dict) -> None:
+    _write_state_raw(workdir, state, normalize=_normalize_state)
+
+
+def read_config(workdir: Path) -> dict:
+    return _read_config_raw(workdir, normalize=_normalize_config)

--- a/src/spdl/autoresearch/pipeline_optimization/_ops/_store.py
+++ b/src/spdl/autoresearch/pipeline_optimization/_ops/_store.py
@@ -49,13 +49,14 @@ import os
 import time
 from pathlib import Path
 
-from spdl.autoresearch._common._state import SCHEMA_VERSION, write_state
+from spdl.autoresearch._common._state import SCHEMA_VERSION
 from spdl.autoresearch.core import HypothesisNode, TaskSpec
 
 from ._policy import (
     _extract_counter,
     _node_from_spec,
     _update_spec_from_node,
+    write_state,
 )
 
 __all__ = [

--- a/src/spdl/autoresearch/pipeline_optimization/_workflow.py
+++ b/src/spdl/autoresearch/pipeline_optimization/_workflow.py
@@ -4,14 +4,14 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-"""Autoresearch workflow adapter for the generic async runner.
+"""Pipeline-optimization workflow for the autoresearch engine.
 
 Design note
 
-This module is the domain side of the runner/adapter boundary. It orchestrates
-experiment coroutines, but durable state lives in ``store.py`` and deterministic
-policy lives in ``policy.py``. Keep SPDL, coding-agent, source-control, metric,
-and hypothesis-planning decisions out of ``runner.py``.
+This module is the domain side of the runner/workflow boundary. It orchestrates
+experiment coroutines, but durable state lives in ``_ops/_store.py`` and
+deterministic policy lives in ``_ops/_policy.py``. Keep SPDL, coding-agent,
+source-control, metric, and hypothesis-planning decisions out of ``runner.py``.
 
 The workflow is the right place to sequence domain operations: restore source,
 apply experiment changes, build, launch, poll, collect metrics, analyze, update
@@ -29,7 +29,7 @@ should not record durable failures as bare strings.
    flowchart TB
        Run["run.py"]
        Runner["Orchestrator"]
-       Adapter["PipelineOptimizationWorkflow"]
+       Workflow["PipelineOptimizationWorkflow"]
        Store["_WorkflowStateStore"]
        Policy["autoresearch_policy"]
        Platform["AutoresearchPlatform"]
@@ -48,6 +48,7 @@ should not record durable failures as bare strings.
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 import time
 from collections.abc import Coroutine
@@ -55,6 +56,11 @@ from pathlib import Path
 from typing import Any
 
 from spdl.autoresearch._common._state import _append_master_row, _read_master_table
+from spdl.autoresearch._common._visualization import (
+    _load_tsv,
+    _plot_hypothesis_tree,
+    _plot_progress,
+)
 from spdl.autoresearch.core import (
     AnalysisResult,
     AutoresearchError,
@@ -67,20 +73,21 @@ from spdl.autoresearch.core import (
     TERMINAL_STATUSES,
 )
 
-from .._platform import AutoresearchPlatform
-from ._analysis_ops import (
+from ._ops._analysis_ops import (
     _analyze_job,
+    _pipeline_opt_metrics,
     _update_on_complete,
     _update_summary_and_plot,
+    MASTER_TABLE_HEADERS,
 )
-from ._failures import (
+from ._ops._failures import (
     _failure_note,
     _make_failure,
     _read_failures,
     _unexpected_failure,
 )
-from ._planning_ops import _build_initial_nodes, _plan_followups
-from ._policy import (
+from ._ops._planning_ops import _build_initial_nodes, _plan_followups
+from ._ops._policy import (
     _change_summary_for_spec,
     _is_duplicate_spec,
     _node_from_spec,
@@ -91,8 +98,9 @@ from ._policy import (
     _spec_from_node,
     _startup_retry_spec,
 )
-from ._source_ops import _launch_node, _prepare_node
-from ._store import _WorkflowStateStore
+from ._ops._source_ops import _launch_node, _prepare_node
+from ._ops._store import _WorkflowStateStore
+from ._platform import AutoresearchPlatform
 
 _LG: logging.Logger = logging.getLogger(__name__)
 
@@ -176,7 +184,8 @@ class PipelineOptimizationWorkflow:
 
         Reads ``master_table.tsv``, the live ``summary.md`` file, and the
         recorded failures (via :py:func:`_read_failures`) without
-        invoking the coding agent. Safe to call at any time.
+        invoking the coding agent.  Also regenerates ``progress.png``
+        and ``hypothesis_tree.png``.  Safe to call at any time.
         """
         sections = ["# Autoresearch summary", "", f"Workdir: `{workdir}`", ""]
         master_table = _read_master_table(workdir)
@@ -186,7 +195,33 @@ class PipelineOptimizationWorkflow:
         if summary_path.exists():
             sections.extend(["## Live summary", "", summary_path.read_text(), ""])
         sections.extend(["## Failures", "", _read_failures(workdir), ""])
+
+        self._regenerate_plots(workdir)
+
         return "\n".join(sections)
+
+    @staticmethod
+    def _regenerate_plots(workdir: Path) -> None:
+        """Best-effort regeneration of progress and hypothesis-tree PNGs."""
+
+        tsv_path = workdir / "master_table.tsv"
+        try:
+            if tsv_path.exists():
+                experiments = _load_tsv(tsv_path)
+                if experiments:
+                    metrics = _pipeline_opt_metrics(experiments)
+                    out = str(workdir / "progress.png")
+                    _plot_progress(experiments, out, metrics)
+        except Exception as exc:
+            _LG.warning("Failed to regenerate progress plot: %s", exc)
+
+        tree_file = workdir / "engine" / "tree.json"
+        try:
+            if tree_file.exists():
+                tree_data = json.loads(tree_file.read_text())
+                _plot_hypothesis_tree(tree_data, str(workdir / "hypothesis_tree.png"))
+        except Exception as exc:
+            _LG.warning("Failed to regenerate hypothesis tree plot: %s", exc)
 
     async def on_result(self, spec: TaskSpec, result: TaskResult) -> list[TaskSpec]:
         children = []
@@ -456,6 +491,7 @@ class PipelineOptimizationWorkflow:
                     "change_summary": _change_summary_for_spec(node.spec),
                     "notes": note,
                 },
+                MASTER_TABLE_HEADERS,
             )
             self.state.setdefault("history", []).append(
                 {

--- a/tests/autoresearch/factory_test.py
+++ b/tests/autoresearch/factory_test.py
@@ -11,8 +11,11 @@ import tempfile
 import unittest
 from pathlib import Path
 
-from spdl.autoresearch._common._state import MASTER_TABLE_HEADERS, write_state
 from spdl.autoresearch.pipeline_optimization import create_workflow
+from spdl.autoresearch.pipeline_optimization._ops._analysis_ops import (
+    MASTER_TABLE_HEADERS,
+)
+from spdl.autoresearch.pipeline_optimization._ops._policy import write_state
 
 __all__: list[str] = []
 

--- a/tests/autoresearch/state_test.py
+++ b/tests/autoresearch/state_test.py
@@ -8,10 +8,10 @@ from __future__ import annotations
 
 import unittest
 
-from spdl.autoresearch._common._state import (
+from spdl.autoresearch._common._state import SCHEMA_VERSION
+from spdl.autoresearch.pipeline_optimization._ops._policy import (
     _normalize_config,
     _normalize_state,
-    SCHEMA_VERSION,
 )
 
 

--- a/tests/autoresearch/workflow_test.py
+++ b/tests/autoresearch/workflow_test.py
@@ -12,11 +12,7 @@ import tempfile
 import unittest
 from pathlib import Path
 
-from spdl.autoresearch._common._state import (
-    _append_master_row,
-    MASTER_TABLE_HEADERS,
-    write_state,
-)
+from spdl.autoresearch._common._state import _append_master_row
 from spdl.autoresearch._common._visualization import _load_tsv
 from spdl.autoresearch.core import (
     AnalysisResult,
@@ -31,6 +27,7 @@ from spdl.autoresearch.pipeline_optimization._ops import (
 )
 from spdl.autoresearch.pipeline_optimization._ops._analysis_ops import (
     _update_on_complete,
+    MASTER_TABLE_HEADERS,
 )
 from spdl.autoresearch.pipeline_optimization._ops._failures import (
     _classify_terminal_job_failure,
@@ -53,6 +50,7 @@ from spdl.autoresearch.pipeline_optimization._ops._policy import (
     _spec_from_node,
     _startup_retry_spec,
     _validate_thread_budget,
+    write_state,
 )
 from spdl.autoresearch.pipeline_optimization._ops._source_ops import _build_apply_prompt
 from spdl.autoresearch.pipeline_optimization._ops._store import _write_text_atomic
@@ -998,6 +996,7 @@ class _AutoresearchWorkflowTest(unittest.TestCase):
                     "change_summary": summary,
                     "sm_util_pct": "50",
                 },
+                MASTER_TABLE_HEADERS,
             )
 
             rows = _load_tsv(workdir / "master_table.tsv")


### PR DESCRIPTION
Summary:
Introduce `MetricSpec` dataclass as the contract between visualization and workflow layers, making the progress chart fully workflow-agnostic. The visualization module (`_common/_visualization.py`) no longer knows about specific metrics — it receives ordered `MetricSpec` objects describing what to plot, axis labels, units, and direction. `_load_tsv()` generically parses all TSV columns as float.

The pipeline-optimization workflow defines its metrics in `_pipeline_opt_metrics()`: sample throughput (primary, higher-is-better), step time, steady-state SM utilization, duration, and overall SM utilization. `MASTER_TABLE_HEADERS` and `_normalize_config` / `_normalize_state` also move from `_common/` to the workflow layer since they encode workflow-specific schema.

The workflow orchestrator moves from `_ops/_adapter.py` to `pipeline_optimization/_workflow.py` — it is the top-level entry point, not an internal `_ops` detail.

`autoresearch summary` now regenerates `progress.png` and `hypothesis_tree.png`.

Reviewed By: kiminoue7

Differential Revision: D106540249
