### PR TITLE
[io] Add public Packets.deserialize and route pickle through it

### DIFF
--- a/src/libspdl/tests/packets_serialization_test.cpp
+++ b/src/libspdl/tests/packets_serialization_test.cpp
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <libspdl/core/packets.h>
+
+#include <gtest/gtest.h>
+
+extern "C" {
+#include <libavcodec/avcodec.h>
+}
+
+#include <cstring>
+#include <stdexcept>
+#include <vector>
+
+namespace spdl::core {
+namespace {
+
+// Build a standalone AVPacket with owned data and the given metadata.
+AVPacket* make_packet(
+    const std::vector<uint8_t>& data,
+    int64_t pts,
+    int64_t dts,
+    int flags,
+    int64_t duration) {
+  AVPacket* pkt = av_packet_alloc();
+  if (!pkt || av_new_packet(pkt, static_cast<int>(data.size())) < 0) {
+    throw std::runtime_error("Failed to allocate test packet");
+  }
+  std::memcpy(pkt->data, data.data(), data.size());
+  pkt->pts = pts;
+  pkt->dts = dts;
+  pkt->flags = flags;
+  pkt->duration = duration;
+  return pkt;
+}
+
+void expect_packet_eq(const AVPacket* a, const AVPacket* b) {
+  EXPECT_EQ(a->pts, b->pts);
+  EXPECT_EQ(a->dts, b->dts);
+  EXPECT_EQ(a->flags, b->flags);
+  EXPECT_EQ(a->duration, b->duration);
+  ASSERT_EQ(a->size, b->size);
+  EXPECT_EQ(0, std::memcmp(a->data, b->data, a->size));
+  ASSERT_EQ(a->side_data_elems, b->side_data_elems);
+  for (int i = 0; i < a->side_data_elems; ++i) {
+    EXPECT_EQ(a->side_data[i].type, b->side_data[i].type);
+    ASSERT_EQ(a->side_data[i].size, b->side_data[i].size);
+    EXPECT_EQ(
+        0,
+        std::memcmp(
+            a->side_data[i].data, b->side_data[i].data, a->side_data[i].size));
+  }
+}
+
+TEST(PacketsSerializationTest, RoundTripPreservesMetadataAndPayload) {
+  Packets<MediaType::Video> packets;
+  packets.src = "test://video";
+  packets.stream_index = 2;
+  packets.time_base = Rational{1, 1000};
+  packets.timestamp = TimeWindow{Rational{1, 10}, Rational{5, 10}};
+
+  packets.pkts.push(make_packet(
+      {1, 2, 3, 4, 5},
+      /*pts=*/100,
+      /*dts=*/90,
+      AV_PKT_FLAG_KEY,
+      /*duration=*/10));
+  packets.pkts.push(make_packet(
+      {9, 8, 7},
+      /*pts=*/110,
+      /*dts=*/100,
+      /*flags=*/0,
+      /*duration=*/10));
+
+  auto data = serialize_packets(packets);
+  auto restored = deserialize_packets<MediaType::Video>(data);
+
+  ASSERT_NE(restored, nullptr);
+  EXPECT_EQ(restored->src, packets.src);
+  EXPECT_EQ(restored->stream_index, packets.stream_index);
+  EXPECT_EQ(restored->time_base.num, packets.time_base.num);
+  EXPECT_EQ(restored->time_base.den, packets.time_base.den);
+
+  ASSERT_TRUE(restored->timestamp.has_value());
+  auto [start, end] = *restored->timestamp;
+  EXPECT_EQ(start.num, 1);
+  EXPECT_EQ(start.den, 10);
+  EXPECT_EQ(end.num, 5);
+  EXPECT_EQ(end.den, 10);
+
+  const auto& orig = packets.pkts.get_packets();
+  const auto& got = restored->pkts.get_packets();
+  ASSERT_EQ(got.size(), orig.size());
+  for (size_t i = 0; i < orig.size(); ++i) {
+    expect_packet_eq(orig[i], got[i]);
+  }
+}
+
+TEST(PacketsSerializationTest, RoundTripPreservesSideData) {
+  Packets<MediaType::Audio> packets;
+  packets.src = "test://audio";
+  packets.stream_index = 0;
+  packets.time_base = Rational{1, 44100};
+
+  AVPacket* pkt = make_packet(
+      {10, 20, 30, 40}, /*pts=*/0, /*dts=*/0, /*flags=*/0, /*duration=*/1024);
+  const std::vector<uint8_t> sd = {0xde, 0xad, 0xbe, 0xef};
+  uint8_t* dst =
+      av_packet_new_side_data(pkt, AV_PKT_DATA_SKIP_SAMPLES, sd.size());
+  ASSERT_NE(dst, nullptr);
+  std::memcpy(dst, sd.data(), sd.size());
+  packets.pkts.push(pkt);
+
+  auto data = serialize_packets(packets);
+  auto restored = deserialize_packets<MediaType::Audio>(data);
+
+  ASSERT_NE(restored, nullptr);
+  const auto& got = restored->pkts.get_packets();
+  ASSERT_EQ(got.size(), 1u);
+  expect_packet_eq(pkt, got[0]);
+  ASSERT_EQ(got[0]->side_data_elems, 1);
+  EXPECT_EQ(got[0]->side_data[0].type, AV_PKT_DATA_SKIP_SAMPLES);
+}
+
+TEST(PacketsSerializationTest, RoundTripEmpty) {
+  Packets<MediaType::Audio> packets;
+  packets.src = "test://empty";
+  packets.stream_index = 1;
+  packets.time_base = Rational{1, 1000};
+
+  auto data = serialize_packets(packets);
+  auto restored = deserialize_packets<MediaType::Audio>(data);
+
+  ASSERT_NE(restored, nullptr);
+  EXPECT_EQ(restored->src, "test://empty");
+  EXPECT_EQ(restored->stream_index, 1);
+  EXPECT_EQ(restored->pkts.get_packets().size(), 0u);
+  EXPECT_FALSE(restored->timestamp.has_value());
+}
+
+TEST(PacketsSerializationTest, MediaTypeMismatchThrows) {
+  Packets<MediaType::Audio> packets;
+  packets.src = "test://mismatch";
+  packets.time_base = Rational{1, 1000};
+
+  auto data = serialize_packets(packets);
+  EXPECT_THROW(deserialize_packets<MediaType::Video>(data), std::runtime_error);
+}
+
+} // namespace
+} // namespace spdl::core

--- a/src/spdl/io/lib/__init__.py
+++ b/src/spdl/io/lib/__init__.py
@@ -104,19 +104,21 @@ def _import_libspdl() -> ModuleType:
     raise RuntimeError(msg)
 
 
+# These thin module-level functions are the targets the copyreg reducers below
+# pickle by reference (a nanobind static method is not itself picklable by
+# reference, so the reducer cannot point at it directly). They delegate to the
+# public ``Packets.deserialize`` static method, the single deserialization entry
+# point shared with the memory-arena offload path.
 def _deserialize_audio_packets(data: bytes):  # type: ignore[no-untyped-def]
-    ext = _import_libspdl()
-    return ext._deserialize_audio_packets(data)
+    return _import_libspdl().AudioPackets.deserialize(data)
 
 
 def _deserialize_video_packets(data: bytes):  # type: ignore[no-untyped-def]
-    ext = _import_libspdl()
-    return ext._deserialize_video_packets(data)
+    return _import_libspdl().VideoPackets.deserialize(data)
 
 
 def _deserialize_image_packets(data: bytes):  # type: ignore[no-untyped-def]
-    ext = _import_libspdl()
-    return ext._deserialize_image_packets(data)
+    return _import_libspdl().ImagePackets.deserialize(data)
 
 
 def _register_pickle(ext: ModuleType) -> None:

--- a/src/spdl/io/lib/_libspdl.pyi
+++ b/src/spdl/io/lib/_libspdl.pyi
@@ -48,6 +48,18 @@ class AudioPackets:
 
     def __getstate__(self) -> bytes: ...
 
+    @staticmethod
+    def deserialize(data: bytes) -> AudioPackets:
+        """
+        Reconstruct packets from the bytes returned by ``__getstate__``.
+
+        Args:
+            data: The serialized packets.
+
+        Returns:
+            The reconstructed packets.
+        """
+
     def __repr__(self) -> str: ...
 
     def __len__(self) -> int: ...
@@ -88,6 +100,18 @@ class VideoPackets:
     """
 
     def __getstate__(self) -> bytes: ...
+
+    @staticmethod
+    def deserialize(data: bytes) -> VideoPackets:
+        """
+        Reconstruct packets from the bytes returned by ``__getstate__``.
+
+        Args:
+            data: The serialized packets.
+
+        Returns:
+            The reconstructed packets.
+        """
 
     def get_timestamps(self, *, raw: bool = False) -> list[float]:
         """
@@ -164,6 +188,18 @@ class ImagePackets:
     """
 
     def __getstate__(self) -> bytes: ...
+
+    @staticmethod
+    def deserialize(data: bytes) -> ImagePackets:
+        """
+        Reconstruct packets from the bytes returned by ``__getstate__``.
+
+        Args:
+            data: The serialized packets.
+
+        Returns:
+            The reconstructed packets.
+        """
 
     @property
     def pix_fmt(self) -> str:

--- a/src/spdl/io/lib/core/packets.cpp
+++ b/src/spdl/io/lib/core/packets.cpp
@@ -88,6 +88,20 @@ void register_packets(nb::module_& m) {
             return nb::bytes(
                 reinterpret_cast<const char*>(bytes.data()), bytes.size());
           })
+      .def_static(
+          "deserialize",
+          [](const nb::bytes& state) -> AudioPacketsPtr {
+            std::vector<uint8_t> data(
+                state.c_str(), state.c_str() + state.size());
+            nb::gil_scoped_release g;
+            return deserialize_packets<MediaType::Audio>(data);
+          },
+          nb::arg("data"),
+          "Reconstruct packets from the bytes returned by ``__getstate__``.\n\n"
+          "Args:\n"
+          "    data: The serialized packets.\n\n"
+          "Returns:\n"
+          "    The reconstructed packets.")
       .def(
           "__repr__",
           [](const AudioPackets& self) {
@@ -176,6 +190,20 @@ void register_packets(nb::module_& m) {
             return nb::bytes(
                 reinterpret_cast<const char*>(bytes.data()), bytes.size());
           })
+      .def_static(
+          "deserialize",
+          [](const nb::bytes& state) -> VideoPacketsPtr {
+            std::vector<uint8_t> data(
+                state.c_str(), state.c_str() + state.size());
+            nb::gil_scoped_release g;
+            return deserialize_packets<MediaType::Video>(data);
+          },
+          nb::arg("data"),
+          "Reconstruct packets from the bytes returned by ``__getstate__``.\n\n"
+          "Args:\n"
+          "    data: The serialized packets.\n\n"
+          "Returns:\n"
+          "    The reconstructed packets.")
       .def(
           "get_timestamps",
           [](const VideoPackets& self, bool raw) -> std::vector<double> {
@@ -290,33 +318,6 @@ void register_packets(nb::module_& m) {
       nb::arg("packets"),
       nb::arg("indices"));
 
-  m.def(
-      "_deserialize_audio_packets",
-      [](const nb::bytes& state) -> AudioPacketsPtr {
-        std::vector<uint8_t> data(state.c_str(), state.c_str() + state.size());
-        nb::gil_scoped_release g;
-        return deserialize_packets<MediaType::Audio>(data);
-      },
-      nb::arg("data"));
-
-  m.def(
-      "_deserialize_video_packets",
-      [](const nb::bytes& state) -> VideoPacketsPtr {
-        std::vector<uint8_t> data(state.c_str(), state.c_str() + state.size());
-        nb::gil_scoped_release g;
-        return deserialize_packets<MediaType::Video>(data);
-      },
-      nb::arg("data"));
-
-  m.def(
-      "_deserialize_image_packets",
-      [](const nb::bytes& state) -> ImagePacketsPtr {
-        std::vector<uint8_t> data(state.c_str(), state.c_str() + state.size());
-        nb::gil_scoped_release g;
-        return deserialize_packets<MediaType::Image>(data);
-      },
-      nb::arg("data"));
-
   nb::class_<ImagePackets>(
       m,
       "ImagePackets",
@@ -333,6 +334,20 @@ void register_packets(nb::module_& m) {
             return nb::bytes(
                 reinterpret_cast<const char*>(bytes.data()), bytes.size());
           })
+      .def_static(
+          "deserialize",
+          [](const nb::bytes& state) -> ImagePacketsPtr {
+            std::vector<uint8_t> data(
+                state.c_str(), state.c_str() + state.size());
+            nb::gil_scoped_release g;
+            return deserialize_packets<MediaType::Image>(data);
+          },
+          nb::arg("data"),
+          "Reconstruct packets from the bytes returned by ``__getstate__``.\n\n"
+          "Args:\n"
+          "    data: The serialized packets.\n\n"
+          "Returns:\n"
+          "    The reconstructed packets.")
       .def_prop_ro(
           "pix_fmt",
           [](const ImagePackets& self) {


### PR DESCRIPTION
Add a `deserialize` static method to `AudioPackets`, `VideoPackets`, and `ImagePackets` as the single public entry point for reconstructing packets from the bytes returned by `__getstate__`. Remove the now-redundant module-level `_deserialize_*_packets` C++ bindings, and repoint the `copyreg` pickle reducers in `spdl/io/lib/__init__.py` at the new static method (kept behind the thin module-level functions because a nanobind static method is not itself picklable by reference).

This exposes a public, encapsulation-friendly deserialization API so callers outside `spdl.io.lib` can reconstruct packets without reaching into private symbols.