### PR TITLE
Fix headspace throughput ceiling to use steady-state, not epoch-average (#1492)

### DIFF
--- a/src/spdl/autoresearch/_common/_visualization.py
+++ b/src/spdl/autoresearch/_common/_visualization.py
@@ -137,19 +137,11 @@ def _load_tsv(tsv_path: Path) -> list[dict]:
 
 
 def _format_label(exp: dict, metrics: list[MetricSpec]) -> str:
-    """Build a compact annotation string from the first few metrics."""
+    """Build a compact annotation string — just the experiment name."""
     name = exp["description"]
-    parts = []
-    for m in metrics:
-        val = exp.get(m.key)
-        if val is not None and val > 0:
-            val_str = format(val, m.fmt)
-            parts.append(f"{val_str} {m.unit}".rstrip())
-    suffix = f" ({', '.join(parts)})" if parts else ""
-    label = name + suffix
-    if len(label) > 55:
-        label = name[:35] + "..." + suffix
-    return label
+    if len(name) > 45:
+        name = name[:42] + "..."
+    return name
 
 
 # ---------------------------------------------------------------------------
@@ -268,6 +260,15 @@ def _plot_headspace_line(
     for exp in experiments:
         if exp["status"] == "HEADSPACE" and exp.get(metric.key) is not None:
             val = exp[metric.key]
+            steady = exp.get("steady_step_time_ms")
+            epoch_avg = exp.get("step_time_ms")
+            if (
+                not metric.lower_is_better
+                and steady
+                and epoch_avg
+                and steady < epoch_avg
+            ):
+                val = val * epoch_avg / steady
             kind = "floor" if metric.lower_is_better else "ceiling"
             val_str = format(val, metric.fmt)
             if metric.unit:
@@ -286,8 +287,13 @@ def _plot_headspace_line(
             break
 
 
-def _plot_crashes(ax, crashes, valid, y_key):
-    crash_y = max(e[y_key] for e in valid) * 1.1 if valid else 0
+def _plot_crashes(ax, crashes, valid, y_key, lower_is_better=True):
+    if not valid:
+        crash_y = 0
+    elif lower_is_better:
+        crash_y = max(e[y_key] for e in valid) * 1.1
+    else:
+        crash_y = min(e[y_key] for e in valid) * 0.9
     ax.scatter(
         [e["idx"] for e in crashes],
         [crash_y] * len(crashes),
@@ -322,12 +328,23 @@ def _partition_experiments(experiments, y_key):
     return valid, crashes, kept, discarded
 
 
-def _collect_y_values(experiments, valid, y_key):
+def _collect_y_values(experiments, valid, metric):
     """Gather all y values including headspace for axis limits."""
+    y_key = metric.key
     all_y = [e[y_key] for e in valid]
     for e in experiments:
         if e["status"] == "HEADSPACE" and e.get(y_key):
-            all_y.append(e[y_key])
+            val = e[y_key]
+            steady = e.get("steady_step_time_ms")
+            epoch_avg = e.get("step_time_ms")
+            if (
+                not metric.lower_is_better
+                and steady
+                and epoch_avg
+                and steady < epoch_avg
+            ):
+                val = val * epoch_avg / steady
+            all_y.append(val)
             break
     return all_y
 
@@ -350,7 +367,7 @@ def _plot_metric(
     valid, crashes, kept, discarded = _partition_experiments(experiments, y_key)
 
     if crashes:
-        _plot_crashes(ax, crashes, valid, y_key)
+        _plot_crashes(ax, crashes, valid, y_key, lower_is_better)
     if discarded:
         _plot_discarded(ax, discarded, y_key)
     if kept:
@@ -367,11 +384,10 @@ def _plot_metric(
 
     ax.set_ylabel(metric.label, fontsize=12)
     if show_legend:
-        loc = "upper right" if lower_is_better else "lower right"
-        ax.legend(loc=loc, fontsize=9)
+        ax.legend(loc="upper left", fontsize=9)
     ax.grid(True, alpha=0.2)
 
-    all_y = _collect_y_values(experiments, valid, y_key)
+    all_y = _collect_y_values(experiments, valid, metric)
     _set_y_limits(ax, all_y, lower_is_better, bool(crashes))
 
 

--- a/src/spdl/autoresearch/pipeline_optimization/_ops/_analysis_ops.py
+++ b/src/spdl/autoresearch/pipeline_optimization/_ops/_analysis_ops.py
@@ -203,6 +203,18 @@ def _append_master_result_row(
         row["steady_sm_util_pct"] = metrics.get("steady_sm_utilization_pct", "")
         row["data_readiness_pct"] = metrics.get("data_readiness_pct", "")
         row["notes"] = metrics.get("notes", "")
+        if node.name == "headspace_cache":
+            tput = row["throughput_samples_per_s"]
+            steady = row["steady_step_time_ms"]
+            epoch_avg = row["step_time_ms"]
+            if (
+                isinstance(tput, (int, float))
+                and isinstance(steady, (int, float))
+                and isinstance(epoch_avg, (int, float))
+                and steady > 0
+                and steady < epoch_avg
+            ):
+                row["throughput_samples_per_s"] = tput * epoch_avg / steady
     if terminal_failure is not None and not row.get("notes"):
         row["notes"] = _failure_note(terminal_failure)
     _append_master_row(workdir, row, MASTER_TABLE_HEADERS)

--- a/src/spdl/autoresearch/pipeline_optimization/prompts/analyze.md
+++ b/src/spdl/autoresearch/pipeline_optimization/prompts/analyze.md
@@ -86,7 +86,7 @@ __PIPELINE_CODE__
 }
 ```
 
-For `throughput_samples_per_s`: **this is the primary optimization metric** (higher is better). Calculate total sample throughput across all ranks from the job logs (e.g., "263.2 samples/s" at the end of training). If not directly available, compute as `batch_size * num_ranks * 1000 / steady_step_time_ms`. This metric correctly accounts for batch size changes — a smaller batch with a lower step time may still have worse throughput.
+For `throughput_samples_per_s`: **this is the primary optimization metric** (higher is better). Calculate total sample throughput across all ranks from the job logs (e.g., "263.2 samples/s" at the end of training). If not directly available, compute as `batch_size * num_ranks * 1000 / steady_step_time_ms`. This metric correctly accounts for batch size changes — a smaller batch with a lower step time may still have worse throughput. **Exception for CacheDataLoader / headspace runs:** the epoch-average throughput line is diluted by the cache warmup phase, so do NOT use it. Always compute `throughput_samples_per_s = batch_size * num_ranks * 1000 / steady_step_time_ms` from the post-warmup steady step time.
 For `steady_step_time_ms`: use the median step time after warmup. If per-step data is unavailable, estimate from sink QPS or set to null.
 For `steady_sm_utilization_pct`: use p50 or p75 SM util from system metrics. Prefer p75 for very short jobs (< 5 min).
 For `sm_utilization_pct`: still report the raw average for the master table, but note it's init-diluted.


### PR DESCRIPTION
Summary:

The CacheDataLoader headspace experiment reports `throughput_samples_per_s` as an epoch-average that is diluted by the cache-filling phase (~76s at real-pipeline speed). The true compute floor corresponds to `steady_step_time_ms`, so the headspace ceiling line in `progress.png` and the master table previously showed a value far below the actual model-compute throughput (e.g. 687 sps vs the correct ~3,405 sps).

This diff fixes the value in three layers so the correction holds end-to-end and also retroactively for already-recorded runs:

1. **Analysis prompt** (`prompts/analyze.md`): instruct the agent that for CacheDataLoader / headspace runs the epoch-average throughput line is diluted and `throughput_samples_per_s` must be computed from `steady_step_time_ms` as `batch_size * num_ranks * 1000 / steady_step_time_ms`.

2. **Recording layer** (`_ops/_analysis_ops.py`): in `_append_master_result_row`, after writing the agent's `throughput_samples_per_s`, detect headspace rows (`node.name == "headspace_cache"`) where `steady_step_time_ms < step_time_ms` and rescale the throughput by `step_time_ms / steady_step_time_ms`. This is a safety net so the master table is correct even if the agent still emits the diluted number.

3. **Visualization** (`_common/_visualization.py`): apply the same warmup-dilution correction in `_plot_headspace_line` before drawing the dashed line, and in `_collect_y_values` when computing y-axis limits. `_collect_y_values` now takes the full `MetricSpec` (so it can read `lower_is_better`) instead of just `y_key`. This is the fallback path for older workdirs whose master table was written before fix #2.

Reviewed By: gl3lan

Differential Revision: D106820654


