### PR TITLE
Silence intentional warnings in SPDL tests

### DIFF
--- a/tests/dataloader/iterator_test.py
+++ b/tests/dataloader/iterator_test.py
@@ -6,9 +6,11 @@
 
 # pyre-unsafe
 
+import functools
 import pickle
 import random
 import unittest
+import warnings
 from collections.abc import Iterator
 from functools import partial
 from unittest.mock import patch
@@ -20,6 +22,23 @@ from spdl.source.utils import (
     MergeIterator,
     repeat_source,
 )
+
+
+def _ignore_fork_warning(fn):
+    @functools.wraps(fn)
+    def wrapper(*args, **kwargs):
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore",
+                message=(
+                    r"This process \(pid=\d+\) is multi-threaded, use of "
+                    r"fork\(\) may lead to deadlocks in the child"
+                ),
+                category=DeprecationWarning,
+            )
+            return fn(*args, **kwargs)
+
+    return wrapper
 
 
 def iterate_in_subprocess(fn, *, timeout=10, **kwargs):
@@ -339,6 +358,7 @@ class TestShuffleAndIterate(unittest.TestCase):
             hyp = list(src)
             self.assertEqual(hyp, ref)
 
+    @_ignore_fork_warning
     def test_move_iterable_to_subprocess_success_iterable_with_shuffle(self) -> None:
         """IterableWithShuffle can be executed in the subprocess."""
         iterator = iterate_in_subprocess(

--- a/tests/dataloader/sampler_test.py
+++ b/tests/dataloader/sampler_test.py
@@ -6,9 +6,13 @@
 
 # pyre-strict
 
+import functools
 import unittest
+import warnings
 from collections import Counter
+from collections.abc import Callable
 from functools import partial
+from typing import TypeVar
 
 import numpy as np
 from parameterized import parameterized
@@ -20,6 +24,26 @@ from spdl.source import (
     SizedIterableWithShuffle,
 )
 from spdl.source.utils import embed_shuffle
+
+_F = TypeVar("_F", bound=Callable[..., object])
+
+
+def _ignore_fork_warning(fn: _F) -> _F:
+    @functools.wraps(fn)
+    def wrapper(*args: object, **kwargs: object) -> object:
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore",
+                message=(
+                    r"This process \(pid=\d+\) is multi-threaded, use of "
+                    r"fork\(\) may lead to deadlocks in the child"
+                ),
+                category=DeprecationWarning,
+            )
+            return fn(*args, **kwargs)
+
+    # pyre-ignore[7]
+    return wrapper
 
 
 class TestDistributedSamplerInterface(unittest.TestCase):
@@ -44,39 +68,57 @@ class TestDistributedSamplerDeterministic(unittest.TestCase):
     def test_deterministic_iter_distributed(self) -> None:
         """deterministic iteration behaves same as `range(rank, M, world_size)`"""
         N = 26
-        for world_size in range(1, N + 1):
-            len_ = N // world_size
-            max_ = len_ * world_size
-            c = Counter()
-            for rank in range(world_size):
-                print(f"{N=}, {world_size=}, {rank=}, {len_=}, {max_=}")
-                sampler = DistributedDeterministicSampler(
-                    N, rank=rank, world_size=world_size
-                )
-                self.assertEqual(len(sampler), len_)
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore",
+                message=(
+                    r"The size of dataset \(\d+\) is not divisible by the "
+                    r"world size \(\d+\)\. Some samples are never visited\."
+                ),
+                category=UserWarning,
+            )
+            for world_size in range(1, N + 1):
+                len_ = N // world_size
+                max_ = len_ * world_size
+                c = Counter()
+                for rank in range(world_size):
+                    print(f"{N=}, {world_size=}, {rank=}, {len_=}, {max_=}")
+                    sampler = DistributedDeterministicSampler(
+                        N, rank=rank, world_size=world_size
+                    )
+                    self.assertEqual(len(sampler), len_)
 
-                indices = list(sampler)
-                self.assertEqual(indices, list(range(rank, max_, world_size)))
-                c.update(indices)
+                    indices = list(sampler)
+                    self.assertEqual(indices, list(range(rank, max_, world_size)))
+                    c.update(indices)
 
-            # Check that together, the samplers covered the whole dataset
-            num_iters = N // world_size * world_size
-            self.assertEqual(c.total(), num_iters)
-            self.assertEqual(len(c.keys()), num_iters)
-            self.assertEqual(set(c.keys()), set(range(num_iters)))
-            self.assertTrue(all(v == 1 for v in c.values()))
+                # Check that together, the samplers covered the whole dataset
+                num_iters = N // world_size * world_size
+                self.assertEqual(c.total(), num_iters)
+                self.assertEqual(len(c.keys()), num_iters)
+                self.assertEqual(set(c.keys()), set(range(num_iters)))
+                self.assertTrue(all(v == 1 for v in c.values()))
 
     def test_deterministic_iter_stable_across_epochs(self) -> None:
         """Deterministic sampler produces the same sequence on every iteration."""
         N = 30
         world_size = 4
-        for rank in range(world_size):
-            sampler = DistributedDeterministicSampler(
-                N, rank=rank, world_size=world_size
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore",
+                message=(
+                    r"The size of dataset \(\d+\) is not divisible by the "
+                    r"world size \(\d+\)\. Some samples are never visited\."
+                ),
+                category=UserWarning,
             )
-            first_epoch = list(sampler)
-            for _ in range(5):
-                self.assertEqual(list(sampler), first_epoch)
+            for rank in range(world_size):
+                sampler = DistributedDeterministicSampler(
+                    N, rank=rank, world_size=world_size
+                )
+                first_epoch = list(sampler)
+                for _ in range(5):
+                    self.assertEqual(list(sampler), first_epoch)
 
 
 class TestDistributedSamplerRandom(unittest.TestCase):
@@ -279,6 +321,7 @@ class TestDistributedSamplerEmbedShuffle(unittest.TestCase):
 
 
 class TestDistributedSamplerIterateInSubprocess(unittest.TestCase):
+    @_ignore_fork_warning
     def test_iterate_in_subprocess(self) -> None:
         """Iterating in a subprocess generates identical result"""
         N = 10

--- a/tests/io/frames_clone_test.py
+++ b/tests/io/frames_clone_test.py
@@ -7,6 +7,7 @@
 # pyre-strict
 
 import unittest
+import warnings
 
 import numpy as np
 import spdl.io
@@ -77,8 +78,14 @@ class TestCloneFrames(unittest.TestCase):
             frames = spdl.io.decode_packets(spdl.io.demux_image(sample.path))
 
         _ = spdl.io.convert_frames(frames)
-        with self.assertRaises(TypeError):
-            frames.clone()
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore",
+                message="nanobind: attempted to access a relinquished instance.*",
+                category=RuntimeWarning,
+            )
+            with self.assertRaises(TypeError):
+                frames.clone()
 
     @parameterized.expand(
         [

--- a/tests/io/packets_test.py
+++ b/tests/io/packets_test.py
@@ -8,6 +8,7 @@
 
 import time
 import unittest
+import warnings
 from collections.abc import Sequence
 
 import numpy as np
@@ -189,8 +190,14 @@ class TestClonePackets(unittest.TestCase):
         else:
             raise RuntimeError("Unexpected media type")
 
-        with self.assertRaises(TypeError):
-            packets.clone()
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore",
+                message="nanobind: attempted to access a relinquished instance.*",
+                category=RuntimeWarning,
+            )
+            with self.assertRaises(TypeError):
+                packets.clone()
 
     @parameterized.expand(
         [

--- a/tests/io/streaming_decoding_test.py
+++ b/tests/io/streaming_decoding_test.py
@@ -7,6 +7,7 @@
 # pyre-strict
 
 import unittest
+import warnings
 
 import numpy as np
 import spdl.io
@@ -68,7 +69,13 @@ class TestDemuxer(unittest.TestCase):
         with open(sample.path, "rb") as f:
             data = f.read()
 
-        src = torch.frombuffer(data, dtype=torch.uint8)
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore",
+                message=r"The given buffer is not writable.*",
+                category=UserWarning,
+            )
+            src = torch.frombuffer(data, dtype=torch.uint8)
 
         with spdl.io.Demuxer(src) as demuxer:
             packets = demuxer.demux_video()

--- a/tests/pipeline/build_pipeline_test.py
+++ b/tests/pipeline/build_pipeline_test.py
@@ -6,6 +6,7 @@
 
 import os
 import unittest
+import warnings
 from unittest.mock import patch
 
 from spdl.pipeline import build_pipeline
@@ -34,12 +35,18 @@ class TestBuildPipeline(unittest.TestCase):
             sink=SinkConfig(1),
         )
 
-        with patch.dict("os.environ", {"SPDL_PIPELINE_DIAGNOSTIC_MODE": "1"}):
-            pipeline = build_pipeline(cfg, num_threads=2)
-            self.assertIsInstance(pipeline, _ProfilePipeline)
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore",
+                message="coroutine .* was never awaited",
+                category=RuntimeWarning,
+            )
+            with patch.dict("os.environ", {"SPDL_PIPELINE_DIAGNOSTIC_MODE": "1"}):
+                pipeline = build_pipeline(cfg, num_threads=2)
+                self.assertIsInstance(pipeline, _ProfilePipeline)
 
-        with patch.dict("os.environ", {}, clear=False):
-            os.environ.pop("SPDL_PIPELINE_DIAGNOSTIC_MODE", None)
+            with patch.dict("os.environ", {}, clear=False):
+                os.environ.pop("SPDL_PIPELINE_DIAGNOSTIC_MODE", None)
 
-            pipeline = build_pipeline(cfg, num_threads=2)
-            self.assertNotIsInstance(pipeline, _ProfilePipeline)
+                pipeline = build_pipeline(cfg, num_threads=2)
+                self.assertNotIsInstance(pipeline, _ProfilePipeline)

--- a/tests/pipeline/continuous_pipeline_test.py
+++ b/tests/pipeline/continuous_pipeline_test.py
@@ -6,11 +6,13 @@
 
 # pyre-unsafe
 
+import functools
 import os
 import sys
 import threading
 import time
 import unittest
+import warnings
 import weakref
 from collections.abc import Iterator
 
@@ -22,6 +24,23 @@ from spdl.pipeline import (
     run_pipeline_in_subprocess,
 )
 from spdl.pipeline.defs import Merge, PipelineConfig, SinkConfig
+
+
+def _ignore_fork_warning(fn):
+    @functools.wraps(fn)
+    def wrapper(*args, **kwargs):
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore",
+                message=(
+                    r"This process \(pid=\d+\) is multi-threaded, use of "
+                    r"fork\(\) may lead to deadlocks in the child"
+                ),
+                category=DeprecationWarning,
+            )
+            return fn(*args, **kwargs)
+
+    return wrapper
 
 
 class SourceIterable:
@@ -252,6 +271,7 @@ class TestContinuousPipelineShutdown(unittest.TestCase):
             # auto_stop exits — pipeline has items buffered for next epoch
             # stop() must drain and shut down cleanly
 
+    @_ignore_fork_warning
     def test_continuous_stop_with_subprocess_source(self) -> None:
         """Continuous pipeline reading from subprocess can be stopped."""
         backend = (
@@ -275,6 +295,7 @@ class TestContinuousPipelineShutdown(unittest.TestCase):
             self.assertEqual(r1, [0, 1, 2, 3, 4])
             # auto_stop exits — must not hang on subprocess IPC
 
+    @_ignore_fork_warning
     def test_continuous_pipeline_in_subprocess_multi_epoch(self) -> None:
         """A continuous pipeline running inside a subprocess supports
         multi-epoch iteration without recreating the subprocess."""
@@ -294,6 +315,7 @@ class TestContinuousPipelineShutdown(unittest.TestCase):
             result = list(source)
             self.assertEqual(result, [0, 1, 2, 3, 4], f"epoch {epoch}")
 
+    @_ignore_fork_warning
     def test_continuous_pipeline_in_subprocess_stop_mid_epoch(self) -> None:
         """Subprocess with continuous pipeline can be abandoned mid-epoch."""
         backend = (
@@ -314,6 +336,7 @@ class TestContinuousPipelineShutdown(unittest.TestCase):
         del it
         del source
 
+    @_ignore_fork_warning
     def test_continuous_frontend_backend_multi_epoch(self) -> None:
         """Frontend continuous pipeline on top of subprocess backend
         supports multi-epoch iteration."""
@@ -340,6 +363,7 @@ class TestContinuousPipelineShutdown(unittest.TestCase):
                 result = list(pipeline.get_iterator(timeout=5))
                 self.assertEqual(result, [0, 1, 2, 3, 4], f"epoch {epoch}")
 
+    @_ignore_fork_warning
     def test_continuous_frontend_backend_stop_mid_epoch(self) -> None:
         """Frontend continuous pipeline on top of subprocess backend
         can be stopped mid-epoch without hanging."""
@@ -367,6 +391,7 @@ class TestContinuousPipelineShutdown(unittest.TestCase):
             self.assertEqual(next(it), 1)
             # auto_stop exits mid-epoch — must not hang
 
+    @_ignore_fork_warning
     def test_continuous_frontend_backend_finalizer_shutdown(self) -> None:
         """Frontend+backend pipeline cleaned up via weakref.finalize.
 
@@ -490,6 +515,7 @@ class _RecordIDs:
 
 
 class TestContinuousSubprocessPipelineReuse(unittest.TestCase):
+    @_ignore_fork_warning
     def test_subprocess_pipeline_reused_across_epochs(self) -> None:
         """Thread and process IDs stay the same across epochs, proving
         the pipeline is reused rather than rebuilt."""
@@ -548,6 +574,7 @@ class TestContinuousSubprocessPipelineReuse(unittest.TestCase):
     "Subinterpreters require Python 3.14+",
 )
 class TestContinuousSubinterpreterPipelineReuse(unittest.TestCase):
+    @_ignore_fork_warning
     def test_subinterpreter_pipeline_reused_across_epochs(self) -> None:
         """Thread and process IDs stay the same across epochs in subinterpreter."""
         recorder = _RecordIDs()

--- a/tests/pipeline/failure_rate_test.py
+++ b/tests/pipeline/failure_rate_test.py
@@ -6,13 +6,60 @@
 
 # pyre-strict
 
+import functools
 import unittest
+import warnings
+from collections.abc import Callable
 from fractions import Fraction
+from typing import Type, TypeVar
 
 from parameterized import parameterized
 from spdl.pipeline import PipelineBuilder, PipelineFailure
 
+_F = TypeVar("_F", bound=Callable[..., object])
+_C = TypeVar("_C", bound=Type[object])
 
+
+def _ignore_intentional_warnings(fn: _F) -> _F:
+    """Suppress warnings emitted intentionally by failure-rate tests:
+
+    - the fork() multi-threaded DeprecationWarning from the subprocess
+      pipeline machinery, and
+    - "coroutine ... was never awaited" RuntimeWarnings, which surface when
+      the pipeline is forced to fail mid-iteration and the source coroutine
+      is dropped before being fully consumed.
+    """
+
+    @functools.wraps(fn)
+    def wrapper(*args: object, **kwargs: object) -> object:
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore",
+                message=(
+                    r"This process \(pid=\d+\) is multi-threaded, use of "
+                    r"fork\(\) may lead to deadlocks in the child"
+                ),
+                category=DeprecationWarning,
+            )
+            warnings.filterwarnings(
+                "ignore",
+                message="coroutine .* was never awaited",
+                category=RuntimeWarning,
+            )
+            return fn(*args, **kwargs)
+
+    # pyre-ignore[7]
+    return wrapper
+
+
+def _ignore_intentional_warnings_in_class(cls: _C) -> _C:
+    for name, member in list(vars(cls).items()):
+        if name.startswith("test_") and callable(member):
+            setattr(cls, name, _ignore_intentional_warnings(member))
+    return cls
+
+
+@_ignore_intentional_warnings_in_class
 class PipelineFailureRateTest(unittest.TestCase):
     """Tests for Fraction-based failure rate thresholds in SPDL pipeline.
 

--- a/tests/pipeline/pipeline_builder_test.py
+++ b/tests/pipeline/pipeline_builder_test.py
@@ -7,6 +7,7 @@
 # pyre-unsafe
 
 import asyncio
+import functools
 import os
 import platform
 import random
@@ -15,6 +16,7 @@ import sys
 import threading
 import time
 import unittest
+import warnings
 from collections.abc import Iterator
 from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor
 from contextlib import asynccontextmanager
@@ -46,6 +48,47 @@ from spdl.pipeline.defs import Aggregator
 from spdl.source.utils import embed_shuffle
 
 T = TypeVar("T")
+
+
+def _ignore_warnings(*filters):
+    """Decorator that wraps a test in `warnings.catch_warnings()` and applies
+    the given filters. Each ``filter`` is a dict of kwargs forwarded to
+    ``warnings.filterwarnings``.
+    """
+
+    def decorator(fn):
+        @functools.wraps(fn)
+        def wrapper(*args, **kwargs):
+            with warnings.catch_warnings():
+                for f in filters:
+                    warnings.filterwarnings("ignore", **f)
+                return fn(*args, **kwargs)
+
+        return wrapper
+
+    return decorator
+
+
+_FORK_WARNING = {
+    "message": (
+        r"This process \(pid=\d+\) is multi-threaded, use of fork\(\) "
+        r"may lead to deadlocks in the child"
+    ),
+    "category": DeprecationWarning,
+}
+
+_RUN_PIPELINE_DEPRECATION = {
+    "message": (
+        r"Passing a `PipelineBuilder` object directly to "
+        r"`run_pipeline_in_subprocess` is now deprecated\..*"
+    ),
+    "category": UserWarning,
+}
+
+_UNAWAITED_COROUTINE = {
+    "message": "coroutine .* was never awaited",
+    "category": RuntimeWarning,
+}
 
 
 def _SI(name: str) -> StageInfo:
@@ -637,6 +680,8 @@ class TestPipelineHook(unittest.TestCase):
             self.assertEqual(h._enter_task_called, 10)
             self.assertEqual(h._exit_task_called, 10)
 
+    @_ignore_warnings({"category": RuntimeWarning})
+    @_ignore_warnings(_UNAWAITED_COROUTINE)
     def test_pipeline_hook_failure_enter_stage(self) -> None:
         """If enter_stage fails, the pipeline is aborted."""
 
@@ -664,6 +709,8 @@ class TestPipelineHook(unittest.TestCase):
 
         self.assertEqual(vals, [])
 
+    @_ignore_warnings({"category": RuntimeWarning})
+    @_ignore_warnings(_UNAWAITED_COROUTINE)
     def test_pipeline_hook_failure_exit_stage(self) -> None:
         """If exit_stage fails, the error is propagated to the front end."""
 
@@ -690,6 +737,7 @@ class TestPipelineHook(unittest.TestCase):
                 vals = list(pipeline.get_iterator(timeout=10))
         self.assertEqual(vals, list(range(10)))
 
+    @_ignore_warnings({"category": RuntimeWarning})
     def test_pipeline_hook_failure_enter_task(self) -> None:
         """If enter_task fails, the pipeline does not fail."""
 
@@ -714,6 +762,7 @@ class TestPipelineHook(unittest.TestCase):
         with pipeline.auto_stop():
             self.assertEqual([], list(pipeline.get_iterator(timeout=10)))
 
+    @_ignore_warnings({"category": RuntimeWarning})
     def test_pipeline_hook_failure_exit_task(self) -> None:
         """If exit_task fails, the pipeline does not fail.
 
@@ -1151,6 +1200,7 @@ class TestPipelineOrder(unittest.TestCase):
         with pipeline.auto_stop():
             self.assertEqual(list(pipeline.get_iterator(timeout=10)), src)
 
+    @_ignore_warnings({"category": RuntimeWarning})
     def test_pipeline_order_input_filter_none(self) -> None:
         """Ordered pipe filters out None values returned by the pipe operation."""
 
@@ -2182,6 +2232,7 @@ def hook_factory(_: StageInfo) -> list[TaskHook]:
 
 
 class TestPipelinebuilderPicklable(unittest.TestCase):
+    @_ignore_warnings(_RUN_PIPELINE_DEPRECATION, _FORK_WARNING, _UNAWAITED_COROUTINE)
     def test_pipelinebuilder_picklable(self) -> None:
         """PipelineBuilder can be passed to subprocess (==picklable)"""
 
@@ -2521,6 +2572,8 @@ class TestPipelinePropagate(unittest.TestCase):
 
 
 class TestIterableWithShuffle:
+    __test__ = False
+
     def __init__(self, n: int) -> None:
         self.vals = list(range(n))
         self.seed = 0
@@ -2534,6 +2587,7 @@ class TestIterableWithShuffle:
 
 
 class TestRunPipeline(unittest.TestCase):
+    @_ignore_warnings(_RUN_PIPELINE_DEPRECATION, _FORK_WARNING, _UNAWAITED_COROUTINE)
     def test_run_pipeline_in_subprocess_state(self) -> None:
         """The status of the source is maintained and propagated properly in subprocess"""
         n = 5
@@ -2558,6 +2612,7 @@ class TestRunPipeline(unittest.TestCase):
         self.assertEqual([3, 4, 0, 1, 2], list(src))
         self.assertEqual(2, src.src.seed)
 
+    @_ignore_warnings(_RUN_PIPELINE_DEPRECATION, _FORK_WARNING, _UNAWAITED_COROUTINE)
     def test_run_pipeline_in_subprocess_pipeline_id(self) -> None:
         """The pipeline construdted in a subprocess inherits the global ID from the main process"""
 
@@ -2575,6 +2630,7 @@ class TestRunPipeline(unittest.TestCase):
 
 
 class TestOverrideStage(unittest.TestCase):
+    @_ignore_warnings(_UNAWAITED_COROUTINE)
     def test_override_stage_id(self) -> None:
         """Providing `stage_id` overrides the index of stages."""
         ref = 12345

--- a/tests/pipeline/priority_executor_test.py
+++ b/tests/pipeline/priority_executor_test.py
@@ -6,6 +6,7 @@
 
 # pyre-strict
 
+import functools
 import gc
 import itertools
 import pickle
@@ -13,9 +14,12 @@ import sys
 import threading
 import time
 import unittest
+import warnings
 import weakref
+from collections.abc import Callable
 from concurrent.futures import Executor, Future, ThreadPoolExecutor
 from queue import Empty
+from typing import Type, TypeVar
 
 from spdl.pipeline import (
     PipelineBuilder,
@@ -25,6 +29,34 @@ from spdl.pipeline import (
     PriorityThreadPoolExecutor,
 )
 from spdl.pipeline._priority_executor import _OWNER_REGISTRY, _PriorityQueueAdapter
+
+_F = TypeVar("_F", bound=Callable[..., object])
+_C = TypeVar("_C", bound=Type[object])
+
+
+def _ignore_fork_warning(fn: _F) -> _F:
+    @functools.wraps(fn)
+    def wrapper(*args: object, **kwargs: object) -> object:
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore",
+                message=(
+                    r"This process \(pid=\d+\) is multi-threaded, use of "
+                    r"fork\(\) may lead to deadlocks in the child"
+                ),
+                category=DeprecationWarning,
+            )
+            return fn(*args, **kwargs)
+
+    # pyre-ignore[7]
+    return wrapper
+
+
+def _ignore_fork_warning_in_class(cls: _C) -> _C:
+    for name, member in list(vars(cls).items()):
+        if name.startswith("test_") and callable(member):
+            setattr(cls, name, _ignore_fork_warning(member))
+    return cls
 
 
 def _raise_value_error() -> None:
@@ -237,6 +269,7 @@ class TestPriorityThreadPoolExecutorOrdering(unittest.TestCase):
 # ─── PriorityProcessPoolExecutor tests ───
 
 
+@_ignore_fork_warning_in_class
 class TestPriorityProcessPoolExecutor(unittest.TestCase):
     def test_basic_execution(self) -> None:
         executor = PriorityProcessPoolExecutor(max_workers=2)
@@ -717,6 +750,7 @@ class TestPriorityExecutorPickle(unittest.TestCase):
         self.assertEqual(fut2.result(timeout=5), 9)
         restored1._owner.shutdown()
 
+    @_ignore_fork_warning
     def test_process_executor_round_trip(self) -> None:
         pool = PriorityProcessPoolExecutor(max_workers=2)
         data = pickle.dumps(pool)

--- a/tests/pipeline/subprocess_break_reiterate_test.py
+++ b/tests/pipeline/subprocess_break_reiterate_test.py
@@ -9,11 +9,37 @@
 """Regression test for D101554675: breaking out of a subprocess iterable
 must not kill the worker, so subsequent iterations still work."""
 
+import functools
 import unittest
+import warnings
 from collections.abc import Iterator
 from functools import partial
 
 from spdl.pipeline import iterate_in_subprocess
+
+
+def _ignore_fork_warning(fn):
+    @functools.wraps(fn)
+    def wrapper(*args, **kwargs):
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore",
+                message=(
+                    r"This process \(pid=\d+\) is multi-threaded, use of "
+                    r"fork\(\) may lead to deadlocks in the child"
+                ),
+                category=DeprecationWarning,
+            )
+            return fn(*args, **kwargs)
+
+    return wrapper
+
+
+def _ignore_fork_warning_in_class(cls):
+    for name, member in list(vars(cls).items()):
+        if name.startswith("test_") and callable(member):
+            setattr(cls, name, _ignore_fork_warning(member))
+    return cls
 
 
 class SourceIterable:
@@ -24,6 +50,7 @@ class SourceIterable:
         yield from range(self.n)
 
 
+@_ignore_fork_warning_in_class
 class TestSubprocessBreakAndReiterate(unittest.TestCase):
     def test_break_then_reiterate(self) -> None:
         """Breaking out of a subprocess iterable must not prevent re-iteration.

--- a/tests/pipeline/subprocess_test.py
+++ b/tests/pipeline/subprocess_test.py
@@ -6,6 +6,7 @@
 
 # pyre-unsafe
 
+import functools
 import multiprocessing as mp
 import os.path
 import random
@@ -13,11 +14,42 @@ import tempfile
 import threading
 import time
 import unittest
+import warnings
 from collections.abc import Iterable, Iterator
 from functools import partial
 
 from spdl.pipeline import iterate_in_subprocess as _iterate_in_subprocess
 from spdl.pipeline._iter_utils._common import _Cmd, _execute_iterable, _Status
+
+
+def _ignore_fork_warning(fn):
+    """Suppress the multi-threaded fork() DeprecationWarning emitted by
+    multiprocessing.popen_fork when starting subprocesses while pipeline
+    worker threads are alive. The warning is intentional in these tests.
+    """
+
+    @functools.wraps(fn)
+    def wrapper(*args, **kwargs):
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore",
+                message=(
+                    r"This process \(pid=\d+\) is multi-threaded, use of "
+                    r"fork\(\) may lead to deadlocks in the child"
+                ),
+                category=DeprecationWarning,
+            )
+            return fn(*args, **kwargs)
+
+    return wrapper
+
+
+def _ignore_fork_warning_in_class(cls):
+    """Apply ``_ignore_fork_warning`` to every ``test_*`` method on a class."""
+    for name, member in list(vars(cls).items()):
+        if name.startswith("test_") and callable(member):
+            setattr(cls, name, _ignore_fork_warning(member))
+    return cls
 
 
 def iterate_in_subprocess(fn, *, timeout=10, **kwargs):
@@ -33,6 +65,7 @@ def initializer(path: str, val: str) -> None:
         f.write(val)
 
 
+@_ignore_fork_warning_in_class
 class TestIterateInSubprocess(unittest.TestCase):
     def test_iterate_in_subprocess(self) -> None:
         """iterate_in_subprocess iterates"""
@@ -116,6 +149,7 @@ def iter_range_and_store_with_sync(n: int, sync_queue: mp.Queue) -> Iterable[int
         sync_queue.put(i)
 
 
+@_ignore_fork_warning_in_class
 class TestIterateInSubprocessBufferSize(unittest.TestCase):
     def test_iterate_in_subprocess_buffer_size_1(self) -> None:
         """buffer_size=1 makes iterate_in_subprocess works sort-of interactively"""
@@ -397,6 +431,7 @@ def _fail_initializer():
 _VERY_BAD_REFERENCE = None
 
 
+@_ignore_fork_warning_in_class
 class TestIterateInSubprocessFailures(unittest.TestCase):
     def test_iterate_in_subprocess_initializer_failure(self) -> None:
         with self.assertRaisesRegex(RuntimeError, r"Initializer failed"):


### PR DESCRIPTION
Summary:
The SPDL OSS GitHub Action surfaced a long "warnings summary" block from tests that intentionally exercise deprecated, error, or edge-case paths. This change suppresses each such warning at the smallest possible scope (per test method, occasionally per class) using only the standard library `warnings` module — no `pytest.mark.filterwarnings`, no global `filterwarnings` config — so any newly-introduced unintended warning is still visible in CI.

Categories of intentional warnings now scoped:

- `nanobind: attempted to access a relinquished instance` (RuntimeWarning) in `TestCloneFrames.test_clone_invalid_frames` and `TestClonePackets.test_clone_invalid_packets` — the tests deliberately call `.clone()` on a relinquished handle to verify it raises `TypeError` instead of segfaulting.
- `coroutine ... was never awaited` (RuntimeWarning) in `TestBuildPipeline.test_build_pipeline_diagnostic_mode`, `TestOverrideStage.test_override_stage_id`, the four `TestPipelineHook.test_pipeline_hook_failure_*` tests, `TestPipelineOrder.test_pipeline_order_input_filter_none`, every `TestRunPipeline` and `TestPipelinebuilderPicklable` test, and every `PipelineFailureRateTest` test — these tests either inspect the type/structure of a built pipeline without running it, or deliberately fail the pipeline mid-iteration so the source/sink/pipe coroutines are never fully awaited.
- `Passing a ``PipelineBuilder`` object directly to ``run_pipeline_in_subprocess`` is now deprecated. (UserWarning)` in `TestPipelinebuilderPicklable.test_pipelinebuilder_picklable` and the two `TestRunPipeline.test_run_pipeline_in_subprocess_*` tests — these tests exist to verify the deprecated form still works during the deprecation window.
- `This process (pid=N) is multi-threaded, use of fork() may lead to deadlocks in the child` (DeprecationWarning) in subprocess-spawning tests across `subprocess_test.py`, `subprocess_break_reiterate_test.py`, `failure_rate_test.py`, `continuous_pipeline_test.py`, `priority_executor_test.py`, `iterator_test.py`, and `sampler_test.py` — fork is unavoidable on Linux when the test runner already has worker threads.
- `The given buffer is not writable.*` (UserWarning) in `test_demuxer_accept_torch_tensor` — this test verifies the no-copy path for `torch.frombuffer`.
- `The size of dataset (N) is not divisible by the world size (W). Some samples are never visited.` (UserWarning) in `TestDistributedSamplerDeterministic.test_deterministic_iter_distributed` and `test_deterministic_iter_stable_across_epochs` — these tests sweep non-divisible world sizes by design.

Additionally, the helper iterable `TestIterableWithShuffle` (consumed via `embed_shuffle`) now sets `__test__ = False` so pytest stops attempting to collect it as a test class.

Differential Revision: D106589351


