### PR TITLE
Add SharedMemorySegmentPool zero-copy arena backend (#1521)

### DIFF
--- a/src/spdl/pipeline/__init__.py
+++ b/src/spdl/pipeline/__init__.py
@@ -8,6 +8,7 @@
 
 # pyre-strict
 
+from ._arena import SharedMemorySegmentPool
 from ._bg_task import BackgroundTask, BackgroundTaskFactory
 from ._build import (
     build_pipeline,
@@ -77,6 +78,7 @@ __all__ = [
     "iterate_in_subprocess",
     "run_pipeline_in_subprocess",
     "run_pipeline_in_subinterpreter",
+    "SharedMemorySegmentPool",
 ]
 
 

--- a/src/spdl/pipeline/_arena/__init__.py
+++ b/src/spdl/pipeline/_arena/__init__.py
@@ -9,11 +9,13 @@
 """Shared-memory arena for moving large payloads across processes."""
 
 from ._arena import _Arena
+from ._pool import SharedMemorySegmentPool
 from ._protocol import ArenaProtocol, ArenaReaderProtocol, ArenaWriterProtocol
 
 __all__ = [
     "ArenaProtocol",
     "ArenaReaderProtocol",
     "ArenaWriterProtocol",
+    "SharedMemorySegmentPool",
     "_Arena",
 ]

--- a/src/spdl/pipeline/_arena/_pool.py
+++ b/src/spdl/pipeline/_arena/_pool.py
@@ -1,0 +1,443 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""Rotating pool of shared-memory segments — one segment per unit, zero-copy.
+
+An alternative arena backend to :py:class:`SharedMemoryRingBuffer`. Each unit
+(one pipeline item) is written into a whole, isolated shared-memory segment, and
+the pool rotates through a fixed number of them. Two segment counters live in a
+small control segment: ``published`` (units published by the worker) and
+``reclaimed`` (units whose segments have been returned to the pool). Unit ``i``
+always uses segment ``i % count``, so the reader derives the segment from its own
+cursor and markers only need an in-segment offset.
+
+Because each unit owns a whole contiguous segment, the reader hands restored
+NumPy/Torch payloads back as **zero-copy views** directly over shared memory
+(``read_binary`` returns a live ``memoryview``). The segment is only returned to
+the pool once every view into it has been released — tracked with
+``weakref.finalize`` on the restored objects. The writer is gated by
+``reclaimed`` (``free = count - (published - reclaimed)``), so it never reuses a
+segment that still has live views.
+
+Backpressure is Mode B (blocking): ``begin_unit`` waits for the consumer to
+reclaim a segment when the pool is full (up to ``acquire_timeout``), throttling a
+fast producer to the consumer's reclaim rate. Set ``acquire_timeout=0`` for
+non-blocking behavior (raise immediately when full). Elastic growth remains
+future work.
+
+.. note::
+
+   Do not retain zero-copy views across a re-iteration of the same worker: the
+   iteration boundary resets the cursors and the writer may overwrite a segment
+   a stale view still points at.
+"""
+
+from __future__ import annotations
+
+import logging
+import struct
+import threading
+import time
+import weakref
+from multiprocessing import shared_memory
+from typing import TypedDict
+
+from ._shm import _attach
+
+_LG: logging.Logger = logging.getLogger(__name__)
+
+__all__ = ["SharedMemorySegmentPool"]
+
+# How often ``begin_unit`` polls the (shared-memory) reclaim counter while
+# waiting for a free segment. Small enough to be responsive, large enough to
+# keep the busy-wait cheap.
+_POLL_INTERVAL: float = 0.0005
+
+# Default time ``begin_unit`` waits for the consumer to reclaim a segment before
+# giving up and raising. Generous, so it only fires on a genuinely stalled or
+# dead consumer rather than normal slow-consumer backpressure.
+_DEFAULT_ACQUIRE_TIMEOUT: float = 60.0
+
+# Control segment: published (units published), reclaimed (units returned).
+_CTRL: struct.Struct = struct.Struct("<QQ")
+
+# Binaries are aligned to this many bytes within a segment so that zero-copy
+# views into them (e.g. ``spdl.io`` Packets payloads) land on aligned addresses.
+# Segment bases are page-aligned mmaps, so an aligned in-segment offset yields an
+# aligned absolute address. Keep in sync with ``SERIALIZATION_ALIGNMENT`` in
+# ``libspdl/core/packets.cpp``.
+_ALIGNMENT: int = 64
+
+
+class _PoolState(TypedDict):
+    """Picklable state of a :py:class:`SharedMemorySegmentPool`."""
+
+    ctrl_name: str
+    seg_names: list[str]
+    segment_size: int
+    count: int
+    acquire_timeout: float
+
+
+class SharedMemorySegmentPool:
+    """**[Experimental]** A rotating pool of shared-memory segments, one per unit.
+
+    Construct it in the parent process and pass it to
+    :py:func:`spdl.pipeline.iterate_in_subprocess` via the ``arena`` argument;
+    ownership transfers to the returned iterable, which closes and unlinks it at
+    teardown. Restored NumPy/Torch payloads are zero-copy views over shared
+    memory; the pool keeps each segment until its views are released.
+
+    .. note::
+
+       **Performance.** Because each unit is restored as a zero-copy view directly
+       over shared memory, this backend avoids the per-item serialization and
+       copy-out that a plain pickle/queue transfer pays on *both* sides of the
+       process boundary. The consistent, measured benefit is **substantially lower
+       host CPU usage** for moving large payloads across the boundary — the
+       transfer stops being a serialize-then-copy operation.
+
+       Whether that converts into higher end-to-end throughput depends on where
+       the bottleneck is. It helps most when the pipeline is **CPU-bound or
+       transfer/serialization-bound**. When the consumer is the bottleneck (for
+       example a GPU-starved, decode-bound stage), throughput can be unchanged and
+       the gain instead shows up as **freed CPU headroom** — which still matters
+       when many workers contend for host cores. Treat this as an opt-in
+       optimization and measure your own pipeline before relying on it.
+
+    Args:
+        segment_size: Size of each segment in bytes. Must be at least as large as
+            the biggest single pipeline unit (the sum of its offloaded binaries).
+        count: Number of segments. With Mode B backpressure (the default) the
+            producer waits for the consumer to reclaim a segment when the pool is
+            full, so ``count`` bounds memory and in-flight units rather than
+            being a hard cap that errors. Size it to the working set that keeps
+            the consumer fed (``buffer_size`` plus concurrent consumer holds).
+        acquire_timeout: Seconds ``begin_unit`` waits for a free segment before
+            raising :py:exc:`BufferError`. Guards against a stalled/dead
+            consumer; set to ``0`` for non-blocking (Mode A) behavior.
+    """
+
+    def __init__(
+        self,
+        segment_size: int,
+        count: int,
+        *,
+        acquire_timeout: float = _DEFAULT_ACQUIRE_TIMEOUT,
+    ) -> None:
+        if segment_size <= 0:
+            raise ValueError("segment_size must be positive")
+        if count <= 0:
+            raise ValueError("count must be positive")
+        if acquire_timeout < 0:
+            raise ValueError("acquire_timeout must be non-negative")
+        self._segment_size: int = segment_size
+        self._count: int = count
+        self._acquire_timeout: float = acquire_timeout
+        ctrl = shared_memory.SharedMemory(create=True, size=_CTRL.size)
+        _CTRL.pack_into(ctrl.buf, 0, 0, 0)
+        segs = [
+            shared_memory.SharedMemory(create=True, size=segment_size)
+            for _ in range(count)
+        ]
+        self._ctrl_name: str = ctrl.name
+        self._seg_names: list[str] = [s.name for s in segs]
+        self._ctrl: shared_memory.SharedMemory | None = ctrl
+        self._segs: list[shared_memory.SharedMemory] | None = segs
+        self._ctrl_buf: "memoryview[bytes] | None" = ctrl.buf
+        self._seg_bufs: "list[memoryview[bytes]] | None" = [s.buf for s in segs]
+
+    # -- pickling: carry only the spec; attach lazily, once, per process --
+
+    def __getstate__(self) -> _PoolState:
+        return {
+            "ctrl_name": self._ctrl_name,
+            "seg_names": self._seg_names,
+            "segment_size": self._segment_size,
+            "count": self._count,
+            "acquire_timeout": self._acquire_timeout,
+        }
+
+    def __setstate__(self, state: _PoolState) -> None:
+        self._ctrl_name = state["ctrl_name"]
+        self._seg_names = state["seg_names"]
+        self._segment_size = state["segment_size"]
+        self._count = state["count"]
+        self._acquire_timeout = state["acquire_timeout"]
+        self._ctrl = None
+        self._segs = None
+        self._ctrl_buf = None
+        self._seg_bufs = None
+
+    @property
+    def segment_size(self) -> int:
+        """Size of each segment in bytes."""
+        return self._segment_size
+
+    @property
+    def count(self) -> int:
+        """Number of segments in the pool."""
+        return self._count
+
+    def _ctrl_view(self) -> "memoryview[bytes]":
+        if self._ctrl_buf is None:
+            self._ctrl = _attach(self._ctrl_name)
+            self._ctrl_buf = self._ctrl.buf
+        return self._ctrl_buf
+
+    def _segment(self, index: int) -> "memoryview[bytes]":
+        if self._seg_bufs is None:
+            self._segs = [_attach(n) for n in self._seg_names]
+            self._seg_bufs = [s.buf for s in self._segs]
+        return self._seg_bufs[index % self._count]
+
+    @property
+    def published(self) -> int:
+        """Number of units published by the writer."""
+        return int(_CTRL.unpack_from(self._ctrl_view(), 0)[0])
+
+    @published.setter
+    def published(self, value: int) -> None:
+        struct.pack_into("<Q", self._ctrl_view(), 0, value)
+
+    @property
+    def reclaimed(self) -> int:
+        """Number of units whose segments have been returned to the pool."""
+        return int(_CTRL.unpack_from(self._ctrl_view(), 0)[1])
+
+    @reclaimed.setter
+    def reclaimed(self, value: int) -> None:
+        struct.pack_into("<Q", self._ctrl_view(), 8, value)
+
+    def open_writer(self) -> _PoolWriter:
+        """Return the writer endpoint (call in the worker process)."""
+        return _PoolWriter(self)
+
+    def open_reader(self) -> _PoolReader:
+        """Return the reader endpoint (call in the parent process)."""
+        return _PoolReader(self)
+
+    def close(self) -> None:
+        """Release this process's mappings of the segments.
+
+        Restored zero-copy views (Packets / NumPy / Torch) may still alias a
+        segment at teardown — their slices keep the underlying mmap exported, so
+        unmapping it raises ``BufferError``. We release what we can and *retain*
+        the segments that are still mapped; their shared memory is freed once the
+        views are garbage-collected, and :py:meth:`unlink` removes the names
+        regardless. Raising here would crash an otherwise-successful run.
+        """
+        if (ctrl_buf := self._ctrl_buf) is not None:
+            ctrl_buf.release()
+            self._ctrl_buf = None
+        if (seg_bufs := self._seg_bufs) is not None:
+            for b in seg_bufs:
+                try:
+                    b.release()
+                except BufferError:
+                    pass
+            self._seg_bufs = None
+        if (ctrl := self._ctrl) is not None:
+            ctrl.close()
+            self._ctrl = None
+        if (segs := self._segs) is not None:
+            stuck = []
+            for s in segs:
+                try:
+                    s.close()
+                except BufferError:
+                    # A live zero-copy view still maps this segment. Retain the
+                    # SharedMemory object so its destructor doesn't re-raise now;
+                    # it unmaps once the view is released.
+                    stuck.append(s)
+            self._segs = stuck or None
+            if stuck:
+                _LG.warning(
+                    "SharedMemorySegmentPool: %d of %d segments still had live "
+                    "zero-copy views at close(); their shared memory will be "
+                    "released once those objects are garbage-collected. Release "
+                    "restored Packets/arrays before tearing down the pipeline "
+                    "to avoid this.",
+                    len(stuck),
+                    self._count,
+                )
+
+    def unlink(self) -> None:
+        """Remove all segments from the system (call once, by the owner)."""
+        for name in [self._ctrl_name, *self._seg_names]:
+            # Attach a temporary handle via _attach (so it is not registered with
+            # the resource_tracker) and close it after unlinking, to avoid
+            # leaking the mapping or emitting already-unlinked warnings.
+            try:
+                shm = _attach(name)
+            except FileNotFoundError:
+                continue
+            try:
+                shm.unlink()
+            except FileNotFoundError:
+                pass
+            finally:
+                shm.close()
+
+
+class _PoolWriter:
+    """Writer endpoint. Used as the last step in the worker process."""
+
+    def __init__(self, pool: SharedMemorySegmentPool) -> None:
+        self._p = pool
+        self._seg_size: int = pool.segment_size
+        self._acquire_timeout: float = pool._acquire_timeout
+        self._cursor: int = 0
+
+    def reset(self) -> None:
+        """Reset both cursors at an iteration boundary (the pool is quiescent)."""
+        self._p.published = 0
+        self._p.reclaimed = 0
+        self._cursor = 0
+
+    def begin_unit(self) -> None:
+        """Acquire the next free segment for a new unit.
+
+        Mode B backpressure: if the pool is full, wait (polling the shared
+        reclaim counter) for the consumer to release a segment, up to
+        ``acquire_timeout`` seconds, then raise. This throttles a fast producer
+        to the consumer's reclaim rate instead of failing when a slow consumer
+        legitimately holds many zero-copy views.
+        """
+        p = self._p
+        if p.count - (p.published - p.reclaimed) < 1:
+            deadline = time.monotonic() + self._acquire_timeout
+            while p.count - (p.published - p.reclaimed) < 1:
+                if time.monotonic() >= deadline:
+                    raise BufferError(
+                        "segment pool exhausted: no free segment after waiting "
+                        f"{self._acquire_timeout:g}s — the consumer is releasing "
+                        "views too slowly or has stalled. Increase "
+                        "SharedMemorySegmentPool count/segment_size or "
+                        "acquire_timeout, or check the consumer."
+                    )
+                time.sleep(_POLL_INTERVAL)
+        self._cursor = 0
+
+    def write_binary(
+        self, data: "bytes | bytearray | memoryview[bytes]"
+    ) -> tuple[int, int]:
+        """Copy one binary into the current segment; return ``(offset, nbytes)``."""
+        mv = memoryview(data).cast("B")
+        n = mv.nbytes
+        # Align the binary so zero-copy views into it land on aligned addresses.
+        self._cursor = (self._cursor + _ALIGNMENT - 1) & ~(_ALIGNMENT - 1)
+        if self._cursor + n > self._seg_size:
+            raise BufferError(
+                f"unit exceeds segment_size ({self._seg_size}); increase "
+                "SharedMemorySegmentPool segment_size"
+            )
+        seg = self._p._segment(self._p.published)
+        offset = self._cursor
+        seg[offset : offset + n] = mv
+        self._cursor += n
+        return offset, n
+
+    def commit_unit(self) -> int:
+        """Publish the unit (advance the publish counter); return its byte span."""
+        span = self._cursor
+        self._p.published = self._p.published + 1
+        return span
+
+    def abort_unit(self) -> None:
+        """Discard an in-progress unit without publishing it."""
+        self._cursor = 0
+
+
+class _SegmentLease:
+    """Reclaims a unit's segment once every anchor handed out for it is released.
+
+    ``end_unit`` registers a :py:func:`weakref.finalize` per anchor (the
+    ``np.frombuffer`` array / Torch tensor a restored view chains to); each
+    firing decrements the count, and the unit is reclaimed when it reaches zero.
+    """
+
+    def __init__(
+        self, reader: _PoolReader, unit: int, count: int, generation: int
+    ) -> None:
+        self._reader = reader
+        self._unit = unit
+        self._remaining = count
+        self._generation = generation
+        self._lock = threading.Lock()
+
+    def release_one(self) -> None:
+        with self._lock:
+            self._remaining -= 1
+            done = self._remaining == 0
+        if done:
+            self._reader._unit_released(self._unit, self._generation)
+
+
+class _PoolReader:
+    """Reader endpoint. Used as the first step in the parent process.
+
+    Returns zero-copy views into the segments and defers reclaiming a segment
+    until every anchor of its unit has been released.
+    """
+
+    # ``read_binary`` hands out live, reusable views into shared memory, so
+    # handlers restore zero-copy views (anchored to defer reclamation).
+    zero_copy: bool = True
+
+    def __init__(self, pool: SharedMemorySegmentPool) -> None:
+        self._p = pool
+        self._next: int = 0  # next unit index to restore
+        self._reclaimed: int = 0  # contiguous reclaim watermark (mirrors shm)
+        self._released: set[int] = set()  # released units above the watermark
+        self._generation: int = 0  # invalidates leases from prior iterations
+        self._lock = threading.Lock()
+
+    def reset(self) -> None:
+        """Reset cursors at an iteration boundary and orphan stale leases."""
+        with self._lock:
+            self._next = 0
+            self._reclaimed = 0
+            self._released.clear()
+            self._generation += 1
+
+    def read_binary(self, offset: int, nbytes: int) -> "memoryview[bytes]":
+        """Return a live view into the current unit's segment (zero copy)."""
+        return self._p._segment(self._next)[offset : offset + nbytes]
+
+    def end_unit(self, span: int, pinned: list[object]) -> None:
+        """Finish the current unit; reclaim now or once its anchors are released.
+
+        ``pinned`` holds the lifetime anchors of the unit's zero-copy views. The
+        segment is reclaimed once all of them are garbage-collected; finalizing
+        the anchor (not the restored object) is what makes a view or shallow copy
+        that outlives the original object keep the segment alive.
+        """
+        unit = self._next
+        self._next += 1
+        if not pinned:
+            # Nothing aliases the segment (e.g. all fields copied out) — reclaim
+            # immediately.
+            self._unit_released(unit, self._generation)
+            return
+        lease = _SegmentLease(self, unit, len(pinned), self._generation)
+        for anchor in pinned:
+            weakref.finalize(anchor, lease.release_one)
+
+    def _unit_released(self, unit: int, generation: int) -> None:
+        with self._lock:
+            if generation != self._generation:
+                return  # stale lease from a previous iteration; ignore
+            self._released.add(unit)
+            advanced = False
+            while self._reclaimed in self._released:
+                self._released.discard(self._reclaimed)
+                self._reclaimed += 1
+                advanced = True
+            if advanced:
+                self._p.reclaimed = self._reclaimed

--- a/tests/pipeline/arena_packets_test.py
+++ b/tests/pipeline/arena_packets_test.py
@@ -1,0 +1,145 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import functools
+import gc
+import unittest
+from typing import Any, cast
+
+import numpy as np
+import spdl.io
+from spdl.pipeline import iterate_in_subprocess, SharedMemorySegmentPool
+from spdl.pipeline._arena._offload import _offload, _restore
+from spdl.pipeline._arena._registry import _default_registry
+
+from ..fixture import FFMPEG_CLI, get_sample
+
+CMDS = {
+    "audio": f"{FFMPEG_CLI} -hide_banner -y -f lavfi -i sine=frequency=1000:sample_rate=48000:duration=3 -c:a pcm_s16le sample.wav",
+    "video": f"{FFMPEG_CLI} -hide_banner -y -f lavfi -i testsrc -frames:v 25 sample.mp4",
+    "image": f"{FFMPEG_CLI} -hide_banner -y -f lavfi -i color=0x000000,format=gray -frames:v 1 sample.png",
+}
+
+
+def _demux(media_type: str) -> Any:
+    """Generate a synthetic sample and demux it into a Packets object."""
+    sample = get_sample(CMDS[media_type])
+    return getattr(spdl.io, f"demux_{media_type}")(sample.path)
+
+
+def _demux_from_paths(paths: list[tuple[str, str]]) -> list[object]:
+    """Demux each ``(media_type, path)`` pair into a Packets object."""
+    return [getattr(spdl.io, f"demux_{mt}")(path) for mt, path in paths]
+
+
+class PacketsOffloadTest(unittest.TestCase):
+    def _pool(self, segment_size: int, count: int) -> SharedMemorySegmentPool:
+        pool = SharedMemorySegmentPool(segment_size=segment_size, count=count)
+        self.addCleanup(pool.unlink)
+        self.addCleanup(pool.close)
+        return pool
+
+    def _assert_round_trips(self, original: object) -> None:
+        pool = self._pool(1 << 20, 2)
+        writer, reader = pool.open_writer(), pool.open_reader()
+        registry = _default_registry()
+        out = _restore(_offload({"p": original}, writer, registry), reader, registry)
+        restored = cast(dict[str, Any], out)["p"]
+        # Same concrete Packets type, and serializing again yields identical
+        # bytes — a strong equivalence check (Packets have no __eq__).
+        self.assertIs(type(restored), type(original))
+        self.assertEqual(restored.__getstate__(), original.__getstate__())
+
+    def test_video_packets_round_trip(self) -> None:
+        """VideoPackets offload to / restore from the arena unchanged."""
+        self._assert_round_trips(_demux("video"))
+
+    def test_audio_packets_round_trip(self) -> None:
+        """AudioPackets offload to / restore from the arena unchanged."""
+        self._assert_round_trips(_demux("audio"))
+
+    def test_image_packets_round_trip(self) -> None:
+        """ImagePackets offload to / restore from the arena unchanged."""
+        self._assert_round_trips(_demux("image"))
+
+    def test_restored_view_decodes_like_original(self) -> None:
+        """Decoding pool-restored (zero-copy view) packets matches the original."""
+        packets = _demux("video")
+        original = spdl.io.to_numpy(
+            spdl.io.convert_frames(spdl.io.decode_packets(packets.clone()))
+        )
+
+        pool = self._pool(1 << 20, 2)
+        writer, reader = pool.open_writer(), pool.open_reader()
+        registry = _default_registry()
+        out = _restore(_offload({"p": packets}, writer, registry), reader, registry)
+        result = spdl.io.to_numpy(
+            spdl.io.convert_frames(
+                spdl.io.decode_packets(cast(dict[str, Any], out)["p"])
+            )
+        )
+
+        np.testing.assert_array_equal(original, result, strict=True)
+        del out, result
+        gc.collect()
+
+    def test_segment_held_until_packets_released(self) -> None:
+        """The pool keeps a segment until the restored (view) packets are gone."""
+        pool = self._pool(1 << 20, 2)
+        writer, reader = pool.open_writer(), pool.open_reader()
+        registry = _default_registry()
+        out = _restore(
+            _offload({"p": _demux("video")}, writer, registry), reader, registry
+        )
+        # The restored packets are a zero-copy view: the segment is still pinned.
+        self.assertEqual(pool.reclaimed, 0)
+        del out
+        gc.collect()
+        # Once the view is dropped, the segment returns to the pool.
+        self.assertEqual(pool.reclaimed, 1)
+
+    def test_packets_stay_inline_above_threshold(self) -> None:
+        """With a threshold above the payload, Packets are pickled inline (via
+        copyreg) rather than offloaded, and still round-trip correctly."""
+        pool = self._pool(1 << 20, 2)
+        writer, reader = pool.open_writer(), pool.open_reader()
+        registry = _default_registry()
+        packets = _demux("video")
+        state = packets.__getstate__()
+        # A threshold larger than the payload keeps it inline: the envelope then
+        # carries the full serialized bytes itself, instead of a small marker.
+        inline = _offload({"p": packets}, writer, registry, threshold=len(state) + 1)
+        offloaded = _offload({"p": packets}, writer, registry, threshold=len(state))
+        self.assertGreater(len(inline), len(state))
+        self.assertLess(len(offloaded), len(inline))
+        out = _restore(inline, reader, registry)
+        self.assertEqual(cast(dict[str, Any], out)["p"].__getstate__(), state)
+
+
+class IterateInSubprocessPacketsTest(unittest.TestCase):
+    def test_packets_round_trip_through_subprocess(self) -> None:
+        """Packets yielded by a subprocess iterator round-trip through the arena."""
+        # Generate each sample once and keep the SrcInfo objects alive so their
+        # temp dirs survive for the duration of the test. The serialized packet
+        # state embeds the source path, so the subprocess worker and the local
+        # ``expected`` must demux the *same* files for the bytes to match.
+        media = ("audio", "video", "image")
+        samples = [get_sample(CMDS[mt]) for mt in media]
+        paths = [(mt, s.path) for mt, s in zip(media, samples)]
+        fn = functools.partial(_demux_from_paths, paths)
+
+        pool = SharedMemorySegmentPool(segment_size=1 << 20, count=4)
+        self.addCleanup(pool.unlink)
+        self.addCleanup(pool.close)
+        got = list(iterate_in_subprocess(fn, arena=pool, buffer_size=2))
+
+        expected = _demux_from_paths(paths)
+        self.assertEqual(len(got), len(expected))
+        for g, e in zip(got, expected):
+            self.assertIs(type(g), type(e))
+            self.assertEqual(g.__getstate__(), e.__getstate__())

--- a/tests/pipeline/arena_pool_test.py
+++ b/tests/pipeline/arena_pool_test.py
@@ -1,0 +1,303 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import gc
+import struct
+import threading
+import time
+import unittest
+from typing import Any, cast
+
+from spdl.pipeline import iterate_in_subprocess, SharedMemorySegmentPool
+from spdl.pipeline._arena._offload import _offload, _restore
+from spdl.pipeline._arena._registry import _default_registry
+
+
+def _make_items() -> list[dict[str, bytes | int]]:
+    return [{"i": i, "blob": bytes([i % 256]) * 40_000} for i in range(8)]
+
+
+class SharedMemorySegmentPoolTest(unittest.TestCase):
+    def _pool(
+        self, segment_size: int, count: int, acquire_timeout: float = 60.0
+    ) -> SharedMemorySegmentPool:
+        pool = SharedMemorySegmentPool(
+            segment_size=segment_size, count=count, acquire_timeout=acquire_timeout
+        )
+        self.addCleanup(pool.unlink)
+        self.addCleanup(pool.close)
+        return pool
+
+    def test_unit_round_trips_through_a_segment(self) -> None:
+        """A unit written to a segment reads back byte-for-byte."""
+        pool = self._pool(1 << 16, 2)
+        writer, reader = pool.open_writer(), pool.open_reader()
+        writer.begin_unit()
+        off, n = writer.write_binary(b"hello pool")
+        span = writer.commit_unit()
+        self.assertEqual(reader.read_binary(off, n), b"hello pool")
+        reader.end_unit(span, [])
+
+    def test_units_rotate_across_segments(self) -> None:
+        """Consecutive units land in successive segments and round-trip."""
+        pool = self._pool(1 << 16, 3)
+        writer, reader = pool.open_writer(), pool.open_reader()
+        for i in range(10):
+            payload = bytes([i % 256]) * 1000
+            writer.begin_unit()
+            off, n = writer.write_binary(payload)
+            span = writer.commit_unit()
+            self.assertEqual(reader.read_binary(off, n), payload)
+            reader.end_unit(span, [])
+
+    def test_write_binary_offsets_are_aligned(self) -> None:
+        """Each binary is placed on a 64-byte boundary (for zero-copy views)."""
+        pool = self._pool(1 << 16, 2)
+        writer = pool.open_writer()
+        writer.begin_unit()
+        off1, _ = writer.write_binary(b"x" * 10)
+        off2, _ = writer.write_binary(b"y" * 100)
+        off3, _ = writer.write_binary(b"z" * 3)
+        writer.commit_unit()
+        self.assertEqual(off1 % 64, 0)
+        self.assertEqual(off2 % 64, 0)
+        self.assertEqual(off3 % 64, 0)
+
+    def test_close_tolerates_live_view(self) -> None:
+        """close() must not raise even if a zero-copy view still maps a segment."""
+        try:
+            import numpy as np
+        except ImportError:
+            self.skipTest("numpy not available")
+        pool = SharedMemorySegmentPool(segment_size=1 << 20, count=2)
+        self.addCleanup(pool.unlink)
+        writer, reader = pool.open_writer(), pool.open_reader()
+        registry = _default_registry()
+        out = _restore(
+            _offload({"a": np.arange(1000, dtype=np.int64)}, writer, registry),
+            reader,
+            registry,
+        )
+        view = cast(dict[str, Any], out)["a"]
+        # A live view keeps the segment exported; close() must not raise.
+        pool.close()
+        pool.unlink()
+        # The view is still valid after close()+unlink() (the mapping persists
+        # until it is released).
+        self.assertEqual(int(view[0]), 0)
+        del out, view
+        gc.collect()
+
+    def test_exhausted_pool_raises(self) -> None:
+        """With acquire_timeout=0 (Mode A), a unit with no free segment is refused."""
+        pool = self._pool(1 << 16, 1, acquire_timeout=0.0)
+        writer = pool.open_writer()
+        writer.begin_unit()
+        writer.write_binary(b"x" * 10)
+        writer.commit_unit()  # the single segment is now in flight (unreclaimed)
+        with self.assertRaises(BufferError):
+            writer.begin_unit()
+
+    def test_begin_unit_blocks_until_reclaim(self) -> None:
+        """Mode B: begin_unit waits for a reclaim instead of failing when full."""
+        pool: SharedMemorySegmentPool = self._pool(1 << 16, 1, acquire_timeout=5.0)
+        writer = pool.open_writer()
+        writer.begin_unit()
+        writer.write_binary(b"x" * 10)
+        writer.commit_unit()  # pool full: published=1, reclaimed=0, count=1
+
+        def _reclaim_soon() -> None:
+            time.sleep(0.1)
+            pool.reclaimed = pool.reclaimed + 1  # simulate the consumer releasing
+
+        t = threading.Thread(target=_reclaim_soon)
+        t.start()
+        try:
+            # Blocks ~0.1s until the reclaim, then succeeds (does not raise).
+            writer.begin_unit()
+        finally:
+            t.join()
+        off, n = writer.write_binary(b"y" * 10)
+        self.assertEqual(writer.commit_unit(), n)
+
+    def test_unit_larger_than_segment_raises(self) -> None:
+        """A unit that does not fit a segment is refused, not truncated."""
+        pool = self._pool(1024, 2)
+        writer = pool.open_writer()
+        writer.begin_unit()
+        with self.assertRaises(BufferError):
+            writer.write_binary(b"x" * 2048)
+
+    def test_offload_restore_round_trips(self) -> None:
+        """A nested object with a large field round-trips via the pool."""
+        pool = self._pool(1 << 20, 2)
+        writer, reader = pool.open_writer(), pool.open_reader()
+        registry = _default_registry()
+        obj = {"id": 3, "blob": b"q" * 200_000, "tags": ["x"]}
+        self.assertEqual(
+            _restore(_offload(obj, writer, registry), reader, registry), obj
+        )
+
+    def test_numpy_restore_is_a_zero_copy_view(self) -> None:
+        """A restored NumPy array aliases the segment (no copy)."""
+        try:
+            import numpy as np
+        except ImportError:
+            self.skipTest("numpy not available")
+        pool = self._pool(1 << 20, 2)
+        writer, reader = pool.open_writer(), pool.open_reader()
+        registry = _default_registry()
+        arr = np.arange(1000, dtype=np.int64)
+        out = _restore(_offload({"a": arr}, writer, registry), reader, registry)
+        view = cast(dict[str, Any], out)["a"]
+        self.assertTrue(np.array_equal(view, arr))
+        # Mutating the segment's first int64 is observed through the view, which
+        # proves the view aliases shared memory rather than a copy.
+        struct.pack_into("<q", pool._segment(0), 0, 999)
+        self.assertEqual(int(view[0]), 999)
+        # Release the view before teardown so close() has no live exports.
+        del out, view
+        gc.collect()
+
+    def test_segment_reclaimed_only_after_view_released(self) -> None:
+        """The pool holds a segment until its zero-copy view is dropped."""
+        try:
+            import numpy as np
+        except ImportError:
+            self.skipTest("numpy not available")
+        pool = self._pool(1 << 20, 2)
+        writer, reader = pool.open_writer(), pool.open_reader()
+        registry = _default_registry()
+        out = _restore(
+            _offload({"a": np.arange(1000, dtype=np.int64)}, writer, registry),
+            reader,
+            registry,
+        )
+        # The view pins the segment: nothing reclaimed yet.
+        self.assertEqual(pool.reclaimed, 0)
+        del out
+        gc.collect()
+        # Once the view is gone, the segment returns to the pool.
+        self.assertEqual(pool.reclaimed, 1)
+
+    def test_torch_restore_is_a_zero_copy_view(self) -> None:
+        """A restored Torch tensor aliases the segment (no copy)."""
+        try:
+            import torch
+        except ImportError:
+            self.skipTest("torch not available")
+        pool = self._pool(1 << 20, 2)
+        writer, reader = pool.open_writer(), pool.open_reader()
+        registry = _default_registry()
+        out = _restore(
+            _offload({"a": torch.arange(1000, dtype=torch.int64)}, writer, registry),
+            reader,
+            registry,
+        )
+        view = cast(dict[str, Any], out)["a"]
+        # Mutating the segment is observed through the tensor -> zero-copy view.
+        struct.pack_into("<q", pool._segment(0), 0, 999)
+        self.assertEqual(int(view[0]), 999)
+        del out, view
+        gc.collect()
+
+    def test_torch_segment_held_until_view_released(self) -> None:
+        """A Torch view outliving the original tensor still pins the segment."""
+        try:
+            import torch
+        except ImportError:
+            self.skipTest("torch not available")
+        pool = self._pool(1 << 20, 2)
+        writer, reader = pool.open_writer(), pool.open_reader()
+        registry = _default_registry()
+        out = _restore(
+            _offload({"a": torch.arange(1000, dtype=torch.int64)}, writer, registry),
+            reader,
+            registry,
+        )
+        view = cast(dict[str, Any], out)["a"][100:200]  # a view sharing storage
+        del out
+        gc.collect()
+        self.assertEqual(pool.reclaimed, 0)
+        del view
+        gc.collect()
+        self.assertEqual(pool.reclaimed, 1)
+
+    def test_segment_held_until_shallow_copy_released(self) -> None:
+        """A view/shallow copy outliving the original array still pins the segment."""
+        try:
+            import numpy as np
+        except ImportError:
+            self.skipTest("numpy not available")
+        pool = self._pool(1 << 20, 2)
+        writer, reader = pool.open_writer(), pool.open_reader()
+        registry = _default_registry()
+        out = _restore(
+            _offload({"a": np.arange(1000, dtype=np.int64)}, writer, registry),
+            reader,
+            registry,
+        )
+        # A slice shares the segment's memory but is a different object whose
+        # base chain skips the array we first received.
+        view = cast(dict[str, Any], out)["a"][100:200]
+        del out
+        gc.collect()
+        # The lifetime is tracked on the underlying memoryview, not the array
+        # object, so the segment is still held while the slice is alive.
+        self.assertEqual(pool.reclaimed, 0)
+        del view
+        gc.collect()
+        self.assertEqual(pool.reclaimed, 1)
+
+    def test_bytes_like_restore_is_a_zero_copy_view(self) -> None:
+        """On the pool, bytes/bytearray/memoryview all restore as a memoryview
+        aliasing the segment, held until the view is released."""
+        for label, src in (
+            ("bytes", b"\xab" * 100_000),
+            ("bytearray", bytearray(b"\xcd" * 100_000)),
+            ("memoryview", memoryview(b"\xef" * 100_000)),
+        ):
+            with self.subTest(input=label):
+                pool = self._pool(1 << 20, 2)
+                writer, reader = pool.open_writer(), pool.open_reader()
+                registry = _default_registry()
+                out = _restore(_offload({"b": src}, writer, registry), reader, registry)
+                view = cast(dict[str, Any], out)["b"]
+                # Every input type comes back as a memoryview (the zero-copy path).
+                self.assertIsInstance(view, memoryview)
+                self.assertEqual(bytes(view), bytes(src))
+                # The view aliases shared memory: a write to the segment shows
+                # through, proving no copy was made.
+                pool._segment(0)[0:1] = b"\x00"
+                self.assertEqual(view[0], 0)
+                # The segment stays reserved until the view is released.
+                self.assertEqual(pool.reclaimed, 0)
+                del out, view
+                gc.collect()
+                self.assertEqual(pool.reclaimed, 1)
+
+
+class IterateInSubprocessSegmentPoolTest(unittest.TestCase):
+    def test_round_trip_through_segment_pool(self) -> None:
+        """Items round-trip end-to-end through a segment-pool arena.
+
+        The pool restores offloaded bytes as zero-copy memoryviews, so each item
+        is materialized (releasing its view) before the next is pulled, keeping the
+        small pool from being exhausted by held views.
+        """
+        pool = SharedMemorySegmentPool(segment_size=1 << 18, count=4)
+        got = []
+        for item in iterate_in_subprocess(_make_items, arena=pool, buffer_size=2):
+            got.append(
+                {
+                    k: bytes(v) if isinstance(v, memoryview) else v
+                    for k, v in item.items()
+                }
+            )
+            del item  # release the zero-copy view so its segment can be reclaimed
+        self.assertEqual(got, _make_items())


### PR DESCRIPTION
Summary:

Adds a second arena backend behind the `buffer` argument of `iterate_in_subprocess`: a rotating pool of shared-memory segments, one segment per unit, that restores payloads as zero-copy views.

`SharedMemorySegmentPool` rotates through a fixed number of isolated segments. Two segment counters live in a small control segment (`published` by the worker, `reclaimed` by the parent); unit `i` always uses segment `i % count`, so the reader derives the segment from its own cursor and markers only need an in-segment offset. Because each unit owns a whole contiguous segment, the reader returns restored NumPy/Torch payloads as live views directly over shared memory — no copy.

A segment is returned to the pool only once every view of its unit is released. This is tracked with `weakref.finalize` on the lifetime anchor returned by `from_buffer` (the `np.frombuffer` array / Torch tensor), not on the restored object: a reshape, slice, or shallow copy shares the buffer but is a different object, and NumPy/Torch do not retain the exact `memoryview` passed in, so anchoring on either would reclaim the segment too early. The writer is gated by `reclaimed` (`free = count - (published - reclaimed)`), so it never reuses a segment that still has live views. Backpressure is non-blocking: acquiring a unit raises if no segment is free. It is exported as the public `spdl.pipeline.SharedMemorySegmentPool`.

Reviewed By: gl3lan, huangruizhe

Differential Revision: D107709115


