### PR TITLE
Add SharedMemoryRingBuffer arena backend

### DIFF
--- a/src/spdl/pipeline/__init__.py
+++ b/src/spdl/pipeline/__init__.py
@@ -8,7 +8,7 @@
 
 # pyre-strict
 
-from ._arena import SharedMemorySegmentPool
+from ._arena import SharedMemoryRingBuffer, SharedMemorySegmentPool
 from ._bg_task import BackgroundTask, BackgroundTaskFactory
 from ._build import (
     build_pipeline,
@@ -78,6 +78,7 @@ __all__ = [
     "iterate_in_subprocess",
     "run_pipeline_in_subprocess",
     "run_pipeline_in_subinterpreter",
+    "SharedMemoryRingBuffer",
     "SharedMemorySegmentPool",
 ]
 

--- a/src/spdl/pipeline/_arena/__init__.py
+++ b/src/spdl/pipeline/_arena/__init__.py
@@ -11,11 +11,13 @@
 from ._arena import _Arena
 from ._pool import SharedMemorySegmentPool
 from ._protocol import ArenaProtocol, ArenaReaderProtocol, ArenaWriterProtocol
+from ._ring import SharedMemoryRingBuffer
 
 __all__ = [
     "ArenaProtocol",
     "ArenaReaderProtocol",
     "ArenaWriterProtocol",
+    "SharedMemoryRingBuffer",
     "SharedMemorySegmentPool",
     "_Arena",
 ]

--- a/src/spdl/pipeline/_arena/_ring.py
+++ b/src/spdl/pipeline/_arena/_ring.py
@@ -1,0 +1,267 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""Single shared-memory ring buffer — the first-cut arena backend.
+
+A :py:class:`SharedMemoryRingBuffer` is a fixed-size contiguous shared-memory
+block that carries large binary payloads from a worker process to a parent
+process. It is the simplest object accepted by the ``arena`` argument of
+:py:func:`spdl.pipeline.iterate_in_subprocess`.
+
+The block starts with a small control header holding two absolute byte
+cursors — ``head`` (advanced by the writer when it publishes a unit) and
+``tail`` (advanced by the reader when it releases a unit) — followed by the
+payload arena. Free space is ``capacity - (head - tail)``.
+
+Writes that cross the physical end of the arena are split into two copies, so
+the wrap-around is invisible to callers. A "unit" (one pipeline item, which may
+contain several binaries) is written at successive offsets and published once,
+and released once, so reservation/return happen in bulk per unit.
+"""
+
+from __future__ import annotations
+
+import struct
+from multiprocessing import shared_memory
+from typing import TypedDict
+
+from ._shm import _attach
+
+__all__ = ["SharedMemoryRingBuffer"]
+
+
+class _RingState(TypedDict):
+    """Picklable state of a :py:class:`SharedMemoryRingBuffer`."""
+
+    shm_name: str
+    capacity: int
+
+
+# Control header: head, tail (absolute, monotonic byte counters).
+_HEADER: struct.Struct = struct.Struct("<QQ")
+_HEADER_SIZE: int = _HEADER.size  # 16
+
+
+class SharedMemoryRingBuffer:
+    """**[Experimental]** A single shared-memory ring buffer for cross-process payloads.
+
+    Construct it in the parent process and pass it to
+    :py:func:`spdl.pipeline.iterate_in_subprocess` via the ``arena`` argument;
+    ownership transfers to that call, which closes and unlinks it at teardown.
+
+    Args:
+        capacity: Size of the payload arena in bytes. Must be at least as large
+            as the biggest single pipeline unit (the sum of the binaries
+            offloaded from one item). Size it to the in-flight high-water mark,
+            roughly ``(buffer_size + 2) * max_unit_bytes``.
+    """
+
+    def __init__(self, capacity: int) -> None:
+        if capacity <= 0:
+            raise ValueError("capacity must be positive")
+        self._capacity: int = capacity
+        shm = shared_memory.SharedMemory(create=True, size=_HEADER_SIZE + capacity)
+        self._shm_name: str = shm.name
+        self._shm: shared_memory.SharedMemory | None = shm
+        self._buf: "memoryview[bytes] | None" = shm.buf
+        _HEADER.pack_into(shm.buf, 0, 0, 0)
+
+    # -- pickling: carry only the spec; attach lazily, once, per process --
+
+    def __getstate__(self) -> _RingState:
+        return {"shm_name": self._shm_name, "capacity": self._capacity}
+
+    def __setstate__(self, state: _RingState) -> None:
+        self._shm_name = state["shm_name"]
+        self._capacity = state["capacity"]
+        self._shm = None
+        self._buf = None
+
+    @property
+    def capacity(self) -> int:
+        """Size of the payload arena in bytes."""
+        return self._capacity
+
+    @property
+    def name(self) -> str:
+        """Name of the underlying shared-memory segment."""
+        return self._shm_name
+
+    def _ensure(self) -> "memoryview[bytes]":
+        if self._buf is None:
+            self._shm = _attach(self._shm_name)
+            self._buf = self._shm.buf
+        return self._buf
+
+    @property
+    def head(self) -> int:
+        """Absolute byte count published by the writer."""
+        return int(_HEADER.unpack_from(self._ensure(), 0)[0])
+
+    @head.setter
+    def head(self, value: int) -> None:
+        struct.pack_into("<Q", self._ensure(), 0, value)
+
+    @property
+    def tail(self) -> int:
+        """Absolute byte count released by the reader."""
+        return int(_HEADER.unpack_from(self._ensure(), 0)[1])
+
+    @tail.setter
+    def tail(self, value: int) -> None:
+        struct.pack_into("<Q", self._ensure(), 8, value)
+
+    def open_writer(self) -> _RingWriter:
+        """Return the writer endpoint (call in the worker process)."""
+        return _RingWriter(self, self._ensure())
+
+    def open_reader(self) -> _RingReader:
+        """Return the reader endpoint (call in the parent process)."""
+        return _RingReader(self, self._ensure())
+
+    def close(self) -> None:
+        """Release this process's mapping of the segment."""
+        if self._buf is not None:
+            self._buf.release()
+            self._buf = None
+        if self._shm is not None:
+            self._shm.close()
+            self._shm = None
+
+    def unlink(self) -> None:
+        """Remove the segment from the system (call once, by the owner)."""
+        shm = self._shm
+        temporary = shm is None
+        if shm is None:
+            # Already closed in this process: attach a temporary handle just to
+            # unlink, using _attach so it is not (re)registered with the
+            # resource_tracker, and close it afterwards so its mapping is freed.
+            try:
+                shm = _attach(self._shm_name)
+            except FileNotFoundError:
+                return
+        try:
+            shm.unlink()
+        except FileNotFoundError:
+            pass
+        finally:
+            if temporary:
+                shm.close()
+
+
+class _RingWriter:
+    """Writer endpoint. Used as the last step in the worker process."""
+
+    def __init__(self, buf: SharedMemoryRingBuffer, mv: "memoryview[bytes]") -> None:
+        self._b = buf
+        self._mv = mv
+        self._cap: int = buf.capacity
+        self._data_off: int = _HEADER_SIZE
+        self._ustart: int = 0
+        self._wpos: int = 0
+
+    def reset(self) -> None:
+        """Reclaim all space at an iteration boundary.
+
+        Safe to set both cursors here because the parent is quiescent (waiting
+        for ``ITERATION_STARTED``) and has not started reading the new
+        iteration; any residual bytes from an abandoned iteration are discarded.
+        """
+        self._b.head = 0
+        self._b.tail = 0
+        self._ustart = self._wpos = 0
+
+    def begin_unit(self) -> None:
+        """Start a new unit at the current published head."""
+        self._ustart = self._wpos = self._b.head
+
+    def write_binary(
+        self, data: "bytes | bytearray | memoryview[bytes]"
+    ) -> tuple[int, int]:
+        """Copy one binary into the arena; return its ``(offset, nbytes)``.
+
+        Non-blocking: raises :py:exc:`BufferError` if the in-progress unit would
+        exceed the free space (Mode A relies on the queue backpressure keeping
+        the arena from filling; an overrun means the capacity is too small).
+        """
+        mv = memoryview(data).cast("B")
+        n = mv.nbytes
+        used = self._wpos - self._b.tail
+        free = self._cap - used
+        if n > free:
+            raise BufferError(
+                f"shared-memory arena full: need {n} more bytes but only {free} "
+                "free; increase SharedMemoryRingBuffer capacity"
+            )
+        buf = self._mv
+        d = self._data_off
+        idx = self._wpos % self._cap
+        end_run = self._cap - idx
+        if n <= end_run:
+            buf[d + idx : d + idx + n] = mv
+        else:
+            buf[d + idx : d + self._cap] = mv[:end_run]
+            buf[d : d + (n - end_run)] = mv[end_run:]
+        self._wpos += n
+        return idx, n
+
+    def commit_unit(self) -> int:
+        """Publish the unit (advance head); return the unit's byte span."""
+        self._b.head = self._wpos
+        return self._wpos - self._ustart
+
+    def abort_unit(self) -> None:
+        """Discard an in-progress unit without publishing it."""
+        self._wpos = self._ustart
+
+
+class _RingReader:
+    """Reader endpoint. Used as the first step in the parent process."""
+
+    # ``read_binary`` copies each payload out into a fresh private buffer (the ring
+    # reuses its space immediately), so restored values never alias shared memory.
+    zero_copy: bool = False
+
+    def __init__(self, buf: SharedMemoryRingBuffer, mv: "memoryview[bytes]") -> None:
+        self._b = buf
+        self._mv = mv
+        self._cap: int = buf.capacity
+        self._data_off: int = _HEADER_SIZE
+
+    def reset(self) -> None:
+        """No-op: the writer resets both cursors at the iteration boundary."""
+
+    def read_binary(self, offset: int, nbytes: int) -> "memoryview[bytes]":
+        """Copy ``nbytes`` out of the arena starting at physical ``offset``.
+
+        The ring reuses its space immediately, so it cannot hand out a live view;
+        it always copies into a fresh writable buffer (concatenating across the
+        physical seam when the payload wraps). Restored views therefore alias the
+        copy, not shared memory.
+        """
+        buf = self._mv
+        d = self._data_off
+        end_run = self._cap - offset
+        if nbytes <= end_run:
+            data = bytes(buf[d + offset : d + offset + nbytes])
+        else:
+            data = bytes(buf[d + offset : d + self._cap]) + bytes(
+                buf[d : d + (nbytes - end_run)]
+            )
+        # Wrap in a bytearray so the restored view is writable (and so Torch's
+        # frombuffer does not warn about a read-only buffer).
+        return memoryview(bytearray(data))
+
+    def end_unit(self, span: int, pinned: list[object]) -> None:
+        """Return the unit's region in bulk (advance tail).
+
+        ``pinned`` is ignored: read_binary already copied the data out, so
+        restored views alias the copy, not the ring, and the region is free to
+        reuse immediately.
+        """
+        self._b.tail = self._b.tail + span

--- a/tests/pipeline/arena_packets_test.py
+++ b/tests/pipeline/arena_packets_test.py
@@ -13,7 +13,11 @@ from typing import Any, cast
 
 import numpy as np
 import spdl.io
-from spdl.pipeline import iterate_in_subprocess, SharedMemorySegmentPool
+from spdl.pipeline import (
+    iterate_in_subprocess,
+    SharedMemoryRingBuffer,
+    SharedMemorySegmentPool,
+)
 from spdl.pipeline._arena._offload import _offload, _restore
 from spdl.pipeline._arena._registry import _default_registry
 
@@ -66,6 +70,24 @@ class PacketsOffloadTest(unittest.TestCase):
     def test_image_packets_round_trip(self) -> None:
         """ImagePackets offload to / restore from the arena unchanged."""
         self._assert_round_trips(_demux("image"))
+
+    def _ring(self, capacity: int) -> SharedMemoryRingBuffer:
+        buf = SharedMemoryRingBuffer(capacity=capacity)
+        self.addCleanup(buf.unlink)
+        self.addCleanup(buf.close)
+        return buf
+
+    def test_round_trips_through_ring_buffer(self) -> None:
+        """The ring copies payloads out, so restored Packets reconstruct the
+        original concrete type (unlike the pool's zero-copy view)."""
+        buf = self._ring(1 << 20)
+        writer, reader = buf.open_writer(), buf.open_reader()
+        registry = _default_registry()
+        original = _demux("video")
+        out = _restore(_offload({"p": original}, writer, registry), reader, registry)
+        restored = cast(dict[str, Any], out)["p"]
+        self.assertIs(type(restored), type(original))
+        self.assertEqual(restored.__getstate__(), original.__getstate__())
 
     def test_restored_view_decodes_like_original(self) -> None:
         """Decoding pool-restored (zero-copy view) packets matches the original."""

--- a/tests/pipeline/arena_ring_test.py
+++ b/tests/pipeline/arena_ring_test.py
@@ -1,0 +1,161 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import unittest
+from typing import Any, cast
+
+from spdl.pipeline._arena import SharedMemoryRingBuffer
+from spdl.pipeline._arena._offload import _offload, _restore
+from spdl.pipeline._arena._registry import _default_registry
+
+
+class SharedMemoryRingBufferTest(unittest.TestCase):
+    def _ring(self, capacity: int) -> SharedMemoryRingBuffer:
+        buf = SharedMemoryRingBuffer(capacity=capacity)
+        self.addCleanup(buf.unlink)
+        self.addCleanup(buf.close)
+        return buf
+
+    def test_write_then_read_round_trips(self) -> None:
+        """A binary written to the arena reads back byte-for-byte."""
+        buf = self._ring(1 << 16)
+        writer = buf.open_writer()
+        reader = buf.open_reader()
+        writer.begin_unit()
+        offset, nbytes = writer.write_binary(b"hello world")
+        span = writer.commit_unit()
+        self.assertEqual(reader.read_binary(offset, nbytes), b"hello world")
+        reader.end_unit(span, [])
+
+    def test_reader_sees_nothing_until_unit_committed(self) -> None:
+        """A unit is invisible to the reader until it is published."""
+        buf = self._ring(1 << 16)
+        writer = buf.open_writer()
+        writer.begin_unit()
+        writer.write_binary(b"x" * 100)
+        # head is only advanced by commit_unit, so the reader's view is empty.
+        self.assertEqual(buf.head, 0)
+        writer.commit_unit()
+        self.assertEqual(buf.head, 100)
+
+    def test_release_advances_tail_in_bulk(self) -> None:
+        """Releasing a unit returns its whole region in one tail advance."""
+        buf = self._ring(1 << 16)
+        writer = buf.open_writer()
+        reader = buf.open_reader()
+        writer.begin_unit()
+        writer.write_binary(b"a" * 30)
+        writer.write_binary(b"b" * 70)
+        span = writer.commit_unit()
+        self.assertEqual(span, 100)
+        reader.end_unit(span, [])
+        self.assertEqual(buf.tail, 100)
+
+    def test_payload_wrapping_physical_end_is_intact(self) -> None:
+        """Data that straddles the physical end of the arena is preserved."""
+        buf = self._ring(64)
+        writer = buf.open_writer()
+        reader = buf.open_reader()
+        # Consume most of the arena so the next write wraps the seam.
+        writer.begin_unit()
+        off0, n0 = writer.write_binary(b"p" * 50)
+        writer.commit_unit()
+        reader.read_binary(off0, n0)
+        reader.end_unit(50, [])
+
+        writer.begin_unit()
+        offset, nbytes = writer.write_binary(b"abcdefghijklmnop")  # 16 bytes, wraps
+        span = writer.commit_unit()
+        self.assertEqual(reader.read_binary(offset, nbytes), b"abcdefghijklmnop")
+        reader.end_unit(span, [])
+
+    def test_overrun_raises(self) -> None:
+        """A write larger than the free space is refused, not truncated."""
+        buf = self._ring(64)
+        writer = buf.open_writer()
+        writer.begin_unit()
+        with self.assertRaises(BufferError):
+            writer.write_binary(b"x" * 128)
+
+
+class OffloadRestoreTest(unittest.TestCase):
+    def _ring(self, capacity: int) -> SharedMemoryRingBuffer:
+        buf = SharedMemoryRingBuffer(capacity=capacity)
+        self.addCleanup(buf.unlink)
+        self.addCleanup(buf.close)
+        return buf
+
+    def test_large_bytes_round_trip_through_arena(self) -> None:
+        """A nested object with a large bytes field round-trips via the arena."""
+        buf = self._ring(1 << 20)
+        writer, reader = buf.open_writer(), buf.open_reader()
+        registry = _default_registry()
+        obj = {"id": 7, "blob": b"z" * 100_000, "tags": ["a", "b"]}
+        out = _restore(_offload(obj, writer, registry), reader, registry)
+        self.assertEqual(out, obj)
+
+    def test_bytes_like_inputs_preserve_type_on_ring(self) -> None:
+        """The ring copies payloads out, so bytes/bytearray/memoryview inputs each
+        restore as the same type with identical contents (it is not the zero-copy
+        backend, so the original type is reconstructed)."""
+        base = bytes(range(256)) * 1000  # 256_000 bytes, above the threshold
+        cases = [
+            ("bytes", base, bytes),
+            ("bytearray", bytearray(base), bytearray),
+            ("memoryview", memoryview(base), memoryview),
+            ("noncontiguous_memoryview", memoryview(base)[::2], memoryview),
+        ]
+        for label, src, expected_type in cases:
+            with self.subTest(input=label):
+                buf = self._ring(1 << 20)
+                writer, reader = buf.open_writer(), buf.open_reader()
+                registry = _default_registry()
+                out = cast(
+                    dict[str, Any],
+                    _restore(_offload({"b": src}, writer, registry), reader, registry),
+                )
+                self.assertIsInstance(out["b"], expected_type)
+                self.assertEqual(bytes(out["b"]), bytes(src))
+
+    def test_small_fields_stay_inline(self) -> None:
+        """Fields below the threshold are not offloaded (zero arena span)."""
+        buf = self._ring(1 << 16)
+        writer, reader = buf.open_writer(), buf.open_reader()
+        registry = _default_registry()
+        blob = _offload({"small": b"tiny", "n": 5}, writer, registry)
+        # First 8 bytes encode the unit span; nothing offloaded -> span 0.
+        self.assertEqual(blob[:8], b"\x00" * 8)
+        self.assertEqual(_restore(blob, reader, registry), {"small": b"tiny", "n": 5})
+
+    def test_many_units_reuse_wrapped_space(self) -> None:
+        """Repeated offload/restore reuses arena space across the wrap point."""
+        buf = self._ring(8192)
+        writer, reader = buf.open_writer(), buf.open_reader()
+        registry = _default_registry()
+        for i in range(100):
+            payload = bytes([i % 256]) * 5000
+            obj = {"i": i, "blob": payload}
+            out = _restore(_offload(obj, writer, registry), reader, registry)
+            self.assertEqual(out, obj)
+
+    def test_numpy_array_round_trips(self) -> None:
+        """A NumPy array offloaded to the arena restores equal."""
+        try:
+            import numpy as np
+        except ImportError:
+            self.skipTest("numpy not available")
+        buf = self._ring(1 << 20)
+        writer, reader = buf.open_writer(), buf.open_reader()
+        registry = _default_registry()
+        arr = np.arange(10_000, dtype=np.float64).reshape(100, 100)
+        out = cast(
+            dict[str, Any],
+            _restore(_offload({"a": arr}, writer, registry), reader, registry),
+        )
+        self.assertTrue(np.array_equal(out["a"], arr))
+        self.assertEqual(out["a"].dtype, arr.dtype)

--- a/tests/pipeline/iterate_in_subprocess_arena_test.py
+++ b/tests/pipeline/iterate_in_subprocess_arena_test.py
@@ -1,0 +1,45 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import unittest
+from collections.abc import Iterable, Iterator
+
+from spdl.pipeline import iterate_in_subprocess, SharedMemoryRingBuffer
+
+
+def _make_items() -> list[dict[str, bytes | int]]:
+    return [{"i": i, "blob": bytes([i % 256]) * 50_000} for i in range(8)]
+
+
+def _failing_iterable() -> Iterator[dict[str, bytes | int]]:
+    yield {"i": 0, "blob": b"x" * 50_000}
+    raise ValueError("boom")
+
+
+class IterateInSubprocessArenaTest(unittest.TestCase):
+    def test_round_trip_through_arena(self) -> None:
+        """Items with large bytes round-trip through the shared-memory arena."""
+        buf = SharedMemoryRingBuffer(capacity=1 << 20)
+        got = list(iterate_in_subprocess(_make_items, arena=buf, buffer_size=2))
+        self.assertEqual(got, _make_items())
+
+    def test_reiteration_yields_full_sequence(self) -> None:
+        """Re-iterating the reused worker reclaims the arena and yields all items."""
+        buf = SharedMemoryRingBuffer(capacity=1 << 20)
+        it: Iterable[dict[str, bytes | int]] = iterate_in_subprocess(
+            _make_items, arena=buf, buffer_size=2
+        )
+        self.assertEqual(list(it), _make_items())
+        self.assertEqual(list(it), _make_items())
+
+    def test_worker_error_propagates_without_hanging(self) -> None:
+        """A worker exception surfaces as RuntimeError instead of deadlocking."""
+        buf = SharedMemoryRingBuffer(capacity=1 << 20)
+        it = iterate_in_subprocess(_failing_iterable, arena=buf, buffer_size=2)
+        with self.assertRaises(RuntimeError):
+            list(it)


### PR DESCRIPTION
Summary:
Adds the first concrete arena backend behind the `buffer` argument of `iterate_in_subprocess`: a single fixed-size contiguous shared-memory ring.

`SharedMemoryRingBuffer` holds two absolute byte cursors (`head` advanced by the writer on publish, `tail` advanced by the reader on release) in a small header followed by the payload arena; free space is `capacity - (head - tail)`. A unit's binaries are written at successive offsets and published once, then released once, so reservation and return happen in bulk per unit. Writes that cross the physical end of the arena are split into two copies, hiding the wrap-around behind a normal interface.

This backend copies payloads out on the reader side (the ring reuses its space immediately, so it cannot hand out live views) and never blocks the writer: it relies on the existing `data_q` backpressure plus a non-blocking capacity check that raises if the arena is undersized. It is exported as the public `spdl.pipeline.SharedMemoryRingBuffer`.

Differential Revision: D107709117


