### PR TITLE
Default engine command to `spdl autoresearch engine`

### DIFF
--- a/src/spdl/autoresearch/_app/_supervisor.py
+++ b/src/spdl/autoresearch/_app/_supervisor.py
@@ -97,8 +97,7 @@ def _build_parser() -> argparse.ArgumentParser:
         "--engine-command",
         help=(
             "Override the engine command shown to the supervisor. Defaults "
-            "to '<argv0> engine ...' so the framework binary re-invokes "
-            "itself in engine mode."
+            "to 'spdl autoresearch engine'."
         ),
     )
     parser.add_argument(
@@ -135,7 +134,7 @@ def _build_engine_command(
 
     Args:
         engine_command_override: Value of ``--engine-command``, or
-            ``None`` to default to ``<argv0> engine``.
+            ``None`` to default to ``spdl autoresearch engine``.
         workflow_spec: Workflow specifier to forward via ``--workflow``.
         workdir: Workdir to forward to the engine.
         framework_flags: Framework-owned flags (such as
@@ -149,7 +148,7 @@ def _build_engine_command(
     if engine_command_override:
         prefix = shlex.split(engine_command_override)
     else:
-        prefix = [sys.argv[0], "engine"]
+        prefix = ["spdl", "autoresearch", "engine"]
     command = list(prefix)
     command.extend(["--workflow", workflow_spec])
     command.extend(["--workdir", str(workdir)])

--- a/tests/autoresearch/app_test.py
+++ b/tests/autoresearch/app_test.py
@@ -174,8 +174,8 @@ class _ArgvSplitTest(unittest.TestCase):
 
 
 class _EngineCommandTest(unittest.TestCase):
-    def test_default_uses_argv0_engine(self) -> None:
-        """Without an override, the engine prefix is 'sys.argv[0] engine'."""
+    def test_default_uses_spdl_autoresearch_engine(self) -> None:
+        """Without an override, the engine prefix is 'spdl autoresearch engine'."""
         cmd = _build_engine_command(
             engine_command_override=None,
             workflow_spec="pkg.mod:factory",
@@ -183,11 +183,12 @@ class _EngineCommandTest(unittest.TestCase):
             framework_flags=["--max-concurrency", "3"],
             workflow_argv_tail=["--build-command", "make"],
         )
-        # argv[0] varies under buck test; only assert structural shape.
-        self.assertEqual(cmd[1], "engine")
         self.assertEqual(
-            cmd[2:],
+            cmd,
             [
+                "spdl",
+                "autoresearch",
+                "engine",
                 "--workflow",
                 "pkg.mod:factory",
                 "--workdir",


### PR DESCRIPTION
Summary:
Now that the `spdl autoresearch` CLI subcommand exists, the engine command no longer needs to differ between OSS (`python -m spdl.autoresearch`) and fbcode (`buck run ...`). The default engine prefix in `_build_engine_command` is changed from `[sys.argv[0], "engine"]` to `["spdl", "autoresearch", "engine"]`, which works in both environments.

The `--engine-command` flag is kept for advanced overrides but is no longer needed for normal use. Removes the now-redundant `--engine-command` from the example launch scripts.

Reviewed By: ynonaolga

Differential Revision: D106453484


