### PR TITLE
Use MTP pipeline with GC tuning for video classification example

### DIFF
--- a/examples/video_classification/utils/pipeline.py
+++ b/examples/video_classification/utils/pipeline.py
@@ -23,9 +23,11 @@ import argparse
 import os
 from collections.abc import Iterator
 from concurrent.futures import ThreadPoolExecutor
+from functools import partial
 from typing import Protocol
 
 import spdl.io
+import spdl.pipeline
 import spdl.source.utils
 import torch
 from spdl.pipeline import PipelineBuilder
@@ -122,6 +124,10 @@ def collate(
     }
 
 
+def _fetch(index: int, *, dataset: VideoDataset) -> list[dict[str, object]]:
+    return dataset[index]
+
+
 def build_pipeline(
     *,
     args: argparse.Namespace,
@@ -130,15 +136,16 @@ def build_pipeline(
     rank: int,
     world_size: int,
 ) -> Iterator[_TBatch]:
-    """Build a multithreaded SPDL pipeline with GPU NVDEC video decoding.
+    """Build an MTP SPDL pipeline with GPU NVDEC video decoding.
 
-    Uses the GPU's dedicated NVDEC hardware decoders instead of CPU FFmpeg,
-    with a split demux/decode architecture. Each stage runs on a dedicated
-    thread executor to eliminate pool contention.
+    Runs CPU-bound stages (fetch, demux) in a subprocess to isolate them
+    from GPU kernel launches, then decodes with NVDEC hardware decoders
+    in the main process.
 
-    Pipeline stages::
+    Pipeline architecture::
 
-        sample → fetch → disaggregate → demux (CPU) → decode (NVDEC) → aggregate → collate
+        Subprocess:  sample → fetch → disaggregate → demux (CPU) → sink
+        Main:        source → decode (NVDEC) → aggregate → collate → sink
 
     Args:
         args: CLI args providing ``num_fetch_threads``, ``num_decode_threads``,
@@ -155,14 +162,6 @@ def build_pipeline(
     local_rank = int(os.environ.get("LOCAL_RANK", 0))
     device = torch.device(f"cuda:{local_rank}")
 
-    cuda_cfg = spdl.io.cuda_config(
-        device_index=local_rank,
-        allocator=(
-            torch.cuda.caching_allocator_alloc,
-            torch.cuda.caching_allocator_delete,
-        ),
-    )
-
     num_fetch_threads = args.num_fetch_threads
     num_decode_threads = args.num_decode_threads
 
@@ -172,10 +171,37 @@ def build_pipeline(
         )  # pyre-ignore[6]
     )
 
-    fetch_executor = ThreadPoolExecutor(max_workers=num_fetch_threads)
-    demux_executor = ThreadPoolExecutor(max_workers=8)
-    decode_executor = ThreadPoolExecutor(max_workers=num_decode_threads)
+    # Backend (subprocess): CPU-only stages
+    backend = (
+        PipelineBuilder()
+        .add_source(source, continuous=True)
+        .pipe(
+            partial(_fetch, dataset=dataset),
+            concurrency=num_fetch_threads,
+        )
+        .disaggregate()
+        .pipe(
+            Demux(label_to_index, subclip_duration=args.subclip_duration),
+            concurrency=8,
+        )
+        .add_sink(buffer_size=3)
+    )
 
+    subprocess_source = spdl.pipeline.run_pipeline_in_subprocess(
+        backend.get_config(),
+        num_threads=num_fetch_threads,
+        mp_context="forkserver",
+    )
+
+    # Frontend (main process): GPU NVDEC decode + aggregate + collate
+    cuda_cfg = spdl.io.cuda_config(
+        device_index=local_rank,
+        allocator=(
+            torch.cuda.caching_allocator_alloc,
+            torch.cuda.caching_allocator_delete,
+        ),
+    )
+    decode_executor = ThreadPoolExecutor(max_workers=num_decode_threads)
     nvdec_decode = NvdecDecode(
         num_frames=args.num_frames,
         cuda_cfg=cuda_cfg,
@@ -184,20 +210,9 @@ def build_pipeline(
         device=device,
     )
 
-    pipeline = (
+    frontend = (
         PipelineBuilder()
-        .add_source(source, continuous=True)
-        .pipe(
-            dataset.__getitem__,
-            concurrency=num_fetch_threads,
-            executor=fetch_executor,
-        )  # pyre-ignore[6]
-        .disaggregate()
-        .pipe(
-            Demux(label_to_index, subclip_duration=args.subclip_duration),
-            concurrency=8,
-            executor=demux_executor,
-        )
+        .add_source(subprocess_source, continuous=True)
         .pipe(
             nvdec_decode,
             concurrency=num_decode_threads,
@@ -206,7 +221,7 @@ def build_pipeline(
         .aggregate(args.batch_size, drop_last=True)
         .pipe(collate)
         .add_sink(buffer_size=3)
-        .build(num_threads=2)
     )
+    pipeline = frontend.build(num_threads=2)
 
     return pipeline.get_iterator(timeout=300)

--- a/examples/video_classification/video_classification.py
+++ b/examples/video_classification/video_classification.py
@@ -38,6 +38,7 @@ Usage
 from __future__ import annotations
 
 import argparse
+import gc
 import logging
 import os
 import time
@@ -90,6 +91,7 @@ def train(
     local_rank: int = int(os.environ.get("LOCAL_RANK", 0))
     device = torch.device(f"cuda:{local_rank}")
     torch.cuda.set_device(device)
+    gc.disable()
 
     _LG.info("Rank %d/%d on device %s", rank, world_size, device)
 
@@ -132,6 +134,9 @@ def train(
             optimizer.step()
             optimizer.zero_grad()
 
+            if global_step % 50 == 0:
+                gc.collect()
+
             epoch_loss += loss.item()
             num_batches += 1
             global_step += 1
@@ -159,6 +164,8 @@ def train(
                 elapsed,
                 num_batches * batch_size * world_size / elapsed,
             )
+
+    gc.enable()
 
 
 def parse_args() -> argparse.Namespace:


### PR DESCRIPTION
Summary:
Switch `build_pipeline` from in-process multithreaded pipeline to MTP (Multi-Threading in subprocess) architecture, and add GC stall mitigation to the training loop.

These changes were identified by an autoresearch run (85 experiments, 16 hours) on the video classification example (R3D-18 on Kinetics-400, 1x8 H100). The winning configuration improves steady-state throughput from 171 to 638 samples/s (+273%).

## Changes and individual contributions

The autoresearch engine tested each optimization independently and in combination. Individual contributions measured against the 171 samples/s baseline:

| Optimization | Alone | Cumulative | Mechanism |
|---|---|---|---|
| MTP subprocess isolation | +19% (203.6 s/s) | +19% | Isolates CPU data loading threads from GPU kernel launches, eliminating GIL contention and noisy-neighbor effects |
| `--subclip-duration 1.0` | +71% (292.3 s/s) | — | Limits video demux to first 1s, reducing NVDEC decode work ~10× (only 16 frames needed from ~300) |
| `--batch-size 64` | +25% (214.3 s/s) | — | Amortizes per-step DDP sync and pipeline drain/refill overhead across more samples |
| `--num-decode-threads 8` | +12% (347.0 s/s) | — | Matches H100's 7 NVDEC hardware slots, eliminating scheduling contention vs default of 16 |
| GC alignment | +30% (637.9 s/s) | +273% | `gc.disable()` + periodic `gc.collect()` prevents random GC pauses from causing DDP synchronization jitter across ranks |

The last three are CLI parameters (not code changes) documented in the commit message for reference.

## What didn't work

The autoresearch run also tested approaches that regressed or showed no improvement:

- **NVDEC concurrency 32/48**: −62% — catastrophic noisy-neighbor effect from 91% CPU utilization
- **CPU FFmpeg decode** (even in subprocess): −7% — pushed CPU to 60%, collapsing SM utilization
- **Demux concurrency 16/24**: −22% — thread contention overhead dominated the fast demux operation
- **`--subclip-duration 0.5`**: diminishing returns vs 1.0s (+1.3% only), too aggressive causes frame padding overhead

## Code changes

**`utils/pipeline.py`** — MTP pipeline:
- CPU-bound stages (fetch, demux) run in a subprocess via `run_pipeline_in_subprocess`, isolating them from GPU kernel launches
- GPU NVDEC decode stays in the main process with a dedicated `ThreadPoolExecutor`
- Replaces `dataset.__getitem__` with a module-level `_fetch` function via `functools.partial` for subprocess pickling compatibility

**`video_classification.py`** — GC alignment:
- `gc.disable()` at training start, `gc.collect()` every 50 steps, `gc.enable()` at end

## The Autoresearch run

 {F1990423673}

Differential Revision: D106691539


