### PR TITLE
Support single-process and CPU-only execution in LLM example

### DIFF
--- a/examples/llm_finetune/llm_finetuning.py
+++ b/examples/llm_finetune/llm_finetuning.py
@@ -167,11 +167,18 @@ def train(
     progress_fn: Callable[[int, int], None] | None = None,
 ) -> None:
     """Main training function, called per-rank."""
-    rank: int = dist.get_rank()
-    world_size: int = dist.get_world_size()
+    if dist.is_initialized():
+        rank = dist.get_rank()
+        world_size = dist.get_world_size()
+    else:
+        rank = 0
+        world_size = 1
     local_rank: int = int(os.environ.get("LOCAL_RANK", 0))
-    device = torch.device(f"cuda:{local_rank}")
-    torch.cuda.set_device(device)
+    if torch.cuda.is_available():
+        device = torch.device(f"cuda:{local_rank}")
+        torch.cuda.set_device(device)
+    else:
+        device = torch.device("cpu")
 
     _LG.info(
         "Rank %d/%d on device %s (dataloader=%s)",
@@ -198,7 +205,13 @@ def train(
         lora_alpha=lora_alpha,
         lora_dropout=lora_dropout,
     )
-    ddp_model = DDP(model, device_ids=[local_rank])
+    if dist.is_initialized():
+        ddp_model = DDP(
+            model,
+            device_ids=[local_rank] if torch.cuda.is_available() else None,
+        )
+    else:
+        ddp_model = model
 
     # --- Optimizer ---
     optimizer = torch.optim.AdamW(
@@ -310,7 +323,7 @@ def train(
     if rank == 0 and output_dir:
         output_path = Path(output_dir)
         output_path.mkdir(parents=True, exist_ok=True)
-        ddp_model.module.save_pretrained(output_path)
+        model.save_pretrained(output_path)  # pyre-ignore[29]
         tokenizer.save_pretrained(output_path)
         _LG.info("Model saved to %s", output_path)
 
@@ -384,7 +397,10 @@ def init_logging() -> None:
 
 
 def main(args: argparse.Namespace) -> None:
-    dist.init_process_group(backend="nccl", timeout=timedelta(minutes=3))
+    use_distributed = "RANK" in os.environ
+    if use_distributed:
+        backend = "nccl" if torch.cuda.is_available() else "gloo"
+        dist.init_process_group(backend=backend, timeout=timedelta(minutes=3))
     try:
         train(
             model_path=resolve_model_path(args.model_path),
@@ -406,7 +422,8 @@ def main(args: argparse.Namespace) -> None:
             progress_fn=report_progress,
         )
     finally:
-        dist.destroy_process_group()
+        if use_distributed:
+            dist.destroy_process_group()
 
 
 if __name__ == "__main__":

--- a/examples/llm_finetune/utils/pipeline.py
+++ b/examples/llm_finetune/utils/pipeline.py
@@ -15,6 +15,7 @@ from typing import TYPE_CHECKING
 
 import spdl.pipeline
 import spdl.source.utils
+import torch
 from spdl.io import transfer_tensor
 from spdl.pipeline import PipelineBuilder
 from spdl.source import DistributedRandomSampler
@@ -146,10 +147,8 @@ def build_spdl_dataloader(
         mp_context=mp_context,
     )
 
-    frontend = (
-        PipelineBuilder()
-        .add_source(source2, continuous=True)
-        .pipe(transfer_tensor)
-        .add_sink(buffer_size=3)
-    )
+    frontend = PipelineBuilder().add_source(source2, continuous=True)
+    if torch.cuda.is_available():
+        frontend = frontend.pipe(transfer_tensor)
+    frontend = frontend.add_sink(buffer_size=3)
     return frontend.build(num_threads=1)


### PR DESCRIPTION
The LLM fine-tuning example previously required `torchrun` (which sets `RANK`/`WORLD_SIZE` env vars) and a CUDA GPU. This makes it impossible to run locally on CPU-only machines for dataloader benchmarking or development.

Changes:
- `main()`: only call `dist.init_process_group`/`destroy_process_group` when `RANK` is set in the environment (i.e., launched via `torchrun`). Also select `gloo` backend when no GPU is available.
- `train()`: check `dist.is_initialized()` and fall back to `rank=0`, `world_size=1`. Check `torch.cuda.is_available()` and fall back to CPU device. Only wrap with `DDP` when distributed is active.
- `build_spdl_dataloader()`: skip the `transfer_tensor` pipeline stage when no CUDA device is available, since it requires a GPU to transfer tensors to.