### PR TITLE
Add demux concurrency guidance to NVDEC docstrings

### DIFF
--- a/src/spdl/io/_core.py
+++ b/src/spdl/io/_core.py
@@ -136,6 +136,19 @@ def _convert_time_window(window: TimeWindow) -> tuple[tuple[int, int], tuple[int
 class Demuxer:
     """Demuxer can demux audio, video and image from the source.
 
+    .. note::
+
+       When running multiple ``Demuxer`` instances concurrently, keep the
+       concurrency low (2--3 threads).  ``Demuxer`` construction calls
+       FFmpeg's ``avformat_find_stream_info``, which opens a decoder via
+       ``avcodec_open2`` to probe each stream.  For codecs backed by
+       external libraries (e.g. libvpx, libaom, libopus) whose
+       thread-safety guarantees are unknown to FFmpeg, this initialization
+       is guarded by a process-wide ``codec_mutex``
+       (``FF_CODEC_CAP_NOT_INIT_THREADSAFE``).  At higher concurrency
+       threads serialize on this lock and per-item latency rises without
+       improving throughput.
+
     Args:
         src: Source identifier.
             If `str` type, it is interpreted as a source location,
@@ -757,6 +770,12 @@ def decode_packets_nvdec(
     .. note::
 
        Unlike FFmpeg-based decoding, NVDEC returns GPU buffer directly.
+
+    .. note::
+
+       When feeding packets from concurrent demux workers, keep demux
+       concurrency low (2--3 threads).  See :py:class:`~spdl.io.Demuxer`
+       for details.
 
     .. seealso::
 

--- a/src/spdl/io/lib/_libspdl_cuda.pyi
+++ b/src/spdl/io/lib/_libspdl_cuda.pyi
@@ -84,6 +84,12 @@ class NvDecDecoder:
 
     .. note::
 
+       When feeding packets from concurrent demux workers, keep demux
+       concurrency low (2--3 threads).  See :py:class:`~spdl.io.Demuxer`
+       for details.
+
+    .. note::
+
        To decode H264 and HEVC videos, packets must be in Annex B format.
        Use :py:func:`~spdl.io.apply_bsf` to convert:
 

--- a/src/spdl/io/lib/cuda/decoding_nvdec.cpp
+++ b/src/spdl/io/lib/cuda/decoding_nvdec.cpp
@@ -90,6 +90,12 @@ This decoder supports two decoding workflows:
 
 .. note::
 
+   When feeding packets from concurrent demux workers, keep demux
+   concurrency low (2--3 threads).  See :py:class:`~spdl.io.Demuxer`
+   for details.
+
+.. note::
+
    To decode H264 and HEVC videos, packets must be in Annex B format.
    Use :py:func:`~spdl.io.apply_bsf` to convert:
 


### PR DESCRIPTION
Add a note to `decode_packets_nvdec` and `NvDecDecoder` advising users to keep demux concurrency low (2-3 threads) when feeding packets from concurrent demux workers. Concurrent demuxing contends on FFmpeg's process-wide `codec_mutex` during `avformat_find_stream_info` probing, so adding more demux threads increases per-item latency without improving throughput.