### PR TITLE
Fix pyre-strict type errors in _internal/utils-type-checking

### DIFF
--- a/src/spdl/_internal/import_utils.py
+++ b/src/spdl/_internal/import_utils.py
@@ -27,9 +27,9 @@ class _LazilyImportedModule(ModuleType):
     # Note:
     # Python caches what was retrieved with `__getattr__`, so this method will not be
     # called again for the same item.
-    def __getattr__(self, item: str) -> Any:
+    def __getattr__(self, name: str) -> Any:
         self._import_once()
-        return getattr(self.module, item)
+        return getattr(self.module, name)
 
     def __repr__(self) -> str:
         if self.module is None:
@@ -60,7 +60,7 @@ def lazy_import(name: str) -> ModuleType:
         1.26.2
     """
 
-    def _import():
+    def _import() -> ModuleType:
         return importlib.import_module(name)
 
     return _LazilyImportedModule(name, _import)


### PR DESCRIPTION
Summary:
D102794969 promoted `fbcode/spdl/_internal/import_utils.py` to `# pyre-strict`, which surfaced two type errors that broke the `fbcode//spdl/_internal:utils-type-checking` target:

1. `_LazilyImportedModule.__getattr__` used parameter name `item`, which is inconsistent with the overridden `ModuleType.__getattr__(name)` signature. Renamed to `name`.
2. The inner `_import` function in `lazy_import` was missing a return type annotation. Added `-> ModuleType`.

Additionally, the related cleanup in D102786674 removed several `# pyre-ignore` comments from `fbcode/spdl/_internal/fb/_event_logger.py` whose underlying type errors are still present (heterogeneous `dict[str, str | int | list[str] | None]` values flowing into typed thrift entry constructors). Restored those `# pyre-ignore` markers so the type-checking target passes again.

Differential Revision: D107246889


