### PR TITLE
Enable Pyrefly in fbcode/spdl

### DIFF
--- a/examples/benchmark_numpy.py
+++ b/examples/benchmark_numpy.py
@@ -146,7 +146,9 @@ def get_mock_data(format: str, compressed: bool = False) -> tuple[bytes, bytes] 
         Serialized mock arrays. If ``"npy"`` then arrays are serialized
         separately. Otherwise arrays are bundled together.
     """
+    # pyrefly: ignore [no-matching-overload]
     img = np.random.randint(256, size=(3, 640, 480), dtype=np.uint8)
+    # pyrefly: ignore [no-matching-overload]
     lbl = np.random.randint(256, size=(640, 480), dtype=np.uint8)
 
     match format:

--- a/examples/benchmark_utils.py
+++ b/examples/benchmark_utils.py
@@ -337,7 +337,9 @@ class BenchmarkRunner:
             config=config,
             executor_type=self.executor_type.value,
             qps=float(qps_mean),
+            # pyrefly: ignore [bad-argument-type]
             ci_lower=float(confidence_interval[0]),
+            # pyrefly: ignore [bad-argument-type]
             ci_upper=float(confidence_interval[1]),
             date=date,
             cpu_percent=float(cpu_mean),
@@ -492,11 +494,13 @@ def load_results_from_csv(
                 if field_type is int or field_type == "int":
                     typed_config_dict[field_name] = int(value)
                 elif field_type is float or field_type == "float":
+                    # pyrefly: ignore [unsupported-operation]
                     typed_config_dict[field_name] = float(value)
                 elif field_type is bool or field_type == "bool":
                     typed_config_dict[field_name] = value.lower() in TRUES
                 else:
                     # Keep as string or use the value as-is
+                    # pyrefly: ignore [unsupported-operation]
                     typed_config_dict[field_name] = value
 
             result = BenchmarkResult(

--- a/examples/imagenet_classification.py
+++ b/examples/imagenet_classification.py
@@ -102,6 +102,7 @@ class Preprocessing(torch.nn.Module):
             The normalized image batch.
         """
         x = x.float() / 255.0
+        # pyrefly: ignore [unsupported-operation]
         return (x - self.mean) / self.std
 
 
@@ -370,6 +371,7 @@ def benchmark(
         elapsed = time.monotonic() - t0
         if num_frames != 0:
             num_correct_top1 = num_correct_top1.item()  # pyre-ignore[16]
+            # pyrefly: ignore [missing-attribute]
             num_correct_top5 = num_correct_top5.item()
             fps = num_frames / elapsed
             _LG.info(f"FPS={fps:.2f} ({num_frames}/{elapsed:.2f})")
@@ -421,6 +423,7 @@ def entrypoint(args_: list[str] | None = None) -> None:
         benchmark(dataloader, model, args.max_batches)
 
     if args.trace:
+        # pyrefly: ignore [missing-attribute]
         prof.export_chrome_trace(f"{trace_path}.json")
 
 

--- a/examples/llm_finetune/utils/dataloader.py
+++ b/examples/llm_finetune/utils/dataloader.py
@@ -39,6 +39,7 @@ class _InstructDataset(torch.utils.data.Dataset):
     def __len__(self) -> int:
         return len(self.samples)
 
+    # pyrefly: ignore [bad-override-param-name]
     def __getitem__(self, idx: int) -> dict[str, torch.Tensor]:
         return _tokenize_sample(self.samples[idx], self.tokenizer, self.max_seq_len)
 

--- a/examples/streaming_nvdec_decoding.py
+++ b/examples/streaming_nvdec_decoding.py
@@ -183,6 +183,7 @@ def main(args: list[str] | None = None) -> None:
                 )
             )
 
+        # pyrefly: ignore [bad-argument-type]
         run(ns.input_file, ns.device_index, post_process, prof, ns.plot_dir)
 
 

--- a/src/spdl/autoresearch/core/_orchestrator.py
+++ b/src/spdl/autoresearch/core/_orchestrator.py
@@ -113,6 +113,7 @@ class TaskSpec:
             payload = {}
         return cls(
             id=str(data["id"]),
+            # pyrefly: ignore [bad-argument-type]
             priority=float(data.get("priority", 0.0)),
             kind=str(data.get("kind", "default")),
             payload=payload,

--- a/src/spdl/autoresearch/pipeline_optimization/_ops/_analysis_ops.py
+++ b/src/spdl/autoresearch/pipeline_optimization/_ops/_analysis_ops.py
@@ -184,6 +184,7 @@ def _append_master_result_row(
     structured: dict | None,
     terminal_failure,
 ) -> None:
+    # pyrefly: ignore [bad-assignment]
     row: dict[str, str | float] = {
         "run_id": node.node_id,
         "name": node.name,

--- a/src/spdl/autoresearch/pipeline_optimization/_platform/_providers.py
+++ b/src/spdl/autoresearch/pipeline_optimization/_platform/_providers.py
@@ -151,12 +151,14 @@ def _discover_extension_providers() -> list[_AutoresearchPlatformProvider]:
 
     for entry_point in importlib.metadata.entry_points(group=_ENTRY_POINT_GROUP):
         loaded = entry_point.load()
+        # pyrefly: ignore [bad-argument-type]
         providers.append(loaded() if callable(loaded) else loaded)
     providers.extend(_discover_convention_providers())
     return providers
 
 
 def _discover_convention_providers() -> list[_AutoresearchPlatformProvider]:
+    # pyrefly: ignore [missing-attribute]
     parent_package = __package__.rsplit(".", 1)[0]
     root = importlib.import_module(parent_package)
     package_paths = getattr(root, "__path__", None)

--- a/src/spdl/dataloader/_dataloader.py
+++ b/src/spdl/dataloader/_dataloader.py
@@ -202,10 +202,12 @@ class DataLoader(Generic[Source, Output]):
         src: Iterable[Source] | AsyncIterable[Source],
         *,
         # Pre-processing
+        # pyrefly: ignore [invalid-param-spec]
         preprocessor: Callables[[Source], T] | None = None,
         # Aggregation
         batch_size: int | None = None,
         drop_last: bool = False,
+        # pyrefly: ignore [invalid-param-spec]
         aggregator: Functions[[list[T]], Output] | None = None,
         # Device transfer
         transfer_fn: Callable[[Output], Output] | None = None,
@@ -219,6 +221,7 @@ class DataLoader(Generic[Source, Output]):
         log_api_usage_once("spdl.dataloader.DataLoader")
 
         self._src = src
+        # pyrefly: ignore [invalid-type-var]
         self._preprocessor = preprocessor
         self._aggregator = aggregator
         self._transfer_fn = transfer_fn

--- a/src/spdl/dataloader/_pytorch_dataloader.py
+++ b/src/spdl/dataloader/_pytorch_dataloader.py
@@ -45,11 +45,13 @@ _DATASET: "torch.utils.data.dataset.Dataset[T]" = None  # pyre-ignore: [15]
 _COLLATE_FN: Callable = None  # pyre-ignore: [15]
 
 
+# pyrefly: ignore [invalid-annotation]
 def _get_item(index: K) -> ...:
     global _DATASET, _COLLATE_FN
     return _COLLATE_FN(_DATASET[index])
 
 
+# pyrefly: ignore [invalid-annotation]
 def _get_items(indices: list[K]) -> ...:
     global _DATASET, _COLLATE_FN
     if hasattr(_DATASET, "__getitems__"):
@@ -61,6 +63,7 @@ def _init_dataset(name: str, collate_fn: Callable) -> None:
     _LG.info("[%s] Initializing dataset.", os.getpid())
     shmem = SharedMemory(name=name)
     global _DATASET, _COLLATE_FN
+    # pyrefly: ignore [bad-argument-type]
     _DATASET = pickle.loads(shmem.buf)
     _COLLATE_FN = collate_fn
 
@@ -85,6 +88,7 @@ def _serialize_dataset(dataset: "torch.utils.data.dataset.Dataset[T]") -> Shared
     t0 = time.monotonic()
     data = pickle.dumps(dataset)
     shmem = SharedMemory(create=True, size=len(data))
+    # pyrefly: ignore [unsupported-operation]
     shmem.buf[:] = data
     elapsed = time.monotonic() - t0
     _LG.info(
@@ -138,10 +142,14 @@ class PyTorchDataLoader(Iterable[V]):
     ) -> None:
         log_api_usage_once("spdl.dataloader.PyTorchDataLoader")
 
+        # pyrefly: ignore [invalid-type-var]
         self.dataset = dataset  # For external access.
         self._shmem: SharedMemory = shmem
+        # pyrefly: ignore [invalid-type-var]
         self._sampler = sampler
+        # pyrefly: ignore [invalid-type-var]
         self._fetch_fn = fetch_fn
+        # pyrefly: ignore [invalid-type-var]
         self._collate_fn = collate_fn
         self._transfer_fn = transfer_fn
         self._mp_ctx = mp_ctx
@@ -256,6 +264,7 @@ def _resolve_sampler(
         _fetch_fn = _get_item
         _collate_fn = collate_fn or default_convert
 
+    # pyrefly: ignore [bad-return]
     return _sampler, _fetch_fn, _collate_fn
 
 
@@ -348,7 +357,9 @@ def get_pytorch_dataloader(
         shmem=shmem,
         sampler=_sampler,
         fetch_fn=_fetch_fn,  # pyre-ignore: [6]
+        # pyrefly: ignore [bad-argument-type]
         collate_fn=_collate_fn,
+        # pyrefly: ignore [bad-argument-type]
         transfer_fn=transfer_fn,
         mp_ctx=mp_ctx,
         num_workers=num_workers,

--- a/src/spdl/io/_common.py
+++ b/src/spdl/io/_common.py
@@ -19,11 +19,14 @@ def _resolve_src(obj: object) -> "str | memoryview[bytes]":
 
     match obj:
         case str() | memoryview():
+            # pyrefly: ignore [bad-return]
             return obj
         case _ if hasattr(obj, "__fspath__"):
+            # pyrefly: ignore [no-matching-overload]
             return os.fspath(obj)
         case _:
             try:
+                # pyrefly: ignore [bad-argument-type, bad-return]
                 return memoryview(obj)
             except TypeError as e:
                 raise TypeError(

--- a/src/spdl/io/_composite.py
+++ b/src/spdl/io/_composite.py
@@ -751,6 +751,7 @@ def sample_decode_video(
         filter_desc = _preprocessing.get_video_filter_desc()
 
     ret: "list[ImageFrames]" = []
+    # pyrefly: ignore [missing-attribute]
     for split, idxes in _libspdl._extract_packets_at_indices(packets, indices):
         frames = _decode_partial(split, idxes, decode_config, filter_desc)
         ret.extend([frames[i] for i in idxes])  # type: ignore[arg-type]

--- a/src/spdl/io/_core.py
+++ b/src/spdl/io/_core.py
@@ -177,6 +177,7 @@ class Demuxer:
         name: str | None = None,
         **kwargs: Any,
     ) -> None:
+        # pyrefly: ignore [no-matching-overload]
         self._demuxer: _libspdl.Demuxer = _libspdl.make_demuxer(
             _resolve_src(src),  # pyre-ignore[6]
             demux_config=demux_config,
@@ -535,6 +536,7 @@ def apply_bsf(
     """
     if packets.codec is None:
         raise ValueError("The packets object does not have codec.")
+    # pyrefly: ignore [bad-return]
     return BSF(packets.codec, bsf).filter(packets, flush=True)
 
 
@@ -903,6 +905,7 @@ def decode_image_nvjpeg(
         data = [_resolve_src2(s) for s in src]
     else:
         data = _resolve_src2(src)
+    # pyrefly: ignore [no-matching-overload]
     return _libspdl_cuda.decode_image_nvjpeg(
         data,  # pyre-ignore[6]
         device_config=device_config,
@@ -1055,6 +1058,7 @@ def convert_array(
     Returns:
         A Buffer object.
     """
+    # pyrefly: ignore [bad-argument-type]
     return _libspdl.convert_array(vals, storage=storage)
 
 
@@ -1101,6 +1105,7 @@ def create_reference_audio_frame(
        Frames object that references the memory region of the input data.
     """
     frame = _libspdl.create_reference_audio_frame(
+        # pyrefly: ignore [bad-argument-type]
         array=array,
         sample_fmt=sample_fmt,
         sample_rate=sample_rate,
@@ -1147,6 +1152,7 @@ def create_reference_video_frame(
        Frames object that references the memory region of the input data.
     """
     frame = _libspdl.create_reference_video_frame(
+        # pyrefly: ignore [bad-argument-type]
         array=array,
         pix_fmt=pix_fmt,
         frame_rate=frame_rate,
@@ -1185,6 +1191,7 @@ def transfer_buffer_cpu(buffer: "CUDABuffer") -> "CPUBuffer":
     Returns:
         Buffer data on CPU.
     """
+    # pyrefly: ignore [bad-argument-type]
     return _libspdl_cuda.transfer_buffer_cpu(buffer)
 
 
@@ -1521,6 +1528,7 @@ def encode_image(
         >>> encode(data)
         >>>
     """
+    # pyrefly: ignore [missing-attribute]
     return _libspdl.encode_image(
         path, data, pix_fmt=pix_fmt, encode_config=encode_config
     )

--- a/src/spdl/io/_preprocessing.py
+++ b/src/spdl/io/_preprocessing.py
@@ -272,6 +272,7 @@ def get_filter_desc(
     match type(packets):
         case _libspdl.AudioPackets:
             # When audio packets have `timestamp` attribute, we delegate to `atrim` filter.
+            # pyrefly: ignore [missing-attribute]
             return get_audio_filter_desc(timestamp=packets.timestamp, **filter_args)
         case _libspdl.VideoPackets:
             # When video packets have `timestamp` attribute, we manually filter the frame

--- a/src/spdl/io/_tar.py
+++ b/src/spdl/io/_tar.py
@@ -76,6 +76,7 @@ def iter_tarfile(
     if isinstance(src, (bytes, memoryview)):
         mv = memoryview(src)
         for name, offset, size in _libspdl._archive.parse_tar(mv):
+            # pyrefly: ignore [invalid-yield]
             yield name, mv[offset : offset + size]
     else:
         yield from _libspdl._archive.parse_tar(src)

--- a/src/spdl/io/_transfer.py
+++ b/src/spdl/io/_transfer.py
@@ -51,6 +51,7 @@ def _recursive_apply(fn: Callable[[T], T], obj: T) -> T:
             return Class(_recursive_apply(fn, v) for v in obj)
         case tuple():
             if hasattr(obj, "_asdict") and hasattr(obj, "_fields"):  # namedtuple
+                # pyrefly: ignore [bad-unpacking]
                 return Class(**_recursive_apply(fn, obj._asdict()))
             return Class(_recursive_apply(fn, v) for v in obj)
         case defaultdict():
@@ -82,6 +83,7 @@ def _transfer(obj: T, device: "TDevice", pinned_memory_cache: "set[Tensor]") -> 
     if isinstance(obj, torch.Tensor) and obj.is_cpu:
         pinned = obj.pin_memory()
         pinned_memory_cache.add(pinned)
+        # pyrefly: ignore [bad-assignment]
         obj = pinned.to(device, non_blocking=True)
     return obj
 

--- a/src/spdl/pipeline/_arena/_pool.py
+++ b/src/spdl/pipeline/_arena/_pool.py
@@ -140,6 +140,7 @@ class SharedMemorySegmentPool:
         self._count: int = count
         self._acquire_timeout: float = acquire_timeout
         ctrl = shared_memory.SharedMemory(create=True, size=_CTRL.size)
+        # pyrefly: ignore [bad-argument-type]
         _CTRL.pack_into(ctrl.buf, 0, 0, 0)
         segs = [
             shared_memory.SharedMemory(create=True, size=segment_size)
@@ -149,7 +150,9 @@ class SharedMemorySegmentPool:
         self._seg_names: list[str] = [s.name for s in segs]
         self._ctrl: shared_memory.SharedMemory | None = ctrl
         self._segs: list[shared_memory.SharedMemory] | None = segs
+        # pyrefly: ignore [bad-assignment]
         self._ctrl_buf: "memoryview[bytes] | None" = ctrl.buf
+        # pyrefly: ignore [bad-assignment]
         self._seg_bufs: "list[memoryview[bytes]] | None" = [s.buf for s in segs]
 
     # -- pickling: carry only the spec; attach lazily, once, per process --
@@ -187,13 +190,17 @@ class SharedMemorySegmentPool:
     def _ctrl_view(self) -> "memoryview[bytes]":
         if self._ctrl_buf is None:
             self._ctrl = _attach(self._ctrl_name)
+            # pyrefly: ignore [bad-assignment]
             self._ctrl_buf = self._ctrl.buf
+        # pyrefly: ignore [bad-return]
         return self._ctrl_buf
 
     def _segment(self, index: int) -> "memoryview[bytes]":
         if self._seg_bufs is None:
             self._segs = [_attach(n) for n in self._seg_names]
+            # pyrefly: ignore [bad-assignment]
             self._seg_bufs = [s.buf for s in self._segs]
+        # pyrefly: ignore [unsupported-operation]
         return self._seg_bufs[index % self._count]
 
     @property

--- a/src/spdl/pipeline/_arena/_registry.py
+++ b/src/spdl/pipeline/_arena/_registry.py
@@ -172,8 +172,10 @@ class _BytesHandler:
         # the common contiguous case (write_binary performs the single copy into
         # shared memory); a non-contiguous memoryview is flattened into a copy.
         # meta carries the original type so the ring backend can reconstruct it.
+        # pyrefly: ignore [bad-argument-type]
         mv = memoryview(obj)
         src = mv.cast("B") if mv.contiguous else memoryview(mv.tobytes())
+        # pyrefly: ignore [bad-return]
         return src, (type(obj),)
 
     def from_buffer(
@@ -216,6 +218,7 @@ class _NumpyHandler:
         arr: Any = np.ascontiguousarray(obj)
         # memoryview over the array's own buffer — no copy (the single copy into
         # shared memory happens in the arena's write_binary).
+        # pyrefly: ignore [bad-return]
         return memoryview(arr).cast("B"), (arr.dtype.str, tuple(arr.shape))
 
     def from_buffer(
@@ -252,6 +255,7 @@ class _TorchHandler:
         t: Any = obj.detach().contiguous().cpu()  # type: ignore[attr-defined]
         # t.numpy() shares the tensor's storage (no copy for a contiguous CPU
         # tensor); memoryview over it stays a view.
+        # pyrefly: ignore [bad-return]
         return memoryview(t.numpy()).cast("B"), (str(t.dtype), tuple(t.shape))
 
     def from_buffer(
@@ -332,6 +336,7 @@ class _PacketsHandler:
         # memoryview over the bytes — no copy; write_binary performs the single
         # copy into shared memory. meta carries the class so restore can call
         # its ``deserialize_view`` (pickled by reference in the marker).
+        # pyrefly: ignore [bad-argument-type, bad-return]
         return memoryview(data), (type(obj),)
 
     def from_buffer(

--- a/src/spdl/pipeline/_arena/_ring.py
+++ b/src/spdl/pipeline/_arena/_ring.py
@@ -68,7 +68,9 @@ class SharedMemoryRingBuffer:
         shm = shared_memory.SharedMemory(create=True, size=_HEADER_SIZE + capacity)
         self._shm_name: str = shm.name
         self._shm: shared_memory.SharedMemory | None = shm
+        # pyrefly: ignore [bad-assignment]
         self._buf: "memoryview[bytes] | None" = shm.buf
+        # pyrefly: ignore [bad-argument-type]
         _HEADER.pack_into(shm.buf, 0, 0, 0)
 
     # -- pickling: carry only the spec; attach lazily, once, per process --
@@ -95,7 +97,9 @@ class SharedMemoryRingBuffer:
     def _ensure(self) -> "memoryview[bytes]":
         if self._buf is None:
             self._shm = _attach(self._shm_name)
+            # pyrefly: ignore [bad-assignment]
             self._buf = self._shm.buf
+        # pyrefly: ignore [bad-return]
         return self._buf
 
     @property

--- a/src/spdl/pipeline/_common/_convert.py
+++ b/src/spdl/pipeline/_common/_convert.py
@@ -63,12 +63,14 @@ def _to_async(
 
         async def afunc(item: T) -> U:
             loop = asyncio.get_running_loop()
+            # pyrefly: ignore [bad-argument-type]
             return await loop.run_in_executor(executor, _func_in_subprocess, func, item)
 
     else:
 
         async def afunc(item: T) -> U:
             loop = asyncio.get_running_loop()
+            # pyrefly: ignore [bad-argument-type]
             return await loop.run_in_executor(executor, func, item)
 
     return afunc

--- a/src/spdl/pipeline/_components/_aggregate.py
+++ b/src/spdl/pipeline/_components/_aggregate.py
@@ -74,6 +74,7 @@ def _aggregate(
     wrapper: _AggregatorWrapper = _AggregatorWrapper(op)
 
     @_queue_stage_hook(output_queue)
+    # pyrefly: ignore [not-callable]
     @_stage_hooks(hooks)
     async def aggregate_pipe() -> None:
         while not fail_counter.too_many_failures():

--- a/src/spdl/pipeline/_components/_hook.py
+++ b/src/spdl/pipeline/_components/_hook.py
@@ -315,6 +315,7 @@ class TaskStatsHook(TaskHook):
             yield
         finally:
             if self.interval > 0:
+                # pyrefly: ignore [unbound-name]
                 done.set()
                 await report  # pyre-ignore: [61]
             self._log_stats(

--- a/src/spdl/pipeline/_components/_node.py
+++ b/src/spdl/pipeline/_components/_node.py
@@ -338,6 +338,7 @@ def _convert_pipes(
                 out_q = q_class(info, buffer_size=_BUFFER_SIZE)
                 n = _Node(info, cfg, [n], input_queue=in_q, output_queue=out_q)
         ret = n
+    # pyrefly: ignore [unbound-name]
     return ret
 
 
@@ -681,6 +682,7 @@ def _default_hook_factory(
     if (hook_class := get_default_hook_class()) is not None:
 
         def _hook_factory(stage_info: StageInfo) -> list[TaskHook]:
+            # pyrefly: ignore [bad-argument-count, unexpected-keyword]
             return [hook_class(stage_info, interval=report_stats_interval)]
 
     else:
@@ -810,6 +812,7 @@ def _gather_error(
     for n in node.upstream:
         errs.extend(_gather_error(n, _visited))
     errs.sort(key=lambda i: i[0])
+    # pyrefly: ignore [bad-return]
     return errs
 
 

--- a/src/spdl/pipeline/_components/_pipe.py
+++ b/src/spdl/pipeline/_components/_pipe.py
@@ -276,6 +276,7 @@ def _pipe(
         raise ValueError("input queue and output queue must be different.")
 
     afunc: Callable[[T], Awaitable[U]] = (  # pyre-ignore: [9]
+        # pyrefly: ignore [bad-assignment]
         convert_to_async(args.op, args.executor)
     )
 
@@ -295,6 +296,7 @@ def _pipe(
         raise ValueError(f"{afunc=} must be either async function or async generator.")
 
     @_queue_stage_hook(output_queue)
+    # pyrefly: ignore [not-callable]
     @_stage_hooks(hooks)
     async def pipe() -> None:
         i, tasks = 0, set()
@@ -314,6 +316,7 @@ def _pipe(
             # note: Make sure that `afunc` is called directly in this function,
             # so as to detect user error. (incompatible `afunc` and `iterator` combo)
             task = create_task(
+                # pyrefly: ignore [bad-argument-type]
                 _wrap(afunc(item), item),
                 name=f"{info}:{(i := i + 1)}",
             )
@@ -406,6 +409,7 @@ def _ordered_pipe(
     assert not inspect.isasyncgenfunction(args.op)
 
     afunc: Callable[[T], Awaitable[U]] = (  # pyre-ignore: [9]
+        # pyrefly: ignore [bad-assignment]
         convert_to_async(args.op, args.executor)
     )
 
@@ -472,6 +476,7 @@ def _ordered_pipe(
             pass
 
     @_queue_stage_hook(output_queue)
+    # pyrefly: ignore [not-callable]
     @_stage_hooks(task_hooks)
     async def ordered_pipe() -> None:
         await asyncio.wait({create_task(get_run_put()), create_task(get_check_put())})
@@ -562,6 +567,7 @@ def _merge(
     op: _TMergeOp = merge_op or _default_merge
 
     @_queue_stage_hook(output_queue)
+    # pyrefly: ignore [not-callable]
     @_stage_hooks(hooks)
     async def merge() -> None:
         await op(info, input_queues, output_queue)

--- a/src/spdl/pipeline/_components/_queue.py
+++ b/src/spdl/pipeline/_components/_queue.py
@@ -232,6 +232,7 @@ class StatsQueue(AsyncQueue):
             yield
         finally:
             if self.interval > 0:
+                # pyrefly: ignore [unbound-name]
                 done.set()
                 await report  # pyre-ignore: [61]
 

--- a/src/spdl/pipeline/_components/_source.py
+++ b/src/spdl/pipeline/_components/_source.py
@@ -43,6 +43,7 @@ async def _source(
         so this coroutine does not explicitly send EOF.
     """
     src_: AsyncIterable[T] = (  # pyre-ignore: [9]
+        # pyrefly: ignore [bad-assignment, no-matching-overload]
         src if hasattr(src, "__aiter__") else _to_async_gen(iter, None)(src)
     )
 
@@ -74,6 +75,7 @@ async def _source_continuous(
     async with _queue_stage_hook(queue):
         while True:
             src_: AsyncIterable[T] = (  # pyre-ignore: [9]
+                # pyrefly: ignore [bad-assignment, no-matching-overload]
                 src if hasattr(src, "__aiter__") else _to_async(src)
             )
             async for item in src_:

--- a/src/spdl/pipeline/_components/_variants.py
+++ b/src/spdl/pipeline/_components/_variants.py
@@ -112,6 +112,7 @@ def _path_variants_router(
     arouter: Callable[[Any], Awaitable[int]] = _make_async_router(router)
 
     @_queue_stage_hook(path_queues)
+    # pyrefly: ignore [not-callable]
     @_stage_hooks(task_hooks)
     async def _router() -> None:
         while True:

--- a/src/spdl/pipeline/_iter_utils/_subprocess.py
+++ b/src/spdl/pipeline/_iter_utils/_subprocess.py
@@ -205,8 +205,11 @@ def iterate_in_subprocess(
     )
 
     ctx = mp.get_context(mp_context)
+    # pyrefly: ignore [bad-assignment]
     cmd_q: queue.Queue[_Cmd] = ctx.Queue()
+    # pyrefly: ignore [bad-assignment]
     data_q: queue.Queue[_Msg[T]] = ctx.Queue(maxsize=buffer_size)
+    # pyrefly: ignore [missing-attribute]
     process = ctx.Process(
         target=_execute_iterable,
         args=(cmd_q, data_q, fn, initializers, arena),

--- a/src/spdl/pipeline/_pgrp_stats.py
+++ b/src/spdl/pipeline/_pgrp_stats.py
@@ -632,6 +632,7 @@ class ProcessGroupStatsMonitor(BackgroundTask):
         and ``CancelledError`` is re-raised.
         """
         ctx = self._mp_context or multiprocessing.get_context()
+        # pyrefly: ignore [missing-attribute]
         proc = ctx.Process(
             target=_pgrp_monitor_subprocess,
             args=(self._interval, self._callback),

--- a/src/spdl/pipeline/defs/__init__.py
+++ b/src/spdl/pipeline/defs/__init__.py
@@ -49,7 +49,9 @@ from ._defs import (
 __all__ = [
     "_PipeArgs",
     "_PipeType",
+    # pyrefly: ignore [bad-dunder-all]
     "_TAsyncCallables",
+    # pyrefly: ignore [bad-dunder-all]
     "_TCallables",
     "_TPipeInputs",
     "Aggregate",

--- a/src/spdl/pipeline/defs/_defs.py
+++ b/src/spdl/pipeline/defs/_defs.py
@@ -486,6 +486,7 @@ class PathVariantsConfig(Generic[T]):
 
     paths: tuple[
         tuple[
+            # pyrefly: ignore [not-a-type]
             "PipeConfig[Any, Any]"
             " | AggregateConfig[Any]"
             " | DisaggregateConfig[Any]"
@@ -692,6 +693,7 @@ def Merge(
        :ref:`Example: Pipeline definitions <example-pipeline-definitions>`
           Illustrates how to build a complex pipeline.
     """
+    # pyrefly: ignore [bad-argument-type]
     return MergeConfig(tuple(pipeline_configs), op=op)
 
 

--- a/src/spdl/source/_sampler.py
+++ b/src/spdl/source/_sampler.py
@@ -20,6 +20,7 @@ if TYPE_CHECKING:
     import numpy as np
     from numpy.typing import NDArray
 
+    # pyrefly: ignore [bad-specialization]
     FloatArray: TypeAlias = NDArray[np.floating[Any]]
 
 

--- a/tests/cuda/buffer_transfer_test.py
+++ b/tests/cuda/buffer_transfer_test.py
@@ -163,6 +163,7 @@ class TestArrayTransfer(unittest.TestCase):
 
         for dtype in [np.uint8, np.int32, np.int64]:
             max_val = np.iinfo(dtype).max
+            # pyrefly: ignore [no-matching-overload]
             array = np.random.randint(0, max_val, size=(1, 128_000), dtype=dtype)
             test(array)
 
@@ -183,6 +184,7 @@ class TestArrayTransfer(unittest.TestCase):
 
         for dtype in [np.uint8, np.int32, np.int64]:
             max_val = np.iinfo(dtype).max
+            # pyrefly: ignore [no-matching-overload]
             array = np.random.randint(0, max_val, size=(1, 128_000), dtype=dtype)
             test(torch.from_numpy(array))
 
@@ -225,6 +227,7 @@ class TestArrayTransfer(unittest.TestCase):
     def test_array_transfer_smoke_test(self) -> None:
         """smoke test for transferring multiple arrays concurrently"""
 
+        # pyrefly: ignore [no-matching-overload]
         array = np.random.randint(0, 256, size=(1, 64_000), dtype=np.uint8)
         device_config = spdl.io.cuda_config(device_index=DEFAULT_CUDA)
         for _ in range(100):
@@ -237,6 +240,7 @@ class TestTransferCpu(unittest.TestCase):
 
         for dtype in [np.uint8, np.int32, np.int64]:
             max_val = np.iinfo(dtype).max
+            # pyrefly: ignore [no-matching-overload]
             array = np.random.randint(0, max_val, size=(1, 128_000), dtype=dtype)
             ref = torch.from_numpy(array)
             cuda_tensor = ref.cuda(device=DEFAULT_CUDA)

--- a/tests/io/array_test.py
+++ b/tests/io/array_test.py
@@ -38,6 +38,7 @@ class TestLoadNpy(unittest.TestCase):
         rng = np.random.default_rng()
         shape = (2, 3, 4, 5)
         info = np.iinfo(dtype)
+        # pyrefly: ignore [no-matching-overload]
         ref = rng.integers(low=info.min, high=info.max, size=shape, dtype=dtype)
         ref[0, 0, 0, 0] = info.min
         ref[-1, -1, -1, -1] = info.max
@@ -70,6 +71,7 @@ class TestLoadNpy(unittest.TestCase):
         rng = np.random.default_rng()
         shape = (2, 3, 4, 5)
         info = np.finfo(dtype)
+        # pyrefly: ignore [no-matching-overload]
         ref = rng.random(size=shape, dtype=dtype)
         ref[0, 0, 0, 0] = info.min
         ref[-1, -1, -1, -1] = info.max

--- a/tests/io/audio_decoding_test.py
+++ b/tests/io/audio_decoding_test.py
@@ -46,6 +46,7 @@ class TestLoadAudio(unittest.TestCase):
         # fmt: on
         sample = get_sample(cmd)
 
+        # pyrefly: ignore [not-iterable]
         dtype, format = _get_format(sample_fmt)
         shape = (40000, 2)
 

--- a/tests/io/audio_encoding_test.py
+++ b/tests/io/audio_encoding_test.py
@@ -51,6 +51,7 @@ class TestEncodeAudioInteger(unittest.TestCase):
 
         shape = (sample_rate * duration, num_channels)
         ii = np.iinfo(dtype)
+        # pyrefly: ignore [no-matching-overload]
         ref = np.random.randint(ii.min, ii.max, size=shape, dtype=dtype)
 
         with NamedTemporaryFile(suffix=".wav") as f:
@@ -177,6 +178,7 @@ class TestEncodeAudioIntegerPlanar(unittest.TestCase):
 
         shape = (num_channels, sample_rate * duration)
         ii = np.iinfo(dtype)
+        # pyrefly: ignore [no-matching-overload]
         ref = np.random.randint(ii.min, ii.max, size=shape, dtype=dtype)
 
         with NamedTemporaryFile(suffix=".nut") as f:
@@ -260,6 +262,7 @@ class TestEncodeAudioSmokeTest(unittest.TestCase):
 
         if sample_fmt.startswith("s"):
             ii = np.iinfo(dtype)
+            # pyrefly: ignore [no-matching-overload]
             ref = np.random.randint(ii.min, ii.max, size=shape, dtype=dtype)
         else:
             ref = np.random.random(shape).astype(dtype)

--- a/tests/io/encoding_test.py
+++ b/tests/io/encoding_test.py
@@ -23,12 +23,14 @@ class TestEncodeImageParity(unittest.TestCase):
     @parameterized.expand(list(product(["rgb24", "gray"], [False, True])))
     def test_encode_image_parity_simple(self, pix_fmt: str, torch_tensor: bool) -> None:
         shape = (16, 16, 3) if pix_fmt == "rgb24" else (16, 16)
+        # pyrefly: ignore [no-matching-overload]
         ref = np.random.randint(256, size=shape, dtype=np.uint8)
 
         with NamedTemporaryFile(suffix=".png") as f:
             f.close()  # for windows
             spdl.io.save_image(
                 f.name,
+                # pyrefly: ignore [bad-argument-type]
                 torch.from_numpy(ref) if torch_tensor else ref,
                 pix_fmt=pix_fmt,
             )
@@ -39,6 +41,7 @@ class TestEncodeImageParity(unittest.TestCase):
     def test_encode_image_parity_png_gray16be(self) -> None:
         shape = (32, 64)
 
+        # pyrefly: ignore [no-matching-overload]
         ref = np.random.randint(256, size=shape, dtype=np.uint16)
         if sys.byteorder == "little":
             ref = ref.byteswap()

--- a/tests/io/memoryview_test.py
+++ b/tests/io/memoryview_test.py
@@ -58,6 +58,7 @@ class TestLoadWavMemoryview(unittest.TestCase):
         mv = memoryview(wav_data)
 
         result_bytes = spdl.io.load_wav(wav_data)
+        # pyrefly: ignore [bad-argument-type]
         result_mv = spdl.io.load_wav(mv)
 
         samples_bytes = spdl.io.to_numpy(result_bytes)
@@ -69,6 +70,7 @@ class TestLoadWavMemoryview(unittest.TestCase):
         wav_data = _create_wav_data(sample_rate=8000, num_samples=8000)
         mv = memoryview(wav_data)
 
+        # pyrefly: ignore [bad-argument-type]
         result = spdl.io.load_wav(mv, time_offset_seconds=0.5, duration_seconds=0.5)
         samples = spdl.io.to_numpy(result)
 
@@ -81,6 +83,7 @@ class TestParseWavMemoryview(unittest.TestCase):
         mv = memoryview(wav_data)
 
         header_bytes = spdl.io.parse_wav(wav_data)
+        # pyrefly: ignore [bad-argument-type]
         header_mv = spdl.io.parse_wav(mv)
 
         self.assertEqual(header_mv.sample_rate, header_bytes.sample_rate)
@@ -95,6 +98,7 @@ class TestIterTarfileMemoryview(unittest.TestCase):
         mv = memoryview(tar_data)
 
         entries_bytes = list(spdl.io.iter_tarfile(tar_data))
+        # pyrefly: ignore [no-matching-overload]
         entries_mv = list(spdl.io.iter_tarfile(mv))
 
         self.assertEqual(len(entries_mv), len(entries_bytes))
@@ -110,5 +114,6 @@ class TestLoadNpzMemoryview(unittest.TestCase):
         npz_data = _create_npz_data()
         mv = memoryview(npz_data)
 
+        # pyrefly: ignore [bad-argument-type]
         data = spdl.io.load_npz(mv)
         np.testing.assert_array_equal(data["x"], np.arange(5))

--- a/tests/io/packets_test.py
+++ b/tests/io/packets_test.py
@@ -77,6 +77,7 @@ class TestDemuxWithoutCodec(unittest.TestCase):
             else:
                 raise RuntimeError("Unexpected packet type")
 
+            # pyrefly: ignore [missing-attribute]
             codec = packets.codec
             self.assertIsNone(codec)
         self.assertGreater(num_packets, 10)

--- a/tests/io/reference_frames_test.py
+++ b/tests/io/reference_frames_test.py
@@ -18,6 +18,7 @@ class TestReferenceAudioFrame(unittest.TestCase):
     def test_audio_frame_keeps_reference_alive(self) -> None:
         """Test that AudioFrame keeps the original array alive even after deletion."""
         # Setup: Create an array and a weak reference to it
+        # pyrefly: ignore [no-matching-overload]
         array = np.random.randint(0, 255, size=(100, 2), dtype=np.uint8)
         weak_ref = weakref.ref(array)
 
@@ -48,6 +49,7 @@ class TestReferenceAudioFrame(unittest.TestCase):
 
     def test_audio_frame_can_be_converted(self) -> None:
         """Test that reference audio frame can be converted to buffer."""
+        # pyrefly: ignore [no-matching-overload]
         array = np.random.randint(0, 255, size=(100, 2), dtype=np.uint8)
 
         frame = spdl.io.create_reference_audio_frame(
@@ -65,6 +67,7 @@ class TestReferenceAudioFrame(unittest.TestCase):
     def test_audio_frame_planar_format(self) -> None:
         """Test that planar format audio frames work correctly."""
         # Setup: Create planar format data (channels first)
+        # pyrefly: ignore [no-matching-overload]
         array = np.random.randint(0, 255, size=(2, 100), dtype=np.uint8)
 
         # Execute: Create reference frame with planar format
@@ -85,6 +88,7 @@ class TestReferenceVideoFrame(unittest.TestCase):
     def test_video_frame_keeps_reference_alive(self) -> None:
         """Test that VideoFrame keeps the original array alive even after deletion."""
         # Setup: Create an array and a weak reference to it
+        # pyrefly: ignore [no-matching-overload]
         array = np.random.randint(0, 255, size=(5, 128, 128, 3), dtype=np.uint8)
         weak_ref = weakref.ref(array)
 
@@ -115,6 +119,7 @@ class TestReferenceVideoFrame(unittest.TestCase):
 
     def test_video_frame_can_be_converted(self) -> None:
         """Test that reference video frame can be converted to buffer."""
+        # pyrefly: ignore [no-matching-overload]
         array = np.random.randint(0, 255, size=(5, 128, 128, 3), dtype=np.uint8)
 
         frame = spdl.io.create_reference_video_frame(
@@ -132,6 +137,7 @@ class TestReferenceVideoFrame(unittest.TestCase):
     def test_video_frame_grayscale(self) -> None:
         """Test that grayscale video frames work correctly."""
         # Setup: Create grayscale data
+        # pyrefly: ignore [no-matching-overload]
         array = np.random.randint(0, 255, size=(5, 128, 128), dtype=np.uint8)
 
         # Execute: Create reference frame with grayscale format
@@ -150,6 +156,7 @@ class TestReferenceVideoFrame(unittest.TestCase):
     def test_video_frame_yuv_format(self) -> None:
         """Test that YUV planar format video frames work correctly."""
         # Setup: Create YUV planar format data (channels first)
+        # pyrefly: ignore [no-matching-overload]
         array = np.random.randint(0, 255, size=(5, 3, 128, 128), dtype=np.uint8)
 
         # Execute: Create reference frame with YUV planar format

--- a/tests/io/transfer_test.py
+++ b/tests/io/transfer_test.py
@@ -36,9 +36,11 @@ class TestRecursiveApply(unittest.TestCase):
         self.assertEqual(_recursive_apply(fn, obj), (2, 4, 6))
 
         obj = [4, 5, 6]
+        # pyrefly: ignore [bad-argument-type]
         self.assertEqual(_recursive_apply(fn, obj), [8, 10, 12])
 
         obj = {"a": 7, "b": 8}
+        # pyrefly: ignore [bad-argument-type]
         self.assertEqual(_recursive_apply(fn, obj), {"a": 14, "b": 16})
 
         obj = defaultdict(list)
@@ -49,11 +51,13 @@ class TestRecursiveApply(unittest.TestCase):
         ref["a"].append(18)
         ref["b"].append(20)
 
+        # pyrefly: ignore [bad-argument-type]
         self.assertEqual(_recursive_apply(fn, obj), ref)
 
         obj = _Item(11, 12)
         ref = _Item(22, 24)
         ref.z = fn(cast(int, ref.z))
+        # pyrefly: ignore [bad-argument-type]
         self.assertEqual(_recursive_apply(fn, obj), ref)
 
     def test_recursive_apply_nested(self) -> None:
@@ -61,21 +65,28 @@ class TestRecursiveApply(unittest.TestCase):
         self.assertEqual(_recursive_apply(fn, obj), (2, 4, (6, 8, 10), 12))
 
         obj = [1, 2, [3, 4, 5], 6]
+        # pyrefly: ignore [bad-argument-type]
         self.assertEqual(_recursive_apply(fn, obj), [2, 4, [6, 8, 10], 12])
 
         obj = {"a": 1, "b": 2, "c": [3, 4, 5], "d": 6}
         self.assertEqual(
-            _recursive_apply(fn, obj), {"a": 2, "b": 4, "c": [6, 8, 10], "d": 12}
+            # pyrefly: ignore [bad-argument-type]
+            _recursive_apply(fn, obj),
+            {"a": 2, "b": 4, "c": [6, 8, 10], "d": 12},
         )
 
         obj = (1, 2, (3, 4, (5, 6, 7), 8), 9)
         self.assertEqual(
-            _recursive_apply(fn, obj), (2, 4, (6, 8, (10, 12, 14), 16), 18)
+            # pyrefly: ignore [bad-argument-type]
+            _recursive_apply(fn, obj),
+            (2, 4, (6, 8, (10, 12, 14), 16), 18),
         )
 
         obj = [1, 2, [3, 4, [5, 6, [7, 8, 9]]], 10]
         self.assertEqual(
-            _recursive_apply(fn, obj), [2, 4, [6, 8, [10, 12, [14, 16, 18]]], 20]
+            # pyrefly: ignore [bad-argument-type]
+            _recursive_apply(fn, obj),
+            [2, 4, [6, 8, [10, 12, [14, 16, 18]]], 20],
         )
 
         obj = {
@@ -85,6 +96,7 @@ class TestRecursiveApply(unittest.TestCase):
             "j": 8,
         }
         self.assertEqual(
+            # pyrefly: ignore [bad-argument-type]
             _recursive_apply(fn, obj),
             {
                 "a": 2,
@@ -99,6 +111,7 @@ class TestRecursiveApply(unittest.TestCase):
         ref = _Item(2, 4)
         ref.z = _Item(10, 12)
         cast(_Item, ref.z).z = 2
+        # pyrefly: ignore [bad-argument-type]
         self.assertEqual(_recursive_apply(fn, obj), ref)
 
 

--- a/tests/io/video_encoding_test.py
+++ b/tests/io/video_encoding_test.py
@@ -36,6 +36,7 @@ class TestEncodeVideoMultiColor(unittest.TestCase):
                 shape = (num_frames, 3, height, width)
             case _:
                 shape = (num_frames, height, width, 3)
+        # pyrefly: ignore [no-matching-overload]
         ref = np.random.randint(0, 255, size=shape, dtype=np.uint8)
 
         with NamedTemporaryFile(suffix=".raw") as f:
@@ -98,6 +99,7 @@ class TestEncodeVideoGray(unittest.TestCase):
         num_frames = int(frame_rate[0] / frame_rate[1] * duration)
         shape = (num_frames, height, width)
         dtype = np.uint8 if pix_fmt == "gray8" else np.int16
+        # pyrefly: ignore [no-matching-overload]
         ref = np.random.randint(0, 255, size=shape, dtype=dtype)
 
         with NamedTemporaryFile(suffix=".raw") as f:

--- a/tests/pipeline/pipeline_builder_test.py
+++ b/tests/pipeline/pipeline_builder_test.py
@@ -1558,6 +1558,7 @@ class TestPipelineType(unittest.TestCase):
         pipeline = (
             PipelineBuilder()
             .add_source(range(10))
+            # pyrefly: ignore [bad-argument-type]
             .pipe(wrong_sig)
             .add_sink(1000)
             .build(num_threads=1)
@@ -1650,6 +1651,7 @@ class TestPipelineFail(unittest.TestCase):
             PipelineBuilder()
             .add_source(range(10))
             .pipe(passthrough)
+            # pyrefly: ignore [bad-argument-type]
             .pipe(fail)
             .pipe(pwc)
             .add_sink(1)
@@ -2640,6 +2642,7 @@ class TestOverrideStage(unittest.TestCase):
 
             def __init__(self, name, *, buffer_size: int = 1) -> None:
                 print(name)
+                # pyrefly: ignore [missing-attribute]
                 id = re.match(r"\d+:(\d+):.*", str(name)).group(1)
                 assert id == str(self.index)
                 CheckNameQueue.index += 1

--- a/tests/pipeline/subprocess_test.py
+++ b/tests/pipeline/subprocess_test.py
@@ -387,6 +387,7 @@ def _init1() -> None:
 def _src2() -> Iterator[int]:
     if True:
         raise ValueError("Failed!")
+    # pyrefly: ignore [bad-return]
     return SourceIterable(10)
 
 


### PR DESCRIPTION
Summary:
Automated migration to enable Pyrefly type checking for `fbcode/spdl`.

- Added `python.set_pyrefly(True)` to PACKAGE file
- Suppressed pre-existing type errors

Pyrefly is Meta's next-generation Python type checker, replacing Pyre.

If you encounter issues, you can revert the PACKAGE change by removing
the `python.set_pyrefly(True)` line.
#pyreupgrade

Differential Revision: D108326059
