### PR TITLE
Fix Windows CI environment

### DIFF
--- a/.github/workflows/_build_windows.yml
+++ b/.github/workflows/_build_windows.yml
@@ -108,30 +108,23 @@ jobs:
           channels: conda-forge
           conda-remove-defaults: "true"
 
-      - name: Diagnose interpreter / pip / wheel tags
-        run: |
-          set -x
-          which python; python --version
-          python -c "import sys; print(sys.executable); print(sys.version); print('FT:', getattr(sys, '_is_gil_enabled', lambda: True)() is False)"
-          which pip; pip --version
-          python -m pip debug --verbose | sed -n '/Compatible tags/,$p' | head -60
-          ls -la package/
-
       - name: Setup
         run: |
           if [[ "${{ inputs.free-threaded }}" == 'ft' ]]; then
             conda install -q python-freethreading
           fi
 
+          conda install -q pip
+
           # Install SPDL
-          pip install $(find package -name '*.whl' -depth -maxdepth 1)
+          python -m pip install $(find package -name '*.whl' -depth -maxdepth 1)
           spdl --help
 
           # Install PyTorch and others
           if [[ "${{ inputs.free-threaded }}" == 'ft' ]]; then
-            pip install torch numpy pytest pytest-xdist parameterized matplotlib
+            python -m pip install torch numpy pytest pytest-xdist parameterized matplotlib
           else
-            pip install torch numpy numba pytest pytest-xdist parameterized matplotlib
+            python -m pip install torch numpy numba pytest pytest-xdist parameterized matplotlib
           fi
 
           # Install FFmpeg

--- a/.github/workflows/_build_windows.yml
+++ b/.github/workflows/_build_windows.yml
@@ -108,6 +108,15 @@ jobs:
           channels: conda-forge
           conda-remove-defaults: "true"
 
+      - name: Diagnose interpreter / pip / wheel tags
+        run: |
+          set -x
+          which python; python --version
+          python -c "import sys; print(sys.executable); print(sys.version); print('FT:', getattr(sys, '_is_gil_enabled', lambda: True)() is False)"
+          which pip; pip --version
+          python -m pip debug --verbose | sed -n '/Compatible tags/,$p' | head -60
+          ls -la package/
+
       - name: Setup
         run: |
           if [[ "${{ inputs.free-threaded }}" == 'ft' ]]; then


### PR DESCRIPTION
Similar to the recent fixes (https://github.com/facebookresearch/spdl/pull/1399, https://github.com/facebookresearch/spdl/pull/1477, https://github.com/facebookresearch/spdl/pull/1443), there was a mixup of Python env in CI.

Explicitly installing pip and using `python -m pip` solves this. 