### PR TITLE
Add shared-memory arena framework for iterate_in_subprocess (#1520)

### DIFF
--- a/src/spdl/pipeline/_arena/__init__.py
+++ b/src/spdl/pipeline/_arena/__init__.py
@@ -1,0 +1,19 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""Shared-memory arena for moving large payloads across processes."""
+
+from ._arena import _Arena
+from ._protocol import ArenaProtocol, ArenaReaderProtocol, ArenaWriterProtocol
+
+__all__ = [
+    "ArenaProtocol",
+    "ArenaReaderProtocol",
+    "ArenaWriterProtocol",
+    "_Arena",
+]

--- a/src/spdl/pipeline/_arena/_arena.py
+++ b/src/spdl/pipeline/_arena/_arena.py
@@ -1,0 +1,89 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""Per-process wrapper bundling an arena with its endpoints and registry."""
+
+from __future__ import annotations
+
+from ._offload import _offload, _restore
+from ._protocol import ArenaProtocol, ArenaReaderProtocol, ArenaWriterProtocol
+from ._registry import _default_registry, _OffloadRegistry
+
+__all__ = ["_Arena"]
+
+
+class _Arena:
+    """Bundles an arena with its lazily-created writer / reader / registry.
+
+    The worker side offloads through :py:attr:`writer` + :py:attr:`registry`; the
+    parent side restores through :py:attr:`reader` + :py:attr:`registry`. Each
+    endpoint and the registry is created on first access and cached (delayed
+    initialization), so a process only opens the side it actually uses — the
+    worker never opens a reader, the parent never opens a writer.
+
+    Construct one per process from the shared arena (or skip it entirely when no
+    arena is in use), so a single ``if arena is not None`` covers "is an arena in
+    use?" without juggling the endpoint and registry as separate optionals.
+    """
+
+    def __init__(self, arena: ArenaProtocol) -> None:
+        self._arena = arena
+        self._writer: ArenaWriterProtocol | None = None
+        self._reader: ArenaReaderProtocol | None = None
+        self._registry: _OffloadRegistry | None = None
+
+    @property
+    def writer(self) -> ArenaWriterProtocol:
+        """The arena's writer endpoint (opened once, on first access)."""
+        if self._writer is None:
+            self._writer = self._arena.open_writer()
+        return self._writer
+
+    @property
+    def reader(self) -> ArenaReaderProtocol:
+        """The arena's reader endpoint (opened once, on first access)."""
+        if self._reader is None:
+            self._reader = self._arena.open_reader()
+        return self._reader
+
+    @property
+    def registry(self) -> _OffloadRegistry:
+        """The offload registry (created once, on first access)."""
+        if self._registry is None:
+            self._registry = _default_registry()
+        return self._registry
+
+    def offload(self, obj: object) -> bytes:
+        """Offload ``obj``'s large fields into the arena; return the envelope.
+
+        Worker-side convenience over :py:func:`_offload` bound to this object's
+        :py:attr:`writer` and :py:attr:`registry`.
+
+        Args:
+            obj: The (picklable) item to offload.
+
+        Returns:
+            The small envelope to put on the inter-process queue; pass it to
+            :py:meth:`restore` on the parent side.
+        """
+        return _offload(obj, self.writer, self.registry)
+
+    def restore(self, blob: bytes) -> object:
+        """Reconstruct an object produced by :py:meth:`offload`.
+
+        Parent-side convenience over :py:func:`_restore` bound to this object's
+        :py:attr:`reader` and :py:attr:`registry`.
+
+        Args:
+            blob: The envelope produced by :py:meth:`offload`.
+
+        Returns:
+            The restored object (offloaded fields aliasing shared memory or
+            copied out, per the backend).
+        """
+        return _restore(blob, self.reader, self.registry)

--- a/src/spdl/pipeline/_arena/_marker.py
+++ b/src/spdl/pipeline/_arena/_marker.py
@@ -1,0 +1,36 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""Marker referencing an offloaded binary stored in a shared-memory arena."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+__all__ = ["_ShmMarker"]
+
+
+@dataclass(frozen=True)
+class _ShmMarker:
+    """Replaces an offloaded binary in the pickled envelope on the queue.
+
+    An instance is produced by the pickler's ``persistent_id`` on the writer
+    side and consumed by ``persistent_load`` on the reader side.
+    """
+
+    offset: int
+    """Physical byte offset of the payload within the arena's data region."""
+
+    nbytes: int
+    """Number of bytes of the payload."""
+
+    kind: str
+    """Registry key identifying how to reconstruct the object (e.g. ``"bytes"``)."""
+
+    meta: tuple[object, ...]
+    """Extra data needed to reconstruct (e.g. ``(dtype, shape)`` for arrays)."""

--- a/src/spdl/pipeline/_arena/_offload.py
+++ b/src/spdl/pipeline/_arena/_offload.py
@@ -1,0 +1,182 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""Offload large fields of an object into the arena and restore them.
+
+``_offload`` pickles an object with a custom ``persistent_id`` that diverts
+offloadable leaves (large ``bytes``, NumPy arrays, Torch tensors, and
+``spdl.io`` Packets) into the shared-memory writer, leaving a small
+:py:class:`_ShmMarker` in the pickle
+stream. ``_restore`` reverses it with a matching ``persistent_load``. Nested
+collections (dict/list/dataclass) are handled automatically by pickle.
+
+The returned envelope is ``<8-byte unit span><pickled small object>``; the span
+lets the reader return the whole unit's region in one bulk call regardless of
+how the binaries are laid out.
+"""
+
+from __future__ import annotations
+
+import io
+import pickle
+import struct
+
+from ._marker import _ShmMarker
+from ._protocol import ArenaReaderProtocol, ArenaWriterProtocol
+from ._registry import _OffloadRegistry
+
+__all__ = ["_DEFAULT_OFFLOAD_THRESHOLD", "_offload", "_restore"]
+
+_DEFAULT_OFFLOAD_THRESHOLD: int = 4096
+
+_SPAN: struct.Struct = struct.Struct("<Q")
+
+
+def _offload(
+    obj: object,
+    writer: ArenaWriterProtocol,
+    registry: _OffloadRegistry,
+    threshold: int = _DEFAULT_OFFLOAD_THRESHOLD,
+) -> bytes:
+    """Offload large fields of ``obj`` and return the small picklable envelope.
+
+    Walks ``obj`` with a custom pickler whose ``persistent_id`` diverts each
+    offloadable leaf — large ``bytes``, NumPy arrays, Torch tensors, etc., as
+    determined by ``registry`` — into ``writer``'s shared-memory region and
+    leaves a small :py:class:`_ShmMarker` in the pickle stream. Nested
+    collections (``dict`` / ``list`` / dataclass / ...) are traversed by pickle
+    automatically, so callers do not need to know the shape of ``obj``.
+
+    The writer is bracketed with ``begin_unit`` / ``commit_unit`` so all
+    binaries from a single ``_offload`` call form one unit; on any exception
+    (unpicklable object, arena reservation failure, ...) the in-progress unit
+    is rolled back via ``abort_unit`` and the original exception re-raised.
+
+    The returned envelope is ``<8-byte unit span><pickled small object>``. The
+    span — the total byte range of the unit in the arena — lets the matching
+    :py:func:`_restore` return the whole unit's region in one bulk call without
+    having to re-walk the binaries.
+
+    Args:
+        obj: The object to offload. May be any picklable value; offloadable
+            leaves are diverted into the arena, the rest is pickled inline.
+        writer: Arena writer endpoint produced by
+            :py:meth:`ArenaProtocol.open_writer`. Receives the offloaded
+            binaries.
+        registry: Decides which leaves get offloaded and how to expose their
+            bytes — typically the result of :py:func:`_default_registry`.
+        threshold: Minimum size in bytes for a leaf to be eligible for
+            offloading. Smaller values are pickled inline. Defaults to
+            :py:data:`_DEFAULT_OFFLOAD_THRESHOLD`.
+
+    Returns:
+        The small envelope to put on the inter-process queue: an 8-byte
+        little-endian unit span followed by the pickled object (with
+        :py:class:`_ShmMarker` instances in place of the offloaded leaves).
+        Pass it to :py:func:`_restore` on the reader side.
+
+    Example:
+        >>> arena = SharedMemoryRingBuffer(capacity=64 * 1024 * 1024)
+        >>> writer = arena.open_writer()
+        >>> registry = _default_registry()
+        >>> envelope = _offload({"img": large_bytes}, writer, registry)
+        >>> queue.put(envelope)  # small payload, no large bytes pickled
+    """
+    writer.begin_unit()
+    buf = io.BytesIO()
+    pickler = pickle.Pickler(buf, protocol=pickle.HIGHEST_PROTOCOL)
+
+    def persistent_id(o: object) -> _ShmMarker | None:
+        handler = registry.handler_for(o, threshold)
+        if handler is None:
+            return None
+        # get_buffer exposes the object's bytes without copying; write_binary
+        # performs the single copy into shared memory.
+        src, meta = handler.get_buffer(o)
+        offset, nbytes = writer.write_binary(src)
+        return _ShmMarker(offset, nbytes, handler.kind, meta)
+
+    pickler.persistent_id = persistent_id  # type: ignore[method-assign]
+    try:
+        pickler.dump(obj)
+    except BaseException:
+        # Roll back the in-progress unit so the writer is not left mid-unit
+        # (e.g. on an unpicklable object or an arena reservation failure).
+        writer.abort_unit()
+        raise
+    span = writer.commit_unit()
+    return _SPAN.pack(span) + buf.getvalue()
+
+
+def _restore(
+    blob: bytes,
+    reader: ArenaReaderProtocol,
+    registry: _OffloadRegistry,
+) -> object:
+    """Reconstruct an object produced by :py:func:`_offload`.
+
+    Reads the 8-byte unit span prefix, unpickles the small body with a custom
+    ``persistent_load`` that turns each :py:class:`_ShmMarker` back into the
+    original object by reading the binary from ``reader`` and asking the
+    matching handler in ``registry`` to rebuild it.
+
+    Zero-copy views of shared memory keep their backing region alive through
+    *anchors* returned by handlers. Anchors are collected for the duration of
+    the call and handed to ``reader.end_unit`` together with the unit span;
+    the backend reclaims the unit's region either immediately (ring / copied
+    out) or once every anchor is garbage-collected (segment pool / zero-copy).
+    ``end_unit`` runs in ``finally`` so accounting stays correct even if
+    unpickling raises.
+
+    Args:
+        blob: The envelope produced by :py:func:`_offload` — an 8-byte
+            little-endian unit span followed by a pickled object with
+            :py:class:`_ShmMarker` instances in place of offloaded leaves.
+        reader: Arena reader endpoint produced by
+            :py:meth:`ArenaProtocol.open_reader`. Provides access to the
+            offloaded binaries and signals end-of-unit.
+        registry: Same registry shape used on the writer side. Each
+            marker's ``kind`` is looked up here to find the handler that
+            knows how to rebuild that type.
+
+    Returns:
+        The object originally passed to :py:func:`_offload`, with offloaded
+        leaves either copied out (ring) or aliasing shared memory through
+        anchors held by ``reader`` (segment pool). The exact restored type
+        for ``bytes`` / ``bytearray`` / ``memoryview`` depends on the
+        backend — see :py:class:`~spdl.pipeline._arena._registry._BytesHandler`.
+
+    Example:
+        >>> reader = arena.open_reader()
+        >>> registry = _default_registry()
+        >>> envelope = queue.get()
+        >>> obj = _restore(envelope, reader, registry)
+    """
+    span = int(_SPAN.unpack_from(blob, 0)[0])
+    unpickler = pickle.Unpickler(io.BytesIO(blob[_SPAN.size :]))
+    # Lifetime anchors for zero-copy fields (e.g. the np.frombuffer array). The
+    # backend keeps the underlying region alive until these are released.
+    pinned: list[object] = []
+
+    def persistent_load(marker: object) -> object:
+        assert isinstance(marker, _ShmMarker)
+        handler = registry.handler(marker.kind)
+        view = reader.read_binary(marker.offset, marker.nbytes)
+        obj, anchor = handler.from_buffer(view, marker.meta, reader.zero_copy)
+        if anchor is not None:
+            pinned.append(anchor)
+        return obj
+
+    unpickler.persistent_load = persistent_load  # type: ignore[method-assign]
+    try:
+        return unpickler.load()
+    finally:
+        # Tell the backend the unit is fully read. It reclaims the region now
+        # (ring / copy-out) or once every anchor is released (segment pool /
+        # zero-copy). Always runs, so accounting stays correct even on error.
+        reader.end_unit(span, pinned)

--- a/src/spdl/pipeline/_arena/_protocol.py
+++ b/src/spdl/pipeline/_arena/_protocol.py
@@ -1,0 +1,242 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""Structural interfaces shared by arena backends.
+
+These let ``iterate_in_subprocess`` accept any arena object through one
+``arena`` argument and dispatch on its type. The single ring
+(:py:class:`~spdl.pipeline._arena._ring.SharedMemoryRingBuffer`) and the rotating
+segment pool (:py:class:`~spdl.pipeline._arena._pool.SharedMemorySegmentPool`)
+both satisfy these protocols structurally.
+
+A unit is one pipeline item (possibly several binaries). The writer brackets a
+unit with ``begin_unit`` / ``commit_unit`` and the reader returns it with
+``end_unit``, so reservation and return happen in bulk per unit regardless of
+the backend.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+__all__ = ["ArenaProtocol", "ArenaReaderProtocol", "ArenaWriterProtocol"]
+
+
+class ArenaWriterProtocol(Protocol):
+    """Writer endpoint: the last step in the worker process.
+
+    Backends implement this protocol to receive offloaded binaries. A *unit*
+    is one pipeline item: it groups all binaries produced by a single
+    :py:func:`_offload` call so they can be reserved
+    and returned to the arena in bulk. Methods are called from a single
+    thread in the worker; they need not be thread-safe.
+    """
+
+    def reset(self) -> None:
+        """Reset per-iteration state at an iteration boundary.
+
+        Called by the worker once per ``START_ITERATION``, while the parent
+        is quiescent. Backends should reclaim any space that leaked across
+        the boundary (e.g. units the parent never read) and return the
+        writer to a clean starting state.
+
+        Returns:
+            None.
+        """
+        ...
+
+    def begin_unit(self) -> None:
+        """Open a new unit before any :py:meth:`write_binary` calls.
+
+        Must be paired with exactly one terminal call —
+        :py:meth:`commit_unit` on success or :py:meth:`abort_unit` on
+        failure. Calling :py:meth:`write_binary` outside an open unit is
+        an error.
+
+        Returns:
+            None.
+        """
+        ...
+
+    def write_binary(
+        self, data: "bytes | bytearray | memoryview[bytes]"
+    ) -> tuple[int, int]:
+        """Copy one binary into the arena and return its placement.
+
+        Performs the single copy from ``data`` into shared memory; the
+        caller is expected to have already exposed the source as a flat,
+        contiguous byte view (no further copies on the source side).
+
+        Args:
+            data: Bytes-like source buffer. Must be flat and contiguous.
+
+        Returns:
+            ``(offset, nbytes)`` where ``offset`` is the physical byte
+            offset of the payload within the arena's data region and
+            ``nbytes`` is the number of bytes written. Both values are
+            stored on the matching :py:class:`_ShmMarker` and used by
+            :py:meth:`ArenaReaderProtocol.read_binary` to retrieve the
+            payload on the reader side.
+        """
+        ...
+
+    def commit_unit(self) -> int:
+        """Close the current unit and return its span.
+
+        Marks the unit as readable by the parent. After this call the
+        writer is no longer in a unit; another :py:meth:`begin_unit` is
+        required before further writes.
+
+        Returns:
+            The unit's *span*: the total byte range the unit occupies in
+            the arena. The caller (typically :py:func:`_offload`) embeds
+            this in the envelope so the reader can return the whole
+            region in one :py:meth:`ArenaReaderProtocol.end_unit` call.
+        """
+        ...
+
+    def abort_unit(self) -> None:
+        """Roll back the in-progress unit on failure.
+
+        Discards any binaries written since :py:meth:`begin_unit` and
+        leaves the writer outside of a unit, ready for another
+        :py:meth:`begin_unit`. Called when offloading raises (e.g. an
+        unpicklable field or a reservation failure) so the writer is not
+        left mid-unit.
+
+        Returns:
+            None.
+        """
+        ...
+
+
+class ArenaReaderProtocol(Protocol):
+    """Reader endpoint: the first step in the parent process.
+
+    Backends implement this protocol to surface offloaded binaries to
+    :py:func:`_restore`. Methods are called from the
+    parent process's consumer thread and need not be thread-safe.
+    """
+
+    zero_copy: bool
+    """Whether :py:meth:`read_binary` hands out live, reusable views into
+    shared memory (segment pool) rather than private copies (ring).
+    Handlers use this flag to choose between a zero-copy view and an
+    owning / copied-out restore."""
+
+    def reset(self) -> None:
+        """Reset per-iteration state at an iteration boundary.
+
+        Called by the parent once per iteration, after the worker has
+        signaled ``ITERATION_STARTED`` and before the first item is
+        consumed. Backends should clear any per-iteration cursors so the
+        reader matches the writer's freshly-reset state.
+
+        Returns:
+            None.
+        """
+        ...
+
+    def read_binary(self, offset: int, nbytes: int) -> "memoryview[bytes]":
+        """Return the bytes for one offloaded binary.
+
+        Args:
+            offset: Physical byte offset in the arena (as returned by
+                :py:meth:`ArenaWriterProtocol.write_binary`).
+            nbytes: Number of bytes of the payload.
+
+        Returns:
+            A :py:class:`memoryview` of exactly ``nbytes`` bytes. With
+            ``zero_copy=True`` (segment pool) the view aliases shared
+            memory and remains valid as long as a corresponding anchor is
+            kept alive (see :py:meth:`end_unit`); with ``zero_copy=False``
+            (ring) the bytes have already been copied out into a private
+            per-unit buffer.
+        """
+        ...
+
+    def end_unit(self, span: int, pinned: list[object]) -> None:
+        """Signal that one unit has been fully read.
+
+        Args:
+            span: The unit's span as returned by
+                :py:meth:`ArenaWriterProtocol.commit_unit`. Lets the
+                backend release the entire region in bulk regardless of
+                how the binaries are laid out.
+            pinned: Lifetime anchors for any zero-copy views handed out
+                from this unit (e.g. ``np.frombuffer`` arrays). The
+                backend must keep the underlying region alive until every
+                anchor in this list is released; with copy-out backends
+                the list is typically empty and ignored.
+
+        Returns:
+            None. Called from a ``finally`` block in
+            :py:func:`_restore`, so accounting stays
+            correct even if unpickling raised.
+        """
+        ...
+
+
+class ArenaProtocol(Protocol):
+    """An arena object passed to ``iterate_in_subprocess`` via ``arena``.
+
+    Owns the shared-memory segment and produces the writer / reader
+    endpoints used on each side of the inter-process boundary. The
+    arena is created and owned by the parent, passed to the worker
+    through process spawn arguments, and torn down by the parent after
+    the worker is confirmed dead.
+    """
+
+    def open_writer(self) -> ArenaWriterProtocol:
+        """Open the writer endpoint for the worker side.
+
+        Should be called once per arena, in the worker process, before
+        the first item is offloaded. The returned writer is the last
+        step in the worker pipeline.
+
+        Returns:
+            A fresh :py:class:`ArenaWriterProtocol` bound to this arena.
+        """
+        ...
+
+    def open_reader(self) -> ArenaReaderProtocol:
+        """Open the reader endpoint for the parent side.
+
+        Should be called once per arena, in the parent process, before
+        the first item is consumed. The returned reader is the first
+        step in the parent pipeline.
+
+        Returns:
+            A fresh :py:class:`ArenaReaderProtocol` bound to this arena.
+        """
+        ...
+
+    def close(self) -> None:
+        """Release this process's handle to the shared-memory segment.
+
+        Called by the parent during teardown after the worker has been
+        confirmed dead. Does not destroy the OS-level segment — see
+        :py:meth:`unlink` for that. Safe to call once per arena.
+
+        Returns:
+            None.
+        """
+        ...
+
+    def unlink(self) -> None:
+        """Destroy the OS-level shared-memory segment.
+
+        Called by the parent during teardown, in a ``finally`` after
+        :py:meth:`close`, so a failing ``close`` cannot leak the segment.
+        Must be called exactly once per arena and only after every
+        process that mapped the segment has released its handle.
+
+        Returns:
+            None.
+        """
+        ...

--- a/src/spdl/pipeline/_arena/_registry.py
+++ b/src/spdl/pipeline/_arena/_registry.py
@@ -1,0 +1,417 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""Registry deciding which objects are offloaded to the arena and how.
+
+A handler decides whether an object should be offloaded (``matches``), exposes
+its raw bytes as a zero-copy source buffer (``get_buffer``) so the arena can copy
+it into shared memory exactly once, and rebuilds it from a destination buffer
+(``from_buffer``).
+
+``from_buffer`` receives the destination buffer plus a ``zero_copy`` flag: true
+for the segment pool (whose buffer is a live, reusable view into shared memory),
+false for the ring (which already copied the bytes out into a private per-unit
+buffer). A handler restores a zero-copy view when ``zero_copy`` is true and an
+owning / copied-out value when it is false — so the restored type can differ
+between backends (see :py:class:`_BytesHandler`).
+
+``from_buffer`` returns ``(object, anchor)``: the restored object, plus an
+*anchor* whose lifetime equals "some view of the shared-memory segment is still
+alive" (e.g. the ``np.frombuffer`` array, or a restored ``memoryview`` itself),
+or ``None`` when the object does not alias a reusable segment — i.e. always on the
+ring (copied out), and on the pool only for the off-switch copy paths. For the
+segment-pool backend a non-``None`` anchor keeps the segment reserved until it is
+garbage-collected. The anchor is returned separately because views and shallow
+copies of a NumPy array / Torch tensor share the buffer but are different objects,
+and — importantly — NumPy/Torch do not retain the exact ``memoryview`` passed in,
+so it cannot be used as the anchor (a plain ``memoryview``, by contrast, *is* its
+own anchor — it keeps the buffer exported and is weak-referenceable).
+
+NumPy and Torch are reached through ``lazy_import`` so ``import spdl.pipeline``
+works without them installed and they never become hard Buck dependencies. A
+handler only touches its module after a cheap module-name check, so unrelated
+objects never trigger the import.
+"""
+
+from __future__ import annotations
+
+from types import ModuleType
+from typing import Any, Protocol
+
+from spdl._internal.import_utils import lazy_import
+
+__all__ = ["_OffloadHandlerProtocol", "_OffloadRegistry", "_default_registry"]
+
+np: ModuleType = lazy_import("numpy")
+torch: ModuleType = lazy_import("torch")
+
+
+class _OffloadHandlerProtocol(Protocol):
+    """Interface for a type that can be offloaded to the arena.
+
+    A handler teaches the registry how to move one family of objects (e.g.
+    ``bytes``, NumPy arrays, Torch tensors) through a shared-memory arena: whether
+    a given object is worth offloading (:py:meth:`matches`), how to expose its
+    bytes as a single source buffer for the one copy into shared memory
+    (:py:meth:`get_buffer`), and how to rebuild it on the reader side
+    (:py:meth:`from_buffer`). Third-party handlers implement this protocol and are
+    passed to :py:class:`_OffloadRegistry`.
+    """
+
+    kind: str
+    """Stable registry key identifying this handler (e.g. ``"bytes"``,
+    ``"numpy"``). Stored on each :py:class:`_ShmMarker` so :py:func:`_restore` can
+    look the handler back up; must be unique within a registry."""
+
+    def matches(self, obj: object, threshold: int) -> bool:
+        """Return whether this handler should offload ``obj``.
+
+        Called for every leaf the pickler encounters, so it must be cheap and
+        side-effect-free for objects it does not handle (e.g. probe the type name
+        before touching a heavy, lazily-imported module).
+
+        Args:
+            obj: The candidate leaf object being pickled.
+            threshold: Minimum payload size in bytes for offloading to be
+                worthwhile; objects smaller than this should be left inline
+                (return ``False``).
+
+        Returns:
+            ``True`` if this handler will offload ``obj`` (the registry then calls
+            :py:meth:`get_buffer`), ``False`` to leave it to another handler or to
+            inline pickling.
+        """
+        ...
+
+    def get_buffer(
+        self, obj: object
+    ) -> tuple["bytes | bytearray | memoryview[bytes]", tuple[object, ...]]:
+        """Expose ``obj``'s payload as one source buffer plus rebuild metadata.
+
+        Should not copy: return a flat, contiguous view over the object's own
+        bytes — the arena's ``write_binary`` performs the single copy into shared
+        memory. Any non-byte information needed to reconstruct the object (dtype,
+        shape, original type, ...) is returned as ``meta``.
+
+        Args:
+            obj: The object to offload; guaranteed to be one that this handler's
+                :py:meth:`matches` accepted.
+
+        Returns:
+            A ``(buffer, meta)`` pair. ``buffer`` is a bytes-like, contiguous
+            source for the single copy into the arena; ``meta`` is a picklable
+            tuple carried on the :py:class:`_ShmMarker` and handed back to
+            :py:meth:`from_buffer` to rebuild the object.
+        """
+        ...
+
+    def from_buffer(
+        self, buf: "memoryview[bytes]", meta: tuple[object, ...], zero_copy: bool
+    ) -> tuple[object, object | None]:
+        """Reconstruct the object from its payload bytes in the arena.
+
+        Args:
+            buf: The payload bytes read back from the arena. When ``zero_copy`` is
+                ``True`` this aliases shared memory and stays valid only while a
+                returned anchor is alive; when ``False`` it is a private copy.
+            meta: The tuple produced by :py:meth:`get_buffer` for this object.
+            zero_copy: ``True`` if ``buf`` is a live, reusable view into shared
+                memory (segment pool); ``False`` if it was already copied out
+                (ring). Handlers restore a zero-copy view in the former case and
+                an owning value in the latter, so the restored type may differ
+                between backends.
+
+        Returns:
+            An ``(object, anchor)`` pair: the restored object, plus an *anchor*
+            whose lifetime keeps any zero-copy view of ``buf`` valid — collected
+            by :py:func:`_restore` and handed to
+            :py:meth:`ArenaReaderProtocol.end_unit` — or ``None`` when the
+            restored object does not alias a reusable segment.
+        """
+        ...
+
+
+class _BytesHandler:
+    """Offload bytes-like objects: ``bytes``, ``bytearray``, and ``memoryview``.
+
+    All three are written into the arena identically. Restore is
+    backend-dependent:
+
+    * Ring buffer (copy backend): the bytes are copied out and the *original* type
+      is reconstructed — ``bytes`` -> ``bytes``, ``bytearray`` -> ``bytearray``,
+      ``memoryview`` -> ``memoryview`` (over the private per-unit copy). Type (and,
+      for ``bytes``/``bytearray``, mutability) matches the input.
+    * Segment pool (zero-copy backend): the copy is deferred and **all three**
+      return a ``memoryview`` aliasing shared memory. That memoryview is its own
+      lifetime anchor (it keeps the buffer exported and is weak-referenceable), so
+      the pool holds the segment until it is released. The restored value is
+      therefore a (writable) ``memoryview`` regardless of the input type — wrap it
+      in ``bytes(...)`` / ``bytearray(...)`` for an owning copy. This discrepancy
+      is the price of the opt-in zero-copy path.
+
+    ``meta`` carries the original type so the ring can rebuild it.
+    """
+
+    kind: str = "bytes"
+
+    def matches(self, obj: object, threshold: int) -> bool:
+        if not isinstance(obj, (bytes, bytearray, memoryview)):
+            return False
+        nbytes = obj.nbytes if isinstance(obj, memoryview) else len(obj)
+        return nbytes >= threshold
+
+    def get_buffer(
+        self, obj: object
+    ) -> tuple["bytes | bytearray | memoryview[bytes]", tuple[object, ...]]:
+        # Expose the input's bytes as a flat, contiguous byte view — no copy for
+        # the common contiguous case (write_binary performs the single copy into
+        # shared memory); a non-contiguous memoryview is flattened into a copy.
+        # meta carries the original type so the ring backend can reconstruct it.
+        mv = memoryview(obj)
+        src = mv.cast("B") if mv.contiguous else memoryview(mv.tobytes())
+        return src, (type(obj),)
+
+    def from_buffer(
+        self, buf: "memoryview[bytes]", meta: tuple[object, ...], zero_copy: bool
+    ) -> tuple[object, object | None]:
+        if zero_copy:
+            # Segment pool: defer the copy — hand back a zero-copy memoryview into
+            # shared memory. It is its own lifetime anchor, so the pool holds the
+            # segment until the view is released. (bytes/bytearray inputs come back
+            # as memoryview here; that is the accepted zero-copy discrepancy.)
+            return buf, buf
+        # Ring: the bytes were copied out into a private per-unit buffer — rebuild
+        # the original type so the restored value matches what was sent. No anchor:
+        # nothing aliases a reusable segment.
+        (orig_type,) = meta
+        if orig_type is bytearray:
+            return bytearray(buf), None
+        if orig_type is memoryview:
+            return buf, None  # ``buf`` already views the private per-unit copy
+        return bytes(buf), None
+
+
+class _NumpyHandler:
+    kind: str = "numpy"
+
+    def matches(self, obj: object, threshold: int) -> bool:
+        # Cheap module-name probe first so unrelated objects never realize the
+        # lazily-imported numpy module; then duck-type (the lazy module is typed
+        # ``Any``, so ``isinstance`` cannot narrow here).
+        if type(obj).__module__.split(".", 1)[0] != "numpy":
+            return False
+        if type(obj).__name__ != "ndarray":
+            return False
+        arr: Any = obj
+        return int(arr.nbytes) >= threshold
+
+    def get_buffer(
+        self, obj: object
+    ) -> tuple["bytes | bytearray | memoryview[bytes]", tuple[object, ...]]:
+        arr: Any = np.ascontiguousarray(obj)
+        # memoryview over the array's own buffer — no copy (the single copy into
+        # shared memory happens in the arena's write_binary).
+        return memoryview(arr).cast("B"), (arr.dtype.str, tuple(arr.shape))
+
+    def from_buffer(
+        self, buf: "memoryview[bytes]", meta: tuple[object, ...], zero_copy: bool
+    ) -> tuple[object, object | None]:
+        dtype_str, shape = meta
+        # np.frombuffer aliases ``buf`` (no copy); for the segment pool this is a
+        # live view into shared memory, for the ring it views the copied-out
+        # bytes that read_binary already produced. The anchor matters only for the
+        # pool: ``arr`` is its lifetime anchor (every reshape/slice/view of the
+        # result keeps it — and thus the segment — alive, whereas the reshaped
+        # object can be dropped while a view of it survives). On the ring the bytes
+        # are already a private copy the array keeps alive, so no anchor is needed.
+        arr: Any = np.frombuffer(buf, dtype=np.dtype(dtype_str))
+        return arr.reshape(shape), (arr if zero_copy else None)
+
+
+class _TorchHandler:
+    kind: str = "torch"
+
+    def matches(self, obj: object, threshold: int) -> bool:
+        if type(obj).__module__.split(".", 1)[0] != "torch":
+            return False
+        if type(obj).__name__ != "Tensor":
+            return False
+        t: Any = obj
+        if not t.is_cpu:
+            return False
+        return int(t.element_size()) * int(t.nelement()) >= threshold
+
+    def get_buffer(
+        self, obj: object
+    ) -> tuple["bytes | bytearray | memoryview[bytes]", tuple[object, ...]]:
+        t: Any = obj.detach().contiguous().cpu()  # type: ignore[attr-defined]
+        # t.numpy() shares the tensor's storage (no copy for a contiguous CPU
+        # tensor); memoryview over it stays a view.
+        return memoryview(t.numpy()).cast("B"), (str(t.dtype), tuple(t.shape))
+
+    def from_buffer(
+        self, buf: "memoryview[bytes]", meta: tuple[object, ...], zero_copy: bool
+    ) -> tuple[object, object | None]:
+        dtype_str, shape = meta
+        dtype = getattr(torch, str(dtype_str).split(".")[-1])
+        # As for NumPy, ``t`` is the pool's lifetime anchor (views keep the base
+        # tensor alive); the ring copied the bytes out, so no anchor is needed.
+        t: Any = torch.frombuffer(buf, dtype=dtype)
+        return t.reshape(shape), (t if zero_copy else None)
+
+
+class _PacketsHandler:
+    """Offload ``spdl.io`` ``AudioPackets`` / ``VideoPackets`` / ``ImagePackets``.
+
+    Packets wrap compressed media buffers — exactly the large binaries this
+    feature targets — but expose no array-style buffer protocol. Their bytes are
+    only reachable through ``serialize_packets`` (the C++ ``__getstate__``, the
+    same path pickle takes), and that call is also the only way to learn their
+    size. To avoid serializing twice, ``matches`` (which must size the object)
+    caches the bytes for the ``get_buffer`` that immediately follows it.
+
+    On restore the bytes are handed to the class's public ``deserialize_view``
+    static method (carried in ``meta``), which builds a Packets whose low-level
+    ``AVPacket``s point *directly into* the arena buffer — a zero-copy view, the
+    same treatment NumPy/Torch get. The restored object is returned as its own
+    lifetime anchor, so the segment-pool backend keeps the segment until the
+    Packets are released; the ring backend already copied the bytes out, so the
+    view aliases that copy instead. Using only ``__getstate__`` /
+    ``deserialize_view`` keeps this handler free of any ``spdl.io`` import: the
+    Packets class travels through the pickled marker.
+    """
+
+    kind: str = "packets"
+
+    _NAMES: frozenset[str] = frozenset(("AudioPackets", "VideoPackets", "ImagePackets"))
+
+    def __init__(self) -> None:
+        # (id(obj), serialized bytes) of the most recent matched object, so the
+        # get_buffer call that follows matches reuses the serialization.
+        self._cache: tuple[int, bytes] | None = None
+
+    def matches(self, obj: object, threshold: int) -> bool:
+        # Cheap type-name probe first (import-free), then confirm it is really an
+        # spdl.io Packets before touching ``__getstate__``: a foreign class that
+        # merely shares the name could return non-bytes from ``__getstate__`` and
+        # corrupt the arena write. The NumPy/Torch handlers disambiguate on the
+        # module name, but the Packets extension module is FFmpeg-version- and
+        # build-specific (``_spdl_ffmpeg*``), so it is not a reliable signal here;
+        # instead require the ``deserialize_view`` static method this handler
+        # depends on to restore — present only on genuine spdl.io Packets.
+        cls = type(obj)
+        if cls.__name__ not in self._NAMES:
+            return False
+        if not hasattr(cls, "deserialize_view"):
+            return False
+        data: bytes = obj.__getstate__()  # type: ignore[attr-defined]
+        if len(data) < threshold:
+            # Below the offload threshold: leave it inline and do NOT cache —
+            # get_buffer will not run, so caching would only pin these bytes
+            # until the next matches() call (a leak for a stream of small
+            # Packets).
+            return False
+        self._cache = (id(obj), data)
+        return True
+
+    def get_buffer(
+        self, obj: object
+    ) -> tuple["bytes | bytearray | memoryview[bytes]", tuple[object, ...]]:
+        if self._cache is not None and self._cache[0] == id(obj):
+            data = self._cache[1]
+        else:
+            # Defensive: matches always runs first and caches, but re-serialize
+            # rather than rely on it (the bytes own their memory either way).
+            data = obj.__getstate__()  # type: ignore[attr-defined]
+        self._cache = None
+        # memoryview over the bytes — no copy; write_binary performs the single
+        # copy into shared memory. meta carries the class so restore can call
+        # its ``deserialize_view`` (pickled by reference in the marker).
+        return memoryview(data), (type(obj),)
+
+    def from_buffer(
+        self, buf: "memoryview[bytes]", meta: tuple[object, ...], zero_copy: bool
+    ) -> tuple[object, object | None]:
+        (cls,) = meta
+        if zero_copy:
+            # Segment pool: zero-copy view — the restored Packets alias ``buf``
+            # directly (the class keeps ``buf`` alive via nb::keep_alive). The
+            # Packets object is its own lifetime anchor, so the pool holds the
+            # segment until they are released.
+            obj = cls.deserialize_view(buf)  # type: ignore[attr-defined]
+            return obj, obj
+        # Ring: the bytes were copied out — build an owning Packets, no anchor.
+        return cls.deserialize(bytes(buf)), None  # type: ignore[attr-defined]
+
+
+class _OffloadRegistry:
+    """Ordered set of handlers used to offload and restore objects.
+
+    Consulted on both sides of the process boundary: the offloading pickler asks
+    :py:meth:`handler_for` which handler (if any) claims each leaf, and
+    :py:func:`_restore` uses :py:meth:`handler` to look a handler back up by the
+    ``kind`` stored on the marker. Order matters — the first matching handler
+    wins — so more specific handlers should be listed before more general ones.
+
+    Args:
+        handlers: Handlers to consult, in priority order. Each must satisfy
+            :py:class:`_OffloadHandlerProtocol` and carry a ``kind`` unique within
+            this registry. :py:meth:`handler_for` tries them in this order;
+            :py:meth:`handler` indexes them by ``kind``.
+    """
+
+    def __init__(self, handlers: list[_OffloadHandlerProtocol]) -> None:
+        self._handlers = handlers
+        self._by_kind: dict[str, _OffloadHandlerProtocol] = {
+            h.kind: h for h in handlers
+        }
+
+    def handler_for(
+        self, obj: object, threshold: int
+    ) -> _OffloadHandlerProtocol | None:
+        """Return the first handler that wants to offload ``obj``, else ``None``.
+
+        Args:
+            obj: The candidate leaf object being pickled.
+            threshold: Minimum payload size in bytes for offloading to be
+                worthwhile, passed through to each handler's
+                :py:meth:`~_OffloadHandlerProtocol.matches`.
+
+        Returns:
+            The first handler (in registration order) whose ``matches`` returns
+            ``True``, or ``None`` if no handler claims ``obj`` (it is then pickled
+            inline).
+        """
+        for h in self._handlers:
+            if h.matches(obj, threshold):
+                return h
+        return None
+
+    def handler(self, kind: str) -> _OffloadHandlerProtocol:
+        """Return the handler registered under ``kind``.
+
+        Args:
+            kind: The registry key stored on a :py:class:`_ShmMarker`, identifying
+                the handler that produced it.
+
+        Returns:
+            The handler whose ``kind`` equals ``kind``.
+
+        Raises:
+            KeyError: If no handler with that ``kind`` is registered.
+        """
+        return self._by_kind[kind]
+
+
+def _default_registry() -> _OffloadRegistry:
+    """Registry covering large bytes-like objects (``bytes``, ``bytearray``,
+    ``memoryview``), NumPy arrays, Torch tensors, and
+    ``spdl.io`` Audio/Video/Image Packets."""
+    return _OffloadRegistry(
+        [_BytesHandler(), _NumpyHandler(), _TorchHandler(), _PacketsHandler()]
+    )

--- a/src/spdl/pipeline/_arena/_shm.py
+++ b/src/spdl/pipeline/_arena/_shm.py
@@ -1,0 +1,37 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""Shared-memory helpers used by the arena backends."""
+
+from __future__ import annotations
+
+from multiprocessing import resource_tracker, shared_memory
+
+__all__ = ["_attach"]
+
+
+def _attach(name: str) -> shared_memory.SharedMemory:
+    """Attach to an existing shared-memory segment by name, without owning it.
+
+    A non-owning process must not let its ``resource_tracker`` unlink the segment
+    when it exits (CPython bpo-39959); only the creating process unlinks. So after
+    attaching, the segment is unregistered from this process's tracker.
+
+    Args:
+        name: The name of the shared-memory segment to attach to.
+
+    Returns:
+        A :py:class:`multiprocessing.shared_memory.SharedMemory` mapping the
+        named segment, detached from this process's resource tracker.
+    """
+    shm = shared_memory.SharedMemory(name=name)
+    try:
+        resource_tracker.unregister(shm._name, "shared_memory")  # type: ignore[attr-defined]
+    except (KeyError, AttributeError):
+        pass
+    return shm

--- a/src/spdl/pipeline/_iter_utils/_common.py
+++ b/src/spdl/pipeline/_iter_utils/_common.py
@@ -18,7 +18,9 @@ import queue
 import time
 from collections.abc import Callable, Iterable, Sequence
 from dataclasses import dataclass
-from typing import Any, Generic, Protocol, TypeVar
+from typing import Any, cast, Generic, Protocol, TypeVar
+
+from spdl.pipeline._arena import _Arena, ArenaProtocol
 
 __all__ = [
     "_Cmd",
@@ -165,6 +167,7 @@ def _execute_iterable(
     data_q: mp.Queue,
     fn: Callable[[], Iterable[T]],
     initializers: Sequence[Callable[[], None]] | None,
+    arena: ArenaProtocol | None = None,
 ) -> None:
     """Worker implementation for :py:func:`~spdl.pipeline.iterate_in_subprocess`
     and :py:func:`~spdl.pipeline.iterate_in_subinterpreter`.
@@ -258,6 +261,11 @@ def _execute_iterable(
 
     data_q.put(_Msg(_Status.INITIALIZATION_SUCCEEDED))
 
+    # Optional shared-memory arena: the writer endpoint is the last step in the
+    # worker; large fields of each item are offloaded to it and replaced by
+    # markers before the (now small) item is put on data_q.
+    helper = _Arena(arena) if arena is not None else None
+
     while True:
         # Stan-by: Waiting for a command from parent
         try:
@@ -267,6 +275,10 @@ def _execute_iterable(
         else:
             match cmd:
                 case _Cmd.START_ITERATION:
+                    if helper is not None:
+                        # Iteration boundary: reclaim leaked arena space. The
+                        # parent is quiescent (waiting for ITERATION_STARTED).
+                        helper.writer.reset()
                     data_q.put(_Msg(_Status.ITERATION_STARTED))
                 case _Cmd.STOP_ITERATION:
                     continue
@@ -307,6 +319,8 @@ def _execute_iterable(
 
             try:
                 item = next(gen)
+                if helper is not None:
+                    item = cast(T, helper.offload(item))
                 data_q.put(_Msg(_Status.ITERATOR_SUCCESS, message=item))
             except StopIteration:
                 data_q.put(_Msg(_Status.ITERATION_FINISHED))

--- a/src/spdl/pipeline/_iter_utils/_subprocess.py
+++ b/src/spdl/pipeline/_iter_utils/_subprocess.py
@@ -18,8 +18,9 @@ import queue
 import weakref
 from collections.abc import Callable, Iterable, Iterator, Sequence
 from dataclasses import dataclass
-from typing import Generic, TypeVar
+from typing import cast, Generic, TypeVar
 
+from spdl.pipeline._arena import _Arena, ArenaProtocol
 from spdl.pipeline._iter_utils._common import (
     _Cmd,
     _drain,
@@ -62,11 +63,21 @@ class _ipc(Generic[T]):
     cmd_q: queue.Queue[_Cmd]
     data_q: queue.Queue[_Msg[T]]
     timeout: float
+    arena: ArenaProtocol | None = None
 
     def terminate(self) -> None:
         self.cmd_q.put(_Cmd.ABORT)
         _drain(self.data_q)
         _join(self.process)
+        # Unlink the shared-memory arena only after the worker is confirmed
+        # dead, so nothing touches the segment afterwards. ``unlink`` runs in
+        # ``finally`` so a failing ``close`` never leaves the OS-level shm
+        # segment behind — teardown is the only place that calls ``unlink``.
+        if (arena := self.arena) is not None:
+            try:
+                arena.close()
+            finally:
+                arena.unlink()
 
 
 class _SubprocessIterable(Iterable[T]):
@@ -82,6 +93,11 @@ class _SubprocessIterable(Iterable[T]):
     def __init__(self, interface: _ipc[T]) -> None:
         self._interface: _ipc[T] | None = interface
         self._finalizer = weakref.finalize(self, interface.terminate)
+        # First step in the parent: restore arena-offloaded fields, if an arena
+        # is in use.
+        self._arena: _Arena | None = (
+            _Arena(interface.arena) if interface.arena is not None else None
+        )
 
     def __iter__(self) -> Iterator[T]:
         """Instruct the worker process to enter iteration mode and iterate on the results."""
@@ -91,7 +107,14 @@ class _SubprocessIterable(Iterable[T]):
         try:
             # pyre-ignore[6]
             _enter_iteration_mode(if_.cmd_q, if_.data_q, if_.timeout, "subprocess")
-            yield from _iterate_results(if_.data_q, if_.timeout, "subprocess")
+            if (arena := self._arena) is None:
+                yield from _iterate_results(if_.data_q, if_.timeout, "subprocess")
+            else:
+                # Reset the reader's per-iteration cursors (the worker has reset
+                # its side and is quiescent until we start consuming).
+                arena.reader.reset()
+                for blob in _iterate_results(if_.data_q, if_.timeout, "subprocess"):
+                    yield cast(T, arena.restore(cast(bytes, blob)))
         except GeneratorExit:
             return
         except BaseException:
@@ -113,6 +136,7 @@ def iterate_in_subprocess(
     mp_context: str | None = None,
     timeout: float | None = None,
     daemon: bool = False,
+    arena: ArenaProtocol | None = None,
 ) -> Iterable[T]:
     """**[Experimental]** Run the given ``iterable`` in a subprocess.
 
@@ -149,6 +173,16 @@ def iterate_in_subprocess(
         timeout: Timeout for inactivity. If the generator function does not yield
             any item for this amount of time, the process is terminated.
         daemon: Whether to run the process as a daemon. Use it only for debugging.
+        arena: Optional shared-memory arena, e.g.
+            :py:class:`~spdl.pipeline.SharedMemoryRingBuffer` or
+            :py:class:`~spdl.pipeline.SharedMemorySegmentPool`. When provided, large
+            binary fields (large ``bytes``, NumPy arrays, Torch tensors) of each
+            yielded item are written into this pre-allocated shared-memory arena.
+            PyTorch and NumPy already move such payloads through shared memory for
+            inter-process transfer by default, but allocate a fresh segment per
+            object; the arena reuses one pre-allocated buffer instead. Ownership
+            transfers to the returned iterable, which closes and unlinks the arena
+            at teardown, so do not reuse the arena afterwards.
 
     Returns:
         Iterator over the results of the generator function.
@@ -175,11 +209,17 @@ def iterate_in_subprocess(
     data_q: queue.Queue[_Msg[T]] = ctx.Queue(maxsize=buffer_size)
     process = ctx.Process(
         target=_execute_iterable,
-        args=(cmd_q, data_q, fn, initializers),
+        args=(cmd_q, data_q, fn, initializers, arena),
         daemon=daemon,
     )
 
-    if_ = _ipc(process, cmd_q, data_q, float("inf") if timeout is None else timeout)
+    if_ = _ipc(
+        process,
+        cmd_q,
+        data_q,
+        float("inf") if timeout is None else timeout,
+        arena,
+    )
 
     process.start()
 

--- a/tests/pipeline/arena_registry_test.py
+++ b/tests/pipeline/arena_registry_test.py
@@ -1,0 +1,237 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""Unit tests for the per-type offload handlers in :py:mod:`_registry`.
+
+These exercise each handler's ``matches`` gating and its ``get_buffer`` /
+``from_buffer`` contract directly, without going through a shared-memory backend.
+``from_buffer`` is fed a plain ``memoryview`` standing in for the arena buffer: a
+writable ``bytearray``-backed view models both the ring's private per-unit copy
+(``zero_copy=False``) and the pool's live shared-memory segment
+(``zero_copy=True``). End-to-end round-trips through a real backend live in the
+ring / pool / packets test files.
+"""
+
+import unittest
+from typing import Any, cast
+
+import spdl.io
+from spdl.pipeline._arena._registry import (
+    _BytesHandler,
+    _NumpyHandler,
+    _PacketsHandler,
+    _TorchHandler,
+)
+
+from ..fixture import FFMPEG_CLI, get_sample
+
+_VIDEO_CMD = f"{FFMPEG_CLI} -hide_banner -y -f lavfi -i testsrc -frames:v 25 sample.mp4"
+
+
+def _demux_video() -> Any:
+    """Generate a synthetic clip and demux it into a VideoPackets object."""
+    # Keep the SrcInfo alive until demux opens the file: dropping it would run
+    # its TemporaryDirectory finalizer and delete sample.mp4 first.
+    sample = get_sample(_VIDEO_CMD)
+    return spdl.io.demux_video(sample.path)
+
+
+def _copy_view(buf: "memoryview[bytes] | bytes | bytearray") -> "memoryview[bytes]":
+    """A writable, private copy of ``buf`` as a memoryview (models arena bytes)."""
+    return memoryview(bytearray(buf))
+
+
+class BytesHandlerTest(unittest.TestCase):
+    def test_matches_accepts_large_bytes_like(self) -> None:
+        """bytes, bytearray and memoryview at/above the threshold are claimed."""
+        handler = _BytesHandler()
+        blob = b"x" * 100
+        self.assertTrue(handler.matches(blob, 100))
+        self.assertTrue(handler.matches(bytearray(blob), 100))
+        self.assertTrue(handler.matches(memoryview(blob), 100))
+
+    def test_matches_rejects_below_threshold(self) -> None:
+        """A bytes-like smaller than the threshold is left inline."""
+        self.assertFalse(_BytesHandler().matches(b"x" * 99, 100))
+
+    def test_matches_rejects_non_bytes_like(self) -> None:
+        """Objects that are not bytes-like are not claimed by this handler."""
+        handler = _BytesHandler()
+        self.assertFalse(handler.matches("a string", 0))
+        self.assertFalse(handler.matches([1, 2, 3], 0))
+        self.assertFalse(handler.matches(12345, 0))
+
+    def test_copy_restore_reconstructs_original_type(self) -> None:
+        """zero_copy=False (ring) rebuilds each input as its own type, no anchor."""
+        handler = _BytesHandler()
+        cases: list[tuple[Any, type[Any]]] = [
+            (b"a" * 50, bytes),
+            (bytearray(b"b" * 50), bytearray),
+            (memoryview(b"c" * 50), memoryview),
+        ]
+        for src, expected_type in cases:
+            with self.subTest(input=expected_type.__name__):
+                buf, meta = handler.get_buffer(src)
+                restored, anchor = handler.from_buffer(_copy_view(buf), meta, False)
+                self.assertIsInstance(restored, expected_type)
+                self.assertEqual(bytes(cast(Any, restored)), bytes(src))
+                self.assertIsNone(anchor)
+
+    def test_zero_copy_restore_is_a_self_anchoring_memoryview(self) -> None:
+        """zero_copy=True (pool) returns a memoryview that is its own anchor."""
+        buf, meta = _BytesHandler().get_buffer(b"z" * 64)
+        restored, anchor = _BytesHandler().from_buffer(_copy_view(buf), meta, True)
+        self.assertIsInstance(restored, memoryview)
+        self.assertIs(restored, anchor)
+
+    def test_noncontiguous_memoryview_is_flattened(self) -> None:
+        """get_buffer copies a non-contiguous memoryview into a flat buffer."""
+        src = memoryview(bytes(range(256)) * 4)[::2]  # strided -> non-contiguous
+        self.assertFalse(src.contiguous)
+        buf, _ = _BytesHandler().get_buffer(src)
+        self.assertTrue(memoryview(buf).contiguous)
+        self.assertEqual(bytes(buf), bytes(src))
+
+
+class NumpyHandlerTest(unittest.TestCase):
+    def setUp(self) -> None:
+        try:
+            import numpy as np
+
+            self.np = np
+        except ImportError:
+            self.skipTest("numpy not available")
+
+    def test_matches_rejects_non_numpy(self) -> None:
+        """A foreign type (even one named 'ndarray') is not claimed."""
+        handler = _NumpyHandler()
+
+        class ndarray:  # noqa: N801 — deliberately mimics numpy.ndarray
+            nbytes: int = 1 << 30
+
+        self.assertFalse(handler.matches(ndarray(), 0))
+        self.assertFalse(handler.matches(b"bytes", 0))
+
+    def test_matches_respects_threshold(self) -> None:
+        """An ndarray is claimed only when its nbytes reaches the threshold."""
+        arr = self.np.zeros(100, dtype=self.np.float64)  # 800 bytes
+        handler = _NumpyHandler()
+        self.assertTrue(handler.matches(arr, 800))
+        self.assertFalse(handler.matches(arr, 801))
+
+    def test_round_trip_copy_and_zero_copy(self) -> None:
+        """get_buffer/from_buffer rebuild an equal array; only the zero-copy path
+        returns a lifetime anchor."""
+        np = self.np
+        arr = np.arange(256, dtype=np.float64).reshape(16, 16)
+        buf, meta = _NumpyHandler().get_buffer(arr)
+
+        copied, anchor = _NumpyHandler().from_buffer(_copy_view(buf), meta, False)
+        copied = cast(Any, copied)
+        self.assertTrue(np.array_equal(copied, arr))
+        self.assertEqual(copied.dtype, arr.dtype)
+        self.assertEqual(copied.shape, arr.shape)
+        self.assertIsNone(anchor)
+
+        viewed, view_anchor = _NumpyHandler().from_buffer(_copy_view(buf), meta, True)
+        self.assertTrue(np.array_equal(cast(Any, viewed), arr))
+        self.assertIsNotNone(view_anchor)
+
+
+class TorchHandlerTest(unittest.TestCase):
+    def setUp(self) -> None:
+        try:
+            import torch
+
+            self.torch = torch
+        except ImportError:
+            self.skipTest("torch not available")
+
+    def test_matches_rejects_non_torch(self) -> None:
+        """A foreign type (even one named 'Tensor') is not claimed."""
+        handler = _TorchHandler()
+
+        class Tensor:  # deliberately mimics torch.Tensor
+            is_cpu: bool = True
+
+        self.assertFalse(handler.matches(Tensor(), 0))
+        self.assertFalse(handler.matches(b"bytes", 0))
+
+    def test_matches_respects_threshold(self) -> None:
+        """A CPU tensor is claimed only when its byte size reaches the threshold."""
+        t = self.torch.zeros(100, dtype=self.torch.int64)  # 800 bytes
+        handler = _TorchHandler()
+        self.assertTrue(handler.matches(t, 800))
+        self.assertFalse(handler.matches(t, 801))
+
+    def test_round_trip_copy_and_zero_copy(self) -> None:
+        """get_buffer/from_buffer rebuild an equal tensor; only the zero-copy path
+        returns a lifetime anchor."""
+        torch = self.torch
+        t = torch.arange(256, dtype=torch.int64).reshape(16, 16)
+        buf, meta = _TorchHandler().get_buffer(t)
+
+        copied, anchor = _TorchHandler().from_buffer(_copy_view(buf), meta, False)
+        self.assertTrue(torch.equal(cast(Any, copied), t))
+        self.assertIsNone(anchor)
+
+        viewed, view_anchor = _TorchHandler().from_buffer(_copy_view(buf), meta, True)
+        self.assertTrue(torch.equal(cast(Any, viewed), t))
+        self.assertIsNotNone(view_anchor)
+
+
+class PacketsHandlerTest(unittest.TestCase):
+    def test_foreign_type_sharing_the_name_is_rejected(self) -> None:
+        """A non-Packets class that merely reuses the name is not matched, and its
+        __getstate__ (which may not return bytes) is never called."""
+
+        class AudioPackets:  # noqa: B903 — deliberately mimics the Packets name
+            def __getstate__(self) -> dict[str, str]:
+                raise AssertionError(
+                    "__getstate__ must not be called on a foreign type"
+                )
+
+        handler = _PacketsHandler()
+        # threshold=0 would match anything that passes the type gate.
+        self.assertFalse(handler.matches(AudioPackets(), 0))
+        self.assertIsNone(handler._cache)
+
+    def test_sub_threshold_packets_are_not_cached(self) -> None:
+        """A genuine Packets below the threshold is left inline and leaves no
+        serialized bytes pinned in the handler cache."""
+        handler = _PacketsHandler()
+        packets = _demux_video()
+        above_size = len(packets.__getstate__()) + 1
+        self.assertFalse(handler.matches(packets, above_size))
+        self.assertIsNone(handler._cache)
+
+    def test_matched_packets_cache_is_consumed_by_get_buffer(self) -> None:
+        """An above-threshold Packets matches, caches its bytes for the following
+        get_buffer, and the cache is cleared once get_buffer consumes it."""
+        handler = _PacketsHandler()
+        packets = _demux_video()
+        self.assertTrue(handler.matches(packets, 0))
+        self.assertIsNotNone(handler._cache)
+        buf, meta = handler.get_buffer(packets)
+        self.assertEqual(bytes(buf), packets.__getstate__())
+        self.assertIs(meta[0], type(packets))
+        self.assertIsNone(handler._cache)
+
+    def test_copy_restore_round_trips(self) -> None:
+        """zero_copy=False rebuilds an owning Packets equal to the original."""
+        handler = _PacketsHandler()
+        packets = _demux_video()
+        buf, meta = handler.get_buffer(packets)
+        restored, anchor = handler.from_buffer(_copy_view(buf), meta, False)
+        self.assertIs(type(restored), type(packets))
+        self.assertEqual(cast(Any, restored).__getstate__(), packets.__getstate__())
+        self.assertIsNone(anchor)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Summary:

Adds the backend-agnostic machinery for moving large binary payloads (large `bytes`, NumPy arrays, Torch tensors) between the worker and parent of `iterate_in_subprocess` through shared memory instead of pickling them through the result queue. This commit contains only the framework; concrete buffer backends are added in following commits.

New private subpackage `spdl/pipeline/_arena/`:

- `_protocol.py`: structural `ArenaProtocol` / `ArenaWriterProtocol` / `ArenaReaderProtocol` interfaces. `iterate_in_subprocess` accepts any object satisfying `ArenaProtocol` through one `buffer` argument and dispatches on its type, so additional backends need no signature change. A unit (one pipeline item, possibly several binaries) is bracketed by `begin_unit` / `commit_unit` on the writer and returned with `end_unit` on the reader, so reservation and return happen in bulk per unit.
- `_marker.py`: `_ShmMarker`, the small descriptor that replaces an offloaded binary in the pickled envelope.
- `_registry.py`: decides which objects are offloaded and how. A handler exposes an object's bytes as a zero-copy source buffer (`get_buffer`) so the arena copies into shared memory exactly once, and rebuilds it from a destination buffer (`from_buffer`), returning the restored object plus a lifetime anchor for zero-copy views. The `bytes` handler is pure Python; NumPy and Torch are reached through `lazy_import` so `import spdl.pipeline` works without them and they never become hard dependencies.
- `_offload.py`: `offload` / `restore`, which divert offloadable leaves of an arbitrarily nested object into the arena via a pickler `persistent_id` / `persistent_load` pair while the rest is pickled normally. The envelope carries an 8-byte unit span so the reader can return the whole region in one call.

`iterate_in_subprocess` gains a `buffer: ArenaProtocol | None` argument. When provided, the worker offloads each item before putting it on the queue and the parent restores it as the first step; the arena is created and owned by the parent, passed to the worker, and closed and unlinked at teardown after the worker is confirmed dead. With `buffer=None` the behavior is unchanged.

Reviewed By: huangruizhe

Differential Revision: D107709116


