### PR TITLE
Add zero-copy deserialization to Packets objects.

### DIFF
--- a/src/libspdl/core/packets.cpp
+++ b/src/libspdl/core/packets.cpp
@@ -21,6 +21,7 @@
 #include <cassert>
 #include <cstring>
 #include <stdexcept>
+#include <utility>
 
 extern "C" {
 #include <libavcodec/avcodec.h>
@@ -141,6 +142,7 @@ Packets<media>& Packets<media>::operator=(Packets<media>&& other) noexcept {
   swap(time_base, other.time_base);
   swap(timestamp, other.timestamp);
   swap(codec, other.codec);
+  swap(is_view, other.is_view);
   return *this;
 }
 
@@ -348,6 +350,12 @@ namespace {
 constexpr uint32_t SERIALIZATION_MAGIC = 0x53504B54; // "SPKT"
 constexpr uint8_t SERIALIZATION_VERSION = 1;
 
+// Each serialized packet payload is followed by this many zeroed bytes. FFmpeg
+// decoders may over-read up to AV_INPUT_BUFFER_PADDING_SIZE past the end of
+// packet data, so the padding lets a payload be restored as a zero-copy view
+// (deserialize_packets_view) without copying it into an av_malloc'd buffer.
+constexpr size_t SERIALIZATION_PADDING = AV_INPUT_BUFFER_PADDING_SIZE;
+
 class ByteWriter {
   std::vector<uint8_t>& buf_;
 
@@ -380,6 +388,18 @@ class ByteWriter {
     if (!s.empty()) {
       write_raw(s.data(), s.size());
     }
+  }
+
+  // Write a packet payload: size, raw bytes, then SERIALIZATION_PADDING zeroed
+  // bytes so the payload can be restored as a zero-copy view.
+  void write_payload(const uint8_t* data, int size) {
+    if (!data || size <= 0) {
+      write<int32_t>(0);
+      return;
+    }
+    write<int32_t>(size);
+    write_raw(data, size);
+    buf_.insert(buf_.end(), SERIALIZATION_PADDING, 0);
   }
 };
 
@@ -429,6 +449,48 @@ class ByteReader {
     }
     return result;
   }
+
+  // Pointer to the current read position; valid while the buffer is alive.
+  const uint8_t* peek() const {
+    return data_ + offset_;
+  }
+
+  void skip(size_t size) {
+    if (offset_ + size > size_) {
+      throw std::runtime_error("Deserialization buffer underflow");
+    }
+    offset_ += size;
+  }
+
+  // Copy out a payload written by ByteWriter::write_payload (consumes the
+  // trailing padding).
+  std::vector<uint8_t> read_payload() {
+    auto size = read<int32_t>();
+    if (size < 0) {
+      throw std::runtime_error("Deserialization error: negative size");
+    }
+    std::vector<uint8_t> result(size);
+    if (size > 0) {
+      read_raw(result.data(), size);
+      skip(SERIALIZATION_PADDING);
+    }
+    return result;
+  }
+
+  // Return a pointer to a payload in place and advance past it (and its
+  // padding) without copying. The pointer is valid while the buffer is alive.
+  std::pair<const uint8_t*, int> view_payload() {
+    auto size = read<int32_t>();
+    if (size < 0) {
+      throw std::runtime_error("Deserialization error: negative size");
+    }
+    if (size == 0) {
+      return {nullptr, 0};
+    }
+    const uint8_t* p = peek();
+    skip(static_cast<size_t>(size) + SERIALIZATION_PADDING);
+    return {p, size};
+  }
 };
 
 void serialize_packet(ByteWriter& w, const AVPacket* pkt) {
@@ -447,7 +509,7 @@ void serialize_packet(ByteWriter& w, const AVPacket* pkt) {
   w.write<int64_t>(pkt->dts);
   w.write<int32_t>(pkt->flags);
   w.write<int64_t>(pkt->duration);
-  w.write_bytes(pkt->data, pkt->size);
+  w.write_payload(pkt->data, pkt->size);
 
   w.write<int32_t>(pkt->side_data_elems);
   for (int i = 0; i < pkt->side_data_elems; ++i) {
@@ -467,12 +529,55 @@ AVPacket* deserialize_packet(ByteReader& r) {
   auto flags = r.read<int32_t>();
   auto duration = r.read<int64_t>();
 
-  auto data = r.read_bytes();
+  auto data = r.read_payload();
   if (!data.empty()) {
     if (av_new_packet(pkt.get(), static_cast<int>(data.size())) < 0) {
       throw std::runtime_error("Failed to allocate packet data");
     }
     std::memcpy(pkt->data, data.data(), data.size());
+  }
+
+  pkt->pts = pts;
+  pkt->dts = dts;
+  pkt->flags = flags;
+  pkt->duration = duration;
+
+  auto num_side_data = r.read<int32_t>();
+  for (int32_t i = 0; i < num_side_data; ++i) {
+    auto type = static_cast<AVPacketSideDataType>(r.read<int32_t>());
+    auto sd_data = r.read_bytes();
+    auto* sd = av_packet_new_side_data(
+        pkt.get(), type, static_cast<int>(sd_data.size()));
+    if (!sd) {
+      throw std::runtime_error("Failed to allocate packet side data");
+    }
+    std::memcpy(sd, sd_data.data(), sd_data.size());
+  }
+
+  return pkt.release();
+}
+
+// Like deserialize_packet, but the payload is a non-owning view into the
+// reader's buffer: pkt->data points into it and pkt->buf stays NULL. Side data
+// is still copied (owned). The caller must keep the buffer alive for the
+// packet's life.
+AVPacket* deserialize_view_packet(ByteReader& r) {
+  detail::AVPacketPtr pkt(av_packet_alloc());
+  if (!pkt) {
+    throw std::runtime_error("Failed to allocate AVPacket");
+  }
+
+  auto pts = r.read<int64_t>();
+  auto dts = r.read<int64_t>();
+  auto flags = r.read<int32_t>();
+  auto duration = r.read<int64_t>();
+
+  auto [data_ptr, size] = r.view_payload();
+  if (size > 0) {
+    // Non-owning view: point at the buffer and leave buf == NULL so FFmpeg
+    // treats the data as unreferenced (clones/refs deep-copy).
+    pkt->data = const_cast<uint8_t*>(data_ptr);
+    pkt->size = size;
   }
 
   pkt->pts = pts;
@@ -731,11 +836,11 @@ std::vector<uint8_t> serialize_packets(const Packets<media>& packets) {
   return buf;
 }
 
+// Read everything up to (but not including) the packet count: the header,
+// src/stream_index/time_base, timestamp and codec. Shared by the copy and view
+// deserializers; leaves `r` positioned at the int32 packet count.
 template <MediaType media>
-std::unique_ptr<Packets<media>> deserialize_packets(
-    const std::vector<uint8_t>& data) {
-  ByteReader r(data.data(), data.size());
-
+static std::unique_ptr<Packets<media>> read_packets_header(ByteReader& r) {
   auto magic = r.read<uint32_t>();
   if (magic != SERIALIZATION_MAGIC) {
     throw std::runtime_error("Invalid serialization magic number");
@@ -783,11 +888,35 @@ std::unique_ptr<Packets<media>> deserialize_packets(
     avcodec_parameters_free(&par);
   }
 
-  // Packets
+  return result;
+}
+
+template <MediaType media>
+std::unique_ptr<Packets<media>> deserialize_packets(
+    const std::vector<uint8_t>& data) {
+  ByteReader r(data.data(), data.size());
+  auto result = read_packets_header<media>(r);
+
   auto num_packets = r.read<int32_t>();
   for (int32_t i = 0; i < num_packets; ++i) {
     result->pkts.push(deserialize_packet(r));
   }
+
+  return result;
+}
+
+template <MediaType media>
+std::unique_ptr<Packets<media>> deserialize_packets_view(
+    const uint8_t* data,
+    size_t size) {
+  ByteReader r(data, size);
+  auto result = read_packets_header<media>(r);
+
+  auto num_packets = r.read<int32_t>();
+  for (int32_t i = 0; i < num_packets; ++i) {
+    result->pkts.push(deserialize_view_packet(r));
+  }
+  result->is_view = true;
 
   return result;
 }
@@ -802,5 +931,12 @@ template std::unique_ptr<VideoPackets> deserialize_packets<MediaType::Video>(
     const std::vector<uint8_t>&);
 template std::unique_ptr<ImagePackets> deserialize_packets<MediaType::Image>(
     const std::vector<uint8_t>&);
+
+template std::unique_ptr<AudioPackets>
+deserialize_packets_view<MediaType::Audio>(const uint8_t*, size_t);
+template std::unique_ptr<VideoPackets>
+deserialize_packets_view<MediaType::Video>(const uint8_t*, size_t);
+template std::unique_ptr<ImagePackets>
+deserialize_packets_view<MediaType::Image>(const uint8_t*, size_t);
 
 } // namespace spdl::core

--- a/src/libspdl/core/packets.h
+++ b/src/libspdl/core/packets.h
@@ -140,6 +140,15 @@ struct Packets {
   /// For streaming demuxing, codec must be fetched from demuxer directly.
   std::optional<Codec<media>> codec;
 
+  /// When true, the AVPacket payloads are non-owning *views* into external
+  /// memory (e.g. a shared-memory segment), built by
+  /// ``deserialize_packets_view``. The caller guarantees that backing memory
+  /// outlives this object — analogous to ``std::string_view``. Cloning or
+  /// re-serializing a view materializes an owning copy (FFmpeg copies when
+  /// ``AVPacket::buf == NULL``), so derived objects are safe to outlive the
+  /// backing memory.
+  bool is_view{false};
+
   /// Default constructor.
   Packets() = default;
 
@@ -225,6 +234,15 @@ std::vector<double> get_timestamps(
 
 /// Serialize Packets to a byte vector for IPC (e.g., multiprocessing).
 ///
+/// NOTE: This byte format is **internal and process-local**. It is only ever
+/// produced and consumed by the same build (e.g. an `iterate_in_subprocess`
+/// worker and its parent), and is **not** stable for on-disk persistence or
+/// cross-version exchange. The layout may change without a version bump; the
+/// embedded magic/version bytes are an internal sanity check, not a
+/// compatibility contract. Each packet payload is written followed by
+/// `AV_INPUT_BUFFER_PADDING_SIZE` zeroed bytes so it can be restored as a
+/// zero-copy view (see `deserialize_packets_view`).
+///
 /// Throws std::runtime_error if any non-serializable pointer field
 /// (AVPacket::opaque, AVPacket::opaque_ref) is non-NULL.
 ///
@@ -234,13 +252,36 @@ std::vector<double> get_timestamps(
 template <MediaType media>
 std::vector<uint8_t> serialize_packets(const Packets<media>& packets);
 
-/// Deserialize byte vector back to Packets.
+/// Deserialize a byte buffer (produced by `serialize_packets`) back to Packets,
+/// copying each payload into a freshly owned AVPacket buffer.
+///
+/// See `serialize_packets` for the note that the format is
+/// internal/process-local.
 ///
 /// @tparam media Media type (Audio, Video, or Image).
 /// @param data Serialized byte vector.
-/// @return Deserialized Packets.
+/// @return Deserialized Packets (owning their payloads).
 template <MediaType media>
 std::unique_ptr<Packets<media>> deserialize_packets(
     const std::vector<uint8_t>& data);
+
+/// Deserialize a byte buffer **without copying payloads**: each AVPacket points
+/// directly into `data` (`AVPacket::buf == NULL`, non-owning). The returned
+/// Packets has `is_view == true`.
+///
+/// The caller MUST keep `data` alive and unmodified for the entire lifetime of
+/// the returned Packets (and of any non-clone references taken from it). The
+/// buffer must have been produced by `serialize_packets` (which writes the
+/// required trailing payload padding). Cloning/re-referencing a view packet
+/// deep-copies (FFmpeg copies when `buf == NULL`), so derived packets are safe.
+///
+/// @tparam media Media type (Audio, Video, or Image).
+/// @param data Pointer to the serialized buffer.
+/// @param size Size of the serialized buffer in bytes.
+/// @return Deserialized Packets viewing `data`.
+template <MediaType media>
+std::unique_ptr<Packets<media>> deserialize_packets_view(
+    const uint8_t* data,
+    size_t size);
 
 } // namespace spdl::core

--- a/src/libspdl/tests/packets_serialization_test.cpp
+++ b/src/libspdl/tests/packets_serialization_test.cpp
@@ -14,6 +14,7 @@ extern "C" {
 #include <libavcodec/avcodec.h>
 }
 
+#include <algorithm>
 #include <cstring>
 #include <stdexcept>
 #include <vector>
@@ -151,6 +152,91 @@ TEST(PacketsSerializationTest, MediaTypeMismatchThrows) {
 
   auto data = serialize_packets(packets);
   EXPECT_THROW(deserialize_packets<MediaType::Video>(data), std::runtime_error);
+}
+
+TEST(PacketsSerializationTest, ViewAliasesBufferWithPadding) {
+  Packets<MediaType::Audio> packets;
+  packets.src = "test://view";
+  packets.stream_index = 0;
+  packets.time_base = Rational{1, 44100};
+  packets.pkts.push(make_packet(
+      {1, 2, 3, 4, 5, 6, 7, 8},
+      /*pts=*/10,
+      /*dts=*/8,
+      AV_PKT_FLAG_KEY,
+      /*duration=*/2));
+  packets.pkts.push(make_packet(
+      {100, 101, 102},
+      /*pts=*/20,
+      /*dts=*/18,
+      /*flags=*/0,
+      /*duration=*/2));
+
+  auto buf = serialize_packets(packets);
+  auto restored =
+      deserialize_packets_view<MediaType::Audio>(buf.data(), buf.size());
+
+  ASSERT_NE(restored, nullptr);
+  EXPECT_TRUE(restored->is_view);
+
+  const auto& orig = packets.pkts.get_packets();
+  const auto& got = restored->pkts.get_packets();
+  ASSERT_EQ(got.size(), orig.size());
+
+  const uint8_t* lo = buf.data();
+  const uint8_t* hi = buf.data() + buf.size();
+  for (size_t i = 0; i < got.size(); ++i) {
+    // Non-owning view pointing inside the serialized buffer.
+    EXPECT_EQ(got[i]->buf, nullptr);
+    EXPECT_GE(got[i]->data, lo);
+    EXPECT_LT(got[i]->data, hi);
+    ASSERT_EQ(got[i]->size, orig[i]->size);
+    EXPECT_EQ(0, std::memcmp(got[i]->data, orig[i]->data, got[i]->size));
+
+    // The trailing padding decoders may over-read is present and zeroed.
+    ASSERT_LE(got[i]->data + got[i]->size + AV_INPUT_BUFFER_PADDING_SIZE, hi);
+    for (int p = 0; p < AV_INPUT_BUFFER_PADDING_SIZE; ++p) {
+      EXPECT_EQ(got[i]->data[got[i]->size + p], 0);
+    }
+  }
+}
+
+TEST(PacketsSerializationTest, ViewCloneDeepCopiesAndOutlivesBuffer) {
+  Packets<MediaType::Audio> packets;
+  packets.src = "test://view-clone";
+  packets.time_base = Rational{1, 1000};
+  const std::vector<uint8_t> payload = {9, 8, 7, 6, 5};
+  packets.pkts.push(
+      make_packet(payload, /*pts=*/1, /*dts=*/1, /*flags=*/0, /*duration=*/1));
+
+  auto buf = serialize_packets(packets);
+
+  AVPacket* clone = nullptr;
+  {
+    auto view =
+        deserialize_packets_view<MediaType::Audio>(buf.data(), buf.size());
+    ASSERT_EQ(view->pkts.get_packets().size(), 1u);
+    AVPacket* vp = view->pkts.get_packets()[0];
+    EXPECT_EQ(vp->buf, nullptr); // non-owning view
+
+    // Cloning a buf==NULL packet must deep-copy.
+    clone = av_packet_clone(vp);
+    ASSERT_NE(clone, nullptr);
+    EXPECT_NE(clone->buf, nullptr); // clone owns its data
+    EXPECT_NE(clone->data, vp->data); // different memory
+    // `view` is destroyed here (it never owned the payload).
+  }
+
+  // Scribble over and free the backing buffer; a lingering view would be a
+  // use-after-free under ASAN.
+  std::fill(buf.begin(), buf.end(), static_cast<uint8_t>(0xAB));
+  buf.clear();
+  buf.shrink_to_fit();
+
+  // The clone still holds a valid, independent copy.
+  ASSERT_EQ(clone->size, static_cast<int>(payload.size()));
+  EXPECT_EQ(0, std::memcmp(clone->data, payload.data(), payload.size()));
+  av_packet_free(&clone);
 }
 
 } // namespace

--- a/src/libspdl/tests/smoke_test.cpp
+++ b/src/libspdl/tests/smoke_test.cpp
@@ -10,6 +10,7 @@
 #include <libspdl/core/decoder.h>
 #include <libspdl/core/demuxing.h>
 #include <libspdl/core/frames.h>
+#include <libspdl/core/packets.h>
 #include <libspdl/core/types.h>
 #include <libspdl/core/utils.h>
 
@@ -243,6 +244,44 @@ TEST(SmokeTest, DecodeVideoWithChainedFilters) {
   auto buf = convert_frames<MediaType::Video>(frames.get());
   ASSERT_NE(buf, nullptr);
   EXPECT_GT(buf->shape.size(), 0);
+}
+
+TEST(SmokeTest, DecodeVideoFromSerializedView) {
+  std::string videoPath = getTestDataPath("test_video.mp4");
+
+  auto demuxer = make_demuxer(videoPath);
+  ASSERT_NE(demuxer, nullptr);
+  auto codec = demuxer->get_default_codec<MediaType::Video>();
+  auto packets = demuxer->demux_window<MediaType::Video>();
+  ASSERT_NE(packets, nullptr);
+  EXPECT_GT(packets->pkts.get_packets().size(), 0);
+
+  // Serialize, then decode (a) the original packets and (b) packets restored as
+  // a zero-copy view into the serialized buffer. Both must decode identically.
+  auto buf = serialize_packets(*packets);
+
+  Decoder<MediaType::Video> ref_decoder(codec, std::nullopt, std::nullopt);
+  auto ref_frames =
+      ref_decoder.decode_packets(std::make_unique<VideoPackets>(*packets));
+  ASSERT_NE(ref_frames, nullptr);
+  EXPECT_GT(ref_frames->get_num_frames(), 0);
+
+  auto view =
+      deserialize_packets_view<MediaType::Video>(buf.data(), buf.size());
+  ASSERT_NE(view, nullptr);
+  EXPECT_TRUE(view->is_view);
+
+  Decoder<MediaType::Video> view_decoder(codec, std::nullopt, std::nullopt);
+  auto view_frames = view_decoder.decode_packets(std::move(view));
+  ASSERT_NE(view_frames, nullptr);
+
+  EXPECT_EQ(view_frames->get_num_frames(), ref_frames->get_num_frames());
+
+  auto ref_buf = convert_frames<MediaType::Video>(ref_frames.get());
+  auto view_buf = convert_frames<MediaType::Video>(view_frames.get());
+  ASSERT_NE(ref_buf, nullptr);
+  ASSERT_NE(view_buf, nullptr);
+  EXPECT_EQ(view_buf->shape, ref_buf->shape);
 }
 
 TEST(SmokeTest, ConfigInitialization) {

--- a/src/spdl/io/lib/_libspdl.pyi
+++ b/src/spdl/io/lib/_libspdl.pyi
@@ -60,6 +60,23 @@ class AudioPackets:
             The reconstructed packets.
         """
 
+    @staticmethod
+    def deserialize_view(data: memoryview) -> AudioPackets:
+        """
+        Reconstruct packets as a zero-copy view into ``data``.
+
+        The bytes are not copied: the packets point directly into ``data``,
+        which is kept alive for their lifetime. ``data`` must come from
+        ``__getstate__`` and must not be modified while the packets (or
+        non-clone references to them) are alive.
+
+        Args:
+            data: A memoryview over the serialized packets.
+
+        Returns:
+            The packets viewing ``data``.
+        """
+
     def __repr__(self) -> str: ...
 
     def __len__(self) -> int: ...
@@ -111,6 +128,23 @@ class VideoPackets:
 
         Returns:
             The reconstructed packets.
+        """
+
+    @staticmethod
+    def deserialize_view(data: memoryview) -> VideoPackets:
+        """
+        Reconstruct packets as a zero-copy view into ``data``.
+
+        The bytes are not copied: the packets point directly into ``data``,
+        which is kept alive for their lifetime. ``data`` must come from
+        ``__getstate__`` and must not be modified while the packets (or
+        non-clone references to them) are alive.
+
+        Args:
+            data: A memoryview over the serialized packets.
+
+        Returns:
+            The packets viewing ``data``.
         """
 
     def get_timestamps(self, *, raw: bool = False) -> list[float]:
@@ -199,6 +233,23 @@ class ImagePackets:
 
         Returns:
             The reconstructed packets.
+        """
+
+    @staticmethod
+    def deserialize_view(data: memoryview) -> ImagePackets:
+        """
+        Reconstruct packets as a zero-copy view into ``data``.
+
+        The bytes are not copied: the packets point directly into ``data``,
+        which is kept alive for their lifetime. ``data`` must come from
+        ``__getstate__`` and must not be modified while the packets (or
+        non-clone references to them) are alive.
+
+        Args:
+            data: A memoryview over the serialized packets.
+
+        Returns:
+            The packets viewing ``data``.
         """
 
     @property

--- a/src/spdl/io/lib/core/packets.cpp
+++ b/src/spdl/io/lib/core/packets.cpp
@@ -12,6 +12,8 @@
 #include <libspdl/core/rational_utils.h>
 #include <libspdl/core/types.h>
 
+#include "memoryview_utils.h"
+
 #include <nanobind/nanobind.h>
 #include <nanobind/stl/optional.h>
 #include <nanobind/stl/string.h>
@@ -76,7 +78,10 @@ void register_packets(nb::module_& m) {
       m,
       "AudioPackets",
       "Packets object containing audio samples.\n\n"
-      "See :doc:`../io/packets_frames_concepts` for information about the Packets base concept.")
+      "See :doc:`../io/packets_frames_concepts` for information about the Packets base concept.",
+      // Weak-referenceable so the memory arena can use a restored (view)
+      // packets object as the lifetime anchor for its shared-memory segment.
+      nb::is_weak_referenceable())
       .def(
           "__getstate__",
           [](const AudioPackets& self) {
@@ -102,6 +107,26 @@ void register_packets(nb::module_& m) {
           "    data: The serialized packets.\n\n"
           "Returns:\n"
           "    The reconstructed packets.")
+      .def_static(
+          "deserialize_view",
+          [](const nb::memoryview& data) -> AudioPacketsPtr {
+            auto sv = ::spdl::detail::memoryview_to_sv(data);
+            const auto* p = reinterpret_cast<const uint8_t*>(sv.data());
+            auto n = sv.size();
+            nb::gil_scoped_release g;
+            return deserialize_packets_view<MediaType::Audio>(p, n);
+          },
+          nb::arg("data"),
+          nb::keep_alive<0, 1>(),
+          "Reconstruct packets as a zero-copy view into ``data``.\n\n"
+          "The bytes are not copied: the packets point directly into ``data``,\n"
+          "which is kept alive for their lifetime. ``data`` must come from\n"
+          "``__getstate__`` and must not be modified while the packets (or\n"
+          "non-clone references to them) are alive.\n\n"
+          "Args:\n"
+          "    data: A memoryview over the serialized packets.\n\n"
+          "Returns:\n"
+          "    The packets viewing ``data``.")
       .def(
           "__repr__",
           [](const AudioPackets& self) {
@@ -178,7 +203,10 @@ void register_packets(nb::module_& m) {
       m,
       "VideoPackets",
       "Packets object containing video frames.\n\n"
-      "See :doc:`../io/packets_frames_concepts` for information about the Packets base concept.")
+      "See :doc:`../io/packets_frames_concepts` for information about the Packets base concept.",
+      // Weak-referenceable so the memory arena can use a restored (view)
+      // packets object as the lifetime anchor for its shared-memory segment.
+      nb::is_weak_referenceable())
       .def(
           "__getstate__",
           [](const VideoPackets& self) {
@@ -204,6 +232,26 @@ void register_packets(nb::module_& m) {
           "    data: The serialized packets.\n\n"
           "Returns:\n"
           "    The reconstructed packets.")
+      .def_static(
+          "deserialize_view",
+          [](const nb::memoryview& data) -> VideoPacketsPtr {
+            auto sv = ::spdl::detail::memoryview_to_sv(data);
+            const auto* p = reinterpret_cast<const uint8_t*>(sv.data());
+            auto n = sv.size();
+            nb::gil_scoped_release g;
+            return deserialize_packets_view<MediaType::Video>(p, n);
+          },
+          nb::arg("data"),
+          nb::keep_alive<0, 1>(),
+          "Reconstruct packets as a zero-copy view into ``data``.\n\n"
+          "The bytes are not copied: the packets point directly into ``data``,\n"
+          "which is kept alive for their lifetime. ``data`` must come from\n"
+          "``__getstate__`` and must not be modified while the packets (or\n"
+          "non-clone references to them) are alive.\n\n"
+          "Args:\n"
+          "    data: A memoryview over the serialized packets.\n\n"
+          "Returns:\n"
+          "    The packets viewing ``data``.")
       .def(
           "get_timestamps",
           [](const VideoPackets& self, bool raw) -> std::vector<double> {
@@ -322,7 +370,10 @@ void register_packets(nb::module_& m) {
       m,
       "ImagePackets",
       "Packets object contain an image frame.\n\n"
-      "See :doc:`../io/packets_frames_concepts` for information about the Packets base concept.")
+      "See :doc:`../io/packets_frames_concepts` for information about the Packets base concept.",
+      // Weak-referenceable so the memory arena can use a restored (view)
+      // packets object as the lifetime anchor for its shared-memory segment.
+      nb::is_weak_referenceable())
       .def(
           "__getstate__",
           [](const ImagePackets& self) {
@@ -348,6 +399,26 @@ void register_packets(nb::module_& m) {
           "    data: The serialized packets.\n\n"
           "Returns:\n"
           "    The reconstructed packets.")
+      .def_static(
+          "deserialize_view",
+          [](const nb::memoryview& data) -> ImagePacketsPtr {
+            auto sv = ::spdl::detail::memoryview_to_sv(data);
+            const auto* p = reinterpret_cast<const uint8_t*>(sv.data());
+            auto n = sv.size();
+            nb::gil_scoped_release g;
+            return deserialize_packets_view<MediaType::Image>(p, n);
+          },
+          nb::arg("data"),
+          nb::keep_alive<0, 1>(),
+          "Reconstruct packets as a zero-copy view into ``data``.\n\n"
+          "The bytes are not copied: the packets point directly into ``data``,\n"
+          "which is kept alive for their lifetime. ``data`` must come from\n"
+          "``__getstate__`` and must not be modified while the packets (or\n"
+          "non-clone references to them) are alive.\n\n"
+          "Args:\n"
+          "    data: A memoryview over the serialized packets.\n\n"
+          "Returns:\n"
+          "    The packets viewing ``data``.")
       .def_prop_ro(
           "pix_fmt",
           [](const ImagePackets& self) {

--- a/tests/io/serialization_test.py
+++ b/tests/io/serialization_test.py
@@ -208,3 +208,83 @@ class TestImagePacketsSerialization(unittest.TestCase):
         result = spdl.io.to_numpy(restored_buf)
 
         np.testing.assert_array_equal(original, result, strict=True)
+
+
+class TestPacketsDeserializeView(unittest.TestCase):
+    """Zero-copy ``deserialize_view``: packets point into the source buffer."""
+
+    def test_video_view_decodes_identically(self) -> None:
+        """A video view decodes to the same frames as the original packets."""
+        cmd = (
+            f"{FFMPEG_CLI} -hide_banner -y "
+            "-f lavfi -i testsrc=duration=1:size=64x64:rate=10 "
+            "-c:v libx264 -pix_fmt yuv420p sample.mp4"
+        )
+        sample = get_sample(cmd)
+        packets = spdl.io.demux_video(sample.path)
+        original = spdl.io.to_numpy(
+            spdl.io.convert_frames(spdl.io.decode_packets(packets.clone()))
+        )
+
+        state = packets.__getstate__()
+        view = spdl.io.VideoPackets.deserialize_view(memoryview(state))
+        result = spdl.io.to_numpy(spdl.io.convert_frames(spdl.io.decode_packets(view)))
+
+        np.testing.assert_array_equal(original, result, strict=True)
+
+    def test_audio_view_decodes_identically(self) -> None:
+        """An audio view decodes to the same samples as the original packets."""
+        cmd = (
+            f"{FFMPEG_CLI} -hide_banner -y "
+            "-f lavfi -i sine=frequency=440:duration=1 -c:a aac sample.mp4"
+        )
+        sample = get_sample(cmd)
+        packets = spdl.io.demux_audio(sample.path)
+        original = spdl.io.to_numpy(
+            spdl.io.convert_frames(spdl.io.decode_packets(packets.clone()))
+        )
+
+        state = packets.__getstate__()
+        view = spdl.io.AudioPackets.deserialize_view(memoryview(state))
+        result = spdl.io.to_numpy(spdl.io.convert_frames(spdl.io.decode_packets(view)))
+
+        np.testing.assert_array_equal(original, result, strict=True)
+
+    def test_image_view_decodes_identically(self) -> None:
+        """An image view decodes to the same pixels as the original packets."""
+        cmd = (
+            f"{FFMPEG_CLI} -hide_banner -y "
+            "-f lavfi -i testsrc=size=64x64 -frames:v 1 sample.png"
+        )
+        sample = get_sample(cmd)
+        packets = spdl.io.demux_image(sample.path)
+        original = spdl.io.to_numpy(
+            spdl.io.convert_frames(spdl.io.decode_packets(packets.clone()))
+        )
+
+        state = packets.__getstate__()
+        view = spdl.io.ImagePackets.deserialize_view(memoryview(state))
+        result = spdl.io.to_numpy(spdl.io.convert_frames(spdl.io.decode_packets(view)))
+
+        np.testing.assert_array_equal(original, result, strict=True)
+
+    def test_view_clone_survives_buffer_release(self) -> None:
+        """A clone of a view decodes even after the source buffer is dropped."""
+        cmd = (
+            f"{FFMPEG_CLI} -hide_banner -y "
+            "-f lavfi -i sine=frequency=440:duration=1 -c:a aac sample.mp4"
+        )
+        sample = get_sample(cmd)
+        packets = spdl.io.demux_audio(sample.path)
+        original = spdl.io.to_numpy(
+            spdl.io.convert_frames(spdl.io.decode_packets(packets.clone()))
+        )
+
+        state = packets.__getstate__()
+        view = spdl.io.AudioPackets.deserialize_view(memoryview(state))
+        clone = view.clone()  # deep-copies (view payloads are buf == NULL)
+        # Drop the view (releasing the kept-alive memoryview) and the bytes.
+        del view, state
+
+        result = spdl.io.to_numpy(spdl.io.convert_frames(spdl.io.decode_packets(clone)))
+        np.testing.assert_array_equal(original, result, strict=True)


### PR DESCRIPTION
Add a `deserialize_view(data: memoryview)` static method to `AudioPackets` / `VideoPackets` / `ImagePackets` that builds packets pointing directly into `data` (no payload copy) and uses `nb::keep_alive<0, 1>` so the source buffer is kept alive for the packets lifetime.

- `serialize_packets` now writes each packet payload followed by `AV_INPUT_BUFFER_PADDING_SIZE` zeroed bytes, so a payload can be restored as a zero-copy view that decoders can safely over-read. The byte format stays internal/process-local (no version bump); the copy `deserialize_packets` simply ignores the padding.
- Add `deserialize_packets_view(const uint8_t*, size_t)`: builds non-owning view packets whose `AVPacket::data` points directly into the caller-supplied buffer (`buf == NULL`); the returned Packets has `is_view == true`. The caller must keep the buffer alive. Cloning/reffing a view deep-copies (FFmpeg copies when `buf == NULL`), so derived packets are safe to outlive the buffer.
- Add an `is_view` flag to `Packets` (a `string`/`string_view`-style marker) and document the serialization format as internal/process-local.

Tests (all under the dev asan/ubsan config):
- libspdl gtests: a view aliases the serialized buffer with correct trailing padding; a clone deep-copies and stays valid after the backing buffer is freed/overwritten.
- smoke test: a real video decoder consumes view packets and produces the same frame count and buffer shape as decoding the originals.