### PR TITLE
Make local job runner and engine command Windows-friendly

### DIFF
--- a/src/spdl/autoresearch/_app/_supervisor.py
+++ b/src/spdl/autoresearch/_app/_supervisor.py
@@ -151,7 +151,7 @@ def _build_engine_command(
         prefix = ["spdl", "autoresearch", "engine"]
     command = list(prefix)
     command.extend(["--workflow", workflow_spec])
-    command.extend(["--workdir", str(workdir)])
+    command.extend(["--workdir", workdir.as_posix()])
     command.extend(framework_flags)
     if workflow_argv_tail:
         command.append("--")

--- a/src/spdl/autoresearch/pipeline_optimization/_platform/_local.py
+++ b/src/spdl/autoresearch/pipeline_optimization/_platform/_local.py
@@ -11,9 +11,9 @@ from __future__ import annotations
 import json
 import logging
 import os
-import shlex
 import signal
 import subprocess
+import threading
 import time
 from pathlib import Path
 
@@ -110,6 +110,7 @@ class _LocalExecution:
         self._root: Path | None = None
         self._mode = mode
         self._dataloader_command = dataloader_command
+        self._processes: dict[str, subprocess.Popen] = {}
 
     def bind_workdir(self, workdir: Path) -> _LocalExecution:
         self._root = workdir / "local_jobs"
@@ -148,20 +149,27 @@ class _LocalExecution:
         stdout = (local_dir / "stdout.log").open("w")
         stderr = (local_dir / "stderr.log").open("w")
         rc_file = local_dir / "returncode.txt"
-        wrapped_command = (
-            f"{run_command}; "
-            f"rc=$?; "
-            f"printf '%s\\n' \"$rc\" > {shlex.quote(str(rc_file))}; "
-            "exit $rc"
-        )
         process = subprocess.Popen(
-            wrapped_command,
+            run_command,
             shell=True,
             cwd=str(workdir),
             stdout=stdout,
             stderr=stderr,
             text=True,
         )
+        self._processes[job_id] = process
+
+        def _await_returncode() -> None:
+            try:
+                returncode = process.wait()
+            finally:
+                stdout.close()
+                stderr.close()
+            tmp = rc_file.with_suffix(rc_file.suffix + ".tmp")
+            tmp.write_text(f"{returncode}\n")
+            os.replace(tmp, rc_file)
+
+        threading.Thread(target=_await_returncode, daemon=True).start()
         _write_json(
             local_dir / "job.json",
             {
@@ -215,12 +223,34 @@ class _LocalExecution:
             return False
         if isinstance(data.get("returncode"), int):
             return True
+        process = self._processes.get(job_id)
+        if process is not None:
+            try:
+                process.terminate()
+                try:
+                    process.wait(timeout=1)
+                except subprocess.TimeoutExpired:
+                    process.kill()
+                    process.wait(timeout=1)
+            except OSError:
+                pass
+            data["returncode"] = (
+                process.returncode
+                if process.returncode is not None
+                else -signal.SIGTERM
+            )
+            data["ended_at"] = time.time()
+            _write_json(self._job_path(job_id), data)
+            return True
         pid = int(data["pid"])
         try:
             os.kill(pid, signal.SIGTERM)
             time.sleep(1)
             if _process_alive(pid):
-                os.kill(pid, signal.SIGKILL)
+                if hasattr(signal, "SIGKILL"):
+                    os.kill(pid, signal.SIGKILL)
+                else:
+                    os.kill(pid, signal.SIGTERM)
             data["returncode"] = data.get("returncode", -signal.SIGTERM)
             data["ended_at"] = time.time()
             _write_json(self._job_path(job_id), data)

--- a/tests/autoresearch/platform_test.py
+++ b/tests/autoresearch/platform_test.py
@@ -6,6 +6,8 @@
 
 from __future__ import annotations
 
+import shlex
+import sys
 import tempfile
 import time
 import unittest
@@ -24,6 +26,20 @@ from spdl.autoresearch.pipeline_optimization._platform._agents import (
 )
 
 __all__: list[str] = []
+
+
+def _echo_marker_command(line: str) -> str:
+    """Build a cross-platform shell one-liner that prints ``line`` to stdout.
+
+    Tests previously used POSIX ``printf``; on Windows ``cmd.exe`` lacks it,
+    so we shell out to the current Python interpreter instead.
+    """
+    py = (
+        shlex.quote(sys.executable)
+        if sys.platform != "win32"
+        else f'"{sys.executable}"'
+    )
+    return f'{py} -c "print({line!r})"'
 
 
 class _PlatformTest(unittest.TestCase):
@@ -48,7 +64,7 @@ class _PlatformTest(unittest.TestCase):
             platform = create_platform("local", workdir)
 
             job_id = platform.execution.launch(
-                "printf '[autoresearch] step=1\\n'",
+                _echo_marker_command("[autoresearch] step=1"),
                 workdir,
             )
             self.assertIsNotNone(job_id)
@@ -79,7 +95,9 @@ class _PlatformTest(unittest.TestCase):
                 workdir,
             )
 
-            job_id = platform.execution.launch("printf 'not executed\\n'", workdir)
+            job_id = platform.execution.launch(
+                _echo_marker_command("not executed"), workdir
+            )
             self.assertIsNotNone(job_id)
             assert job_id is not None
 
@@ -93,12 +111,16 @@ class _PlatformTest(unittest.TestCase):
                 {
                     "platform": "local",
                     "local_execution_mode": "dataloader_only",
-                    "local_dataloader_command": "printf '[autoresearch] dataloader\\n'",
+                    "local_dataloader_command": _echo_marker_command(
+                        "[autoresearch] dataloader"
+                    ),
                 },
                 workdir,
             )
 
-            job_id = platform.execution.launch("printf 'training\\n'", workdir)
+            job_id = platform.execution.launch(
+                _echo_marker_command("training"), workdir
+            )
             self.assertIsNotNone(job_id)
             assert job_id is not None
 


### PR DESCRIPTION
Summary:
spdl/autoresearch unit tests fail on Windows in two places, both rooted in POSIX assumptions in the way coding-agent subprocesses are launched. This change makes those paths cross-platform without skipping any tests.

`_build_engine_command` rendered the workdir with `str(workdir)`, which on Windows produces `\tmp\wd` and breaks the engine command we hand to the supervisor agent. Switching to `workdir.as_posix()` keeps a stable forward-slash form that `pathlib`/`os` accept on every platform, and matches what `app_test.py::_EngineCommandTest` already asserts.

`_LocalExecution.launch` previously wrapped the user command in a POSIX shell snippet (`rc=$?; printf '%s\n' "$rc" > rc.txt; exit $rc`). On Windows `cmd.exe` has no `printf` and no `$?`, so the wrapper never wrote `returncode.txt` and `status()` was permanently stuck at `RUNNING`. The fix is to drop the shell wrapper entirely and track the return code in Python: spawn the user's command directly with `subprocess.Popen(shell=True, ...)`, then start a daemon thread that calls `process.wait()` and atomically writes `returncode.txt` (write-then-`os.replace`). The thread also closes the stdout/stderr file handles so the log files flush. We keep a per-instance `dict[job_id, Popen]` so `cancel` can use `process.terminate()` / `process.kill()` instead of POSIX-only `signal.SIGKILL`; the legacy `os.kill` path remains as a fallback when the handle isn't available, and is now guarded behind `hasattr(signal, "SIGKILL")`.

Finally, `platform_test.py` fed `printf '...'` as the user command, which is itself POSIX-only. A small `_echo_marker_command(line)` helper builds a shell one-liner that runs `python -c "print(...)"` against `sys.executable`, so the same test command works through `cmd.exe` on Windows and `/bin/sh` on POSIX. The three subprocess-running tests now go through this helper.

Differential Revision: D106656592
