### PR TITLE
[io] Align serialized packet payloads to 64 bytes for zero-copy views

### DIFF
--- a/src/libspdl/core/packets.cpp
+++ b/src/libspdl/core/packets.cpp
@@ -356,6 +356,13 @@ constexpr uint8_t SERIALIZATION_VERSION = 1;
 // (deserialize_packets_view) without copying it into an av_malloc'd buffer.
 constexpr size_t SERIALIZATION_PADDING = AV_INPUT_BUFFER_PADDING_SIZE;
 
+// Each payload is aligned to this many bytes *within the serialized blob*. When
+// the arena writer also places the blob on an aligned boundary, a zero-copy
+// view lands on an aligned address (some SIMD-optimized decoders need this). 64
+// bytes matches av_malloc and the widest SIMD. Keep in sync with the arena
+// writer's alignment (spdl/pipeline/_arena/_pool.py).
+constexpr size_t SERIALIZATION_ALIGNMENT = 64;
+
 class ByteWriter {
   std::vector<uint8_t>& buf_;
 
@@ -390,14 +397,25 @@ class ByteWriter {
     }
   }
 
-  // Write a packet payload: size, raw bytes, then SERIALIZATION_PADDING zeroed
-  // bytes so the payload can be restored as a zero-copy view.
+  // Pad the buffer with zeros up to the next SERIALIZATION_ALIGNMENT boundary
+  // (offsets are relative to the blob start).
+  void pad_to_alignment() {
+    if (auto rem = buf_.size() % SERIALIZATION_ALIGNMENT; rem != 0) {
+      buf_.insert(buf_.end(), SERIALIZATION_ALIGNMENT - rem, 0);
+    }
+  }
+
+  // Write a packet payload: size, alignment padding, raw bytes, then
+  // SERIALIZATION_PADDING zeroed bytes. The alignment padding places the
+  // payload on an aligned blob offset, and the trailing padding lets it be
+  // restored as a zero-copy view (decoders over-read the trailing padding).
   void write_payload(const uint8_t* data, int size) {
     if (!data || size <= 0) {
       write<int32_t>(0);
       return;
     }
     write<int32_t>(size);
+    pad_to_alignment();
     write_raw(data, size);
     buf_.insert(buf_.end(), SERIALIZATION_PADDING, 0);
   }
@@ -462,8 +480,16 @@ class ByteReader {
     offset_ += size;
   }
 
+  // Advance to the next SERIALIZATION_ALIGNMENT boundary (mirrors
+  // ByteWriter::pad_to_alignment).
+  void align_to_alignment() {
+    if (auto rem = offset_ % SERIALIZATION_ALIGNMENT; rem != 0) {
+      skip(SERIALIZATION_ALIGNMENT - rem);
+    }
+  }
+
   // Copy out a payload written by ByteWriter::write_payload (consumes the
-  // trailing padding).
+  // alignment padding and the trailing padding).
   std::vector<uint8_t> read_payload() {
     auto size = read<int32_t>();
     if (size < 0) {
@@ -471,6 +497,7 @@ class ByteReader {
     }
     std::vector<uint8_t> result(size);
     if (size > 0) {
+      align_to_alignment();
       read_raw(result.data(), size);
       skip(SERIALIZATION_PADDING);
     }
@@ -478,7 +505,8 @@ class ByteReader {
   }
 
   // Return a pointer to a payload in place and advance past it (and its
-  // padding) without copying. The pointer is valid while the buffer is alive.
+  // padding) without copying. The pointer sits on an aligned blob offset and is
+  // valid while the buffer is alive.
   std::pair<const uint8_t*, int> view_payload() {
     auto size = read<int32_t>();
     if (size < 0) {
@@ -487,6 +515,7 @@ class ByteReader {
     if (size == 0) {
       return {nullptr, 0};
     }
+    align_to_alignment();
     const uint8_t* p = peek();
     skip(static_cast<size_t>(size) + SERIALIZATION_PADDING);
     return {p, size};

--- a/src/libspdl/tests/packets_serialization_test.cpp
+++ b/src/libspdl/tests/packets_serialization_test.cpp
@@ -193,6 +193,11 @@ TEST(PacketsSerializationTest, ViewAliasesBufferWithPadding) {
     ASSERT_EQ(got[i]->size, orig[i]->size);
     EXPECT_EQ(0, std::memcmp(got[i]->data, orig[i]->data, got[i]->size));
 
+    // Payload sits on a 64-byte-aligned blob offset, so it lands on an aligned
+    // address once the arena writer places the blob on an aligned boundary
+    // (matches SERIALIZATION_ALIGNMENT in packets.cpp).
+    EXPECT_EQ((got[i]->data - lo) % 64, 0);
+
     // The trailing padding decoders may over-read is present and zeroed.
     ASSERT_LE(got[i]->data + got[i]->size + AV_INPUT_BUFFER_PADDING_SIZE, hi);
     for (int p = 0; p < AV_INPUT_BUFFER_PADDING_SIZE; ++p) {


### PR DESCRIPTION
Pad each serialized packet payload to a 64-byte boundary *within the serialized blob* in libspdl's `serialize_packets`, so that a payload later restored as a zero-copy view lands on an aligned absolute address. Some SIMD-optimized FFmpeg decoders require this (and the rest run faster on it). `SERIALIZATION_ALIGNMENT = 64` matches `av_malloc` and the widest SIMD (AVX-512).

Implementation: `ByteWriter::write_payload` now writes the size, calls `pad_to_alignment` to zero-pad up to the next 64-byte blob offset, then the raw bytes and the existing trailing `SERIALIZATION_PADDING`. Both readers mirror it with `ByteReader::align_to_alignment` before reading: the copy path (`read_payload`, used by `deserialize`) and the zero-copy path (`view_payload`, used by `deserialize_view`).

Because the writer and both readers move together, `serialize -> deserialize` round-trips byte-for-byte. Regular (non-arena) packet IPC — pickle via the copyreg reducer, `copy.deepcopy`, etc. — is therefore unaffected in behavior; the only difference is up to 63 bytes of alignment padding per payload, which the copy reader skips (the copy lands in an `av_malloc`'d buffer that is already aligned, so the padding is harmless there). The serialized form stays internal and process-local; no version bump.