### PR TITLE
[autoresearch] Format autoresearch commit messages with title + body

### DIFF
--- a/src/spdl/autoresearch/pipeline_optimization/_factory.py
+++ b/src/spdl/autoresearch/pipeline_optimization/_factory.py
@@ -450,9 +450,85 @@ def _instrument_pipeline(
     source_dir = config.get("source_dir", "")
     if scm and source_dir and platform.workspace.has_changes(scm, source_dir):
         commit_hash = platform.workspace.commit(
-            scm, source_dir, "[autoresearch] Add TTFB/step-time instrumentation"
+            scm, source_dir, "ar: Add TTFB/step-time instrumentation"
         )
         _LG.info("Committed instrumentation: %s", commit_hash[:12])
+        print(f"  Committed: {commit_hash[:12]}")
+
+    if config.get("dataloader_only"):
+        _instrument_dataloader_only(workdir, config, platform)
+
+
+def _instrument_dataloader_only(
+    workdir: Path,
+    config: dict,
+    platform: AutoresearchPlatform,
+) -> None:
+    """Make model forward/backward/optimizer no-op for dataloader-only benchmarking."""
+    pipeline_script = config.get("pipeline_script", "")
+    if not pipeline_script or not Path(pipeline_script).exists():
+        return
+
+    pipeline_code = Path(pipeline_script).read_text()
+    _LG.info("Applying dataloader-only modifications to %s", pipeline_script)
+    print("Making model parts no-op for dataloader-only benchmarking...")
+
+    prompt = platform.agent._load_prompt(
+        "instrument_dataloader_only",
+        PIPELINE_SCRIPT=pipeline_script,
+        PIPELINE_CODE=pipeline_code,
+    )
+    output = _run_instrument_agent(
+        workdir, platform, prompt, "instrument_dataloader_only"
+    )
+    if output is None:
+        return
+
+    modified_code = _extract_python_block(output)
+    if modified_code is None:
+        _LG.warning(
+            "Dataloader-only instrument attempt returned no code block, retrying"
+        )
+        retry_prompt = (
+            prompt + "\n\n**You MUST output the ENTIRE modified file in a single "
+            "```python code block. Do NOT describe changes in prose. "
+            "Output ONLY code.**\n"
+        )
+        output = _run_instrument_agent(
+            workdir, platform, retry_prompt, "instrument_dataloader_only_retry"
+        )
+        if output is None:
+            return
+        modified_code = _extract_python_block(output)
+
+    if modified_code is None:
+        _LG.warning(
+            "Dataloader-only instrumentation failed — no code block in response"
+        )
+        print("  Warning: dataloader-only instrumentation failed")
+        _record_setup_failure(
+            workdir,
+            read_state(workdir),
+            _make_failure(
+                FailureKind.SETUP_INSTRUMENTATION_FAILED,
+                FailurePhase.INSTRUMENTATION,
+                "Coding agent did not return a Python code block for "
+                "dataloader-only instrumentation",
+            ),
+        )
+        return
+
+    Path(pipeline_script).write_text(modified_code)
+    _LG.info("Wrote dataloader-only code to %s", pipeline_script)
+    print(f"  Wrote dataloader-only code to {pipeline_script}")
+
+    scm = config.get("scm", "")
+    source_dir = config.get("source_dir", "")
+    if scm and source_dir and platform.workspace.has_changes(scm, source_dir):
+        commit_hash = platform.workspace.commit(
+            scm, source_dir, "ar: Make model no-op for dataloader-only mode"
+        )
+        _LG.info("Committed dataloader-only modifications: %s", commit_hash[:12])
         print(f"  Committed: {commit_hash[:12]}")
 
 

--- a/src/spdl/autoresearch/pipeline_optimization/_ops/_source_ops.py
+++ b/src/spdl/autoresearch/pipeline_optimization/_ops/_source_ops.py
@@ -26,6 +26,53 @@ from ._failures import _make_failure, _raise_failure
 
 _LG: logging.Logger = logging.getLogger(__name__)
 
+_MAX_TITLE_LEN = 72
+
+
+def _build_commit_message(
+    run_id: str,
+    exp: dict,
+    *,
+    extra_lines: list[str] | None = None,
+) -> str:
+    """Build a commit message with a short title and detailed body.
+
+    Format follows the Git/GitHub convention:
+    - Line 1: title (≤72 chars) describing the delta
+    - Line 2: blank
+    - Line 3+: body with description, hypothesis, and context
+
+    Works with both ``git commit -m`` and ``sl commit -m``.
+    """
+    name = exp.get("change_summary") or exp.get("name", run_id)
+    prefix = f"ar: {run_id}: "
+    max_name_len = _MAX_TITLE_LEN - len(prefix)
+    if len(name) > max_name_len:
+        name = name[: max_name_len - 1] + "…"
+    title = prefix + name
+
+    body_parts: list[str] = []
+
+    description = exp.get("description", "")
+    if description:
+        body_parts.append(description)
+
+    hypothesis = exp.get("hypothesis", "")
+    if hypothesis:
+        body_parts.append(f"Hypothesis: {hypothesis}")
+
+    changes = exp.get("changes")
+    if changes:
+        body_parts.append(f"Changes: {', '.join(changes)}")
+
+    if extra_lines:
+        body_parts.extend(extra_lines)
+
+    if not body_parts:
+        return title
+
+    return title + "\n\n" + "\n\n".join(body_parts)
+
 
 def _extract_code_block(text: str) -> str | None:
     for pattern in [
@@ -240,7 +287,7 @@ def _apply_code_changes(
 
     scm = config.get("scm", "")
     if scm and source_dir and platform.workspace.has_changes(scm, source_dir):
-        msg = f"[autoresearch] {run_id}: {exp.get('description', exp['name'])}"
+        msg = _build_commit_message(run_id, exp)
         try:
             commit_hash = platform.workspace.commit(scm, source_dir, msg)
         except Exception as error:
@@ -312,7 +359,9 @@ def _prepare_node(
     node.commit = exp.get("commit")
 
     if scm and source_dir and platform.workspace.has_changes(scm, source_dir):
-        msg = f"[autoresearch] {run_id} changes"
+        msg = _build_commit_message(
+            run_id, exp, extra_lines=["Residual changes after lint/build."]
+        )
         try:
             platform.workspace.commit(scm, source_dir, msg)
         except Exception as error:


### PR DESCRIPTION
Autoresearch experiment commits previously used a single long line for the entire description, making the commit tree hard to read in UIs. This changes the format to follow the Git/GitHub convention: a short title (≤72 chars) on line 1, a blank line, then a detailed body with description, hypothesis, and changes.

The title uses `change_summary` (concise) when available, falling back to `name`. The body includes the full `description`, `hypothesis`, and `changes` list from the experiment spec. This works with both `sl commit -m` and `git commit -m`.