### PR TITLE
block producer on a process-shared cv when the arena is full

### DIFF
--- a/src/spdl/pipeline/_arena/_pool.py
+++ b/src/spdl/pipeline/_arena/_pool.py
@@ -24,11 +24,11 @@ the pool once every view into it has been released — tracked with
 ``reclaimed`` (``free = count - (published - reclaimed)``), so it never reuses a
 segment that still has live views.
 
-Backpressure is Mode B (blocking): ``begin_unit`` waits for the consumer to
-reclaim a segment when the pool is full (up to ``acquire_timeout``), throttling a
-fast producer to the consumer's reclaim rate. Set ``acquire_timeout=0`` for
-non-blocking behavior (raise immediately when full). Elastic growth remains
-future work.
+Backpressure is Mode B (blocking): ``begin_unit`` waits on a process-shared
+:py:class:`multiprocessing.Condition` until the consumer reclaims a segment
+(up to ``acquire_timeout``), throttling a fast producer to the consumer's reclaim
+rate. Set ``acquire_timeout=0`` for non-blocking behavior (raise immediately when
+full). Elastic growth remains future work.
 
 .. note::
 
@@ -40,11 +40,12 @@ future work.
 from __future__ import annotations
 
 import logging
+import multiprocessing
 import struct
 import threading
-import time
 import weakref
 from multiprocessing import shared_memory
+from multiprocessing.synchronize import Condition as _Condition
 from typing import TypedDict
 
 from ._shm import _attach
@@ -53,18 +54,15 @@ _LG: logging.Logger = logging.getLogger(__name__)
 
 __all__ = ["SharedMemorySegmentPool"]
 
-# How often ``begin_unit`` polls the (shared-memory) reclaim counter while
-# waiting for a free segment. Small enough to be responsive, large enough to
-# keep the busy-wait cheap.
-_POLL_INTERVAL: float = 0.0005
-
 # Default time ``begin_unit`` waits for the consumer to reclaim a segment before
 # giving up and raising. Generous, so it only fires on a genuinely stalled or
 # dead consumer rather than normal slow-consumer backpressure.
 _DEFAULT_ACQUIRE_TIMEOUT: float = 60.0
 
-# Control segment: published (units published), reclaimed (units returned).
-_CTRL: struct.Struct = struct.Struct("<QQ")
+# Control segment: published (units published, uint64), reclaimed (units
+# returned, uint64), shutdown (uint8 flag set on teardown to wake any blocked
+# producer cleanly).
+_CTRL: struct.Struct = struct.Struct("<QQB")
 
 # Binaries are aligned to this many bytes within a segment so that zero-copy
 # views into them (e.g. ``spdl.io`` Packets payloads) land on aligned addresses.
@@ -82,6 +80,7 @@ class _PoolState(TypedDict):
     segment_size: int
     count: int
     acquire_timeout: float
+    space_cv: _Condition
 
 
 class SharedMemorySegmentPool:
@@ -94,6 +93,11 @@ class SharedMemorySegmentPool:
     memory; the pool keeps each segment until its views are released.
 
     .. versionadded:: 0.5.0
+
+    .. versionchanged:: 0.6.0
+       Backpressure now uses a process-shared
+       :py:class:`multiprocessing.Condition` instead of busy-polling the shared
+       reclaim counter; idle producers no longer consume CPU while waiting.
 
     .. note::
 
@@ -143,7 +147,7 @@ class SharedMemorySegmentPool:
         self._acquire_timeout: float = acquire_timeout
         ctrl = shared_memory.SharedMemory(create=True, size=_CTRL.size)
         # pyrefly: ignore [bad-argument-type]
-        _CTRL.pack_into(ctrl.buf, 0, 0, 0)
+        _CTRL.pack_into(ctrl.buf, 0, 0, 0, 0)
         segs = [
             shared_memory.SharedMemory(create=True, size=segment_size)
             for _ in range(count)
@@ -156,6 +160,11 @@ class SharedMemorySegmentPool:
         self._ctrl_buf: "memoryview[bytes] | None" = ctrl.buf
         # pyrefly: ignore [bad-assignment]
         self._seg_bufs: "list[memoryview[bytes]] | None" = [s.buf for s in segs]
+        # Process-shared condition variable used by ``begin_unit`` to block the
+        # producer until the consumer reclaims a segment (or the arena is shut
+        # down). Picklable through ``Process(args=...)`` spawn, like the rest of
+        # the arena.
+        self._space_cv: _Condition = multiprocessing.Condition()
 
     # -- pickling: carry only the spec; attach lazily, once, per process --
 
@@ -166,6 +175,7 @@ class SharedMemorySegmentPool:
             "segment_size": self._segment_size,
             "count": self._count,
             "acquire_timeout": self._acquire_timeout,
+            "space_cv": self._space_cv,
         }
 
     def __setstate__(self, state: _PoolState) -> None:
@@ -174,6 +184,7 @@ class SharedMemorySegmentPool:
         self._segment_size = state["segment_size"]
         self._count = state["count"]
         self._acquire_timeout = state["acquire_timeout"]
+        self._space_cv = state["space_cv"]
         self._ctrl = None
         self._segs = None
         self._ctrl_buf = None
@@ -222,6 +233,35 @@ class SharedMemorySegmentPool:
     @reclaimed.setter
     def reclaimed(self, value: int) -> None:
         struct.pack_into("<Q", self._ctrl_view(), 8, value)
+        # Wake any producer blocked in ``begin_unit`` waiting for a free segment.
+        # Doing this in the setter (rather than at every call site) means manual
+        # mutations of the counter — including the consumer's ``_unit_released``
+        # path and tests that simulate a reclaim — also wake the producer.
+        with self._space_cv:
+            self._space_cv.notify_all()
+
+    @property
+    def _shutdown(self) -> bool:
+        return bool(_CTRL.unpack_from(self._ctrl_view(), 0)[2])
+
+    @_shutdown.setter
+    def _shutdown(self, value: bool) -> None:
+        struct.pack_into("<B", self._ctrl_view(), 16, 1 if value else 0)
+
+    def shutdown_arena(self) -> None:
+        """Wake any producer blocked in :py:meth:`_PoolWriter.begin_unit`.
+
+        Sets a sticky shutdown flag in the control segment and broadcasts on the
+        space condition variable so a producer that is currently waiting for a
+        free segment exits the wait promptly with a :py:exc:`BufferError`. Safe
+        to call multiple times and from either process.
+        """
+        try:
+            self._shutdown = True
+        except Exception:  # noqa: BLE001 — control buf may already be released
+            return
+        with self._space_cv:
+            self._space_cv.notify_all()
 
     def open_writer(self) -> _PoolWriter:
         """Return the writer endpoint (call in the worker process)."""
@@ -241,6 +281,9 @@ class SharedMemorySegmentPool:
         views are garbage-collected, and :py:meth:`unlink` removes the names
         regardless. Raising here would crash an otherwise-successful run.
         """
+        # First wake any blocked producer so it exits its wait before we tear
+        # down the shared memory it observes.
+        self.shutdown_arena()
         if (ctrl_buf := self._ctrl_buf) is not None:
             ctrl_buf.release()
             self._ctrl_buf = None
@@ -312,17 +355,35 @@ class _PoolWriter:
     def begin_unit(self) -> None:
         """Acquire the next free segment for a new unit.
 
-        Mode B backpressure: if the pool is full, wait (polling the shared
-        reclaim counter) for the consumer to release a segment, up to
+        Mode B backpressure: if the pool is full, wait on the arena's process-
+        shared condition variable for the consumer to release a segment, up to
         ``acquire_timeout`` seconds, then raise. This throttles a fast producer
         to the consumer's reclaim rate instead of failing when a slow consumer
         legitimately holds many zero-copy views.
+
+        Raises:
+            BufferError: when the pool is full and the consumer does not reclaim
+                a segment within ``acquire_timeout``, when the arena is shut
+                down (e.g. the parent has begun teardown), or when
+                ``acquire_timeout=0`` and no segment is currently free.
         """
         p = self._p
         if p.count - (p.published - p.reclaimed) < 1:
-            deadline = time.monotonic() + self._acquire_timeout
-            while p.count - (p.published - p.reclaimed) < 1:
-                if time.monotonic() >= deadline:
+            if self._acquire_timeout == 0:
+                raise BufferError(
+                    "segment pool exhausted: no free segment and "
+                    "acquire_timeout=0. Increase SharedMemorySegmentPool "
+                    "count/segment_size or acquire_timeout, or check the consumer."
+                )
+            with p._space_cv:
+                # Re-check after acquiring the cv: the consumer may have
+                # reclaimed (and notified) between the outer test and now.
+                def _ready() -> bool:
+                    if p._shutdown:
+                        return True
+                    return p.count - (p.published - p.reclaimed) >= 1
+
+                if not p._space_cv.wait_for(_ready, timeout=self._acquire_timeout):
                     raise BufferError(
                         "segment pool exhausted: no free segment after waiting "
                         f"{self._acquire_timeout:g}s — the consumer is releasing "
@@ -330,7 +391,10 @@ class _PoolWriter:
                         "SharedMemorySegmentPool count/segment_size or "
                         "acquire_timeout, or check the consumer."
                     )
-                time.sleep(_POLL_INTERVAL)
+                if p._shutdown:
+                    raise BufferError(
+                        "segment pool shut down while waiting for a free segment"
+                    )
         self._cursor = 0
 
     def write_binary(
@@ -449,4 +513,5 @@ class _PoolReader:
                 self._reclaimed += 1
                 advanced = True
             if advanced:
+                # Setter wakes any blocked producer via the space cv.
                 self._p.reclaimed = self._reclaimed

--- a/src/spdl/pipeline/_arena/_ring.py
+++ b/src/spdl/pipeline/_arena/_ring.py
@@ -22,12 +22,19 @@ Writes that cross the physical end of the arena are split into two copies, so
 the wrap-around is invisible to callers. A "unit" (one pipeline item, which may
 contain several binaries) is written at successive offsets and published once,
 and released once, so reservation/return happen in bulk per unit.
+
+Backpressure: ``write_binary`` waits on a process-shared
+:py:class:`multiprocessing.Condition` until the consumer releases enough space,
+up to ``acquire_timeout`` seconds, then raises. Set ``acquire_timeout=0`` for
+the legacy non-blocking behavior (raise immediately when full).
 """
 
 from __future__ import annotations
 
+import multiprocessing
 import struct
 from multiprocessing import shared_memory
+from multiprocessing.synchronize import Condition as _Condition
 from typing import TypedDict
 
 from ._shm import _attach
@@ -35,16 +42,25 @@ from ._shm import _attach
 __all__ = ["SharedMemoryRingBuffer"]
 
 
+# Default time ``write_binary`` waits for the consumer to free enough space
+# before giving up and raising. Generous, so it only fires on a genuinely
+# stalled or dead consumer rather than normal slow-consumer backpressure.
+_DEFAULT_ACQUIRE_TIMEOUT: float = 60.0
+
+
 class _RingState(TypedDict):
     """Picklable state of a :py:class:`SharedMemoryRingBuffer`."""
 
     shm_name: str
     capacity: int
+    acquire_timeout: float
+    space_cv: _Condition
 
 
-# Control header: head, tail (absolute, monotonic byte counters).
-_HEADER: struct.Struct = struct.Struct("<QQ")
-_HEADER_SIZE: int = _HEADER.size  # 16
+# Control header: head, tail (absolute, monotonic byte counters), shutdown
+# (uint8 flag set on teardown to wake any blocked producer cleanly).
+_HEADER: struct.Struct = struct.Struct("<QQB")
+_HEADER_SIZE: int = _HEADER.size  # 17
 
 
 class SharedMemoryRingBuffer:
@@ -56,33 +72,65 @@ class SharedMemoryRingBuffer:
 
     .. versionadded:: 0.5.0
 
+    .. versionchanged:: 0.6.0
+       The producer now blocks on a process-shared
+       :py:class:`multiprocessing.Condition` when the arena is full and resumes
+       once the consumer releases enough space, throttling the producer instead
+       of failing it. Pass ``acquire_timeout=0`` to restore the legacy
+       raise-immediately behavior.
+
+    .. versionadded:: 0.6.0
+       The ``acquire_timeout`` argument.
+
     Args:
         capacity: Size of the payload arena in bytes. Must be at least as large
             as the biggest single pipeline unit (the sum of the binaries
             offloaded from one item). Size it to the in-flight high-water mark,
             roughly ``(buffer_size + 2) * max_unit_bytes``.
+        acquire_timeout: Seconds ``write_binary`` waits for the consumer to free
+            enough space before raising :py:exc:`BufferError`. Guards against a
+            stalled/dead consumer; set to ``0`` for non-blocking behavior (raise
+            immediately when the in-progress unit would not fit).
     """
 
-    def __init__(self, capacity: int) -> None:
+    def __init__(
+        self,
+        capacity: int,
+        *,
+        acquire_timeout: float = _DEFAULT_ACQUIRE_TIMEOUT,
+    ) -> None:
         if capacity <= 0:
             raise ValueError("capacity must be positive")
+        if acquire_timeout < 0:
+            raise ValueError("acquire_timeout must be non-negative")
         self._capacity: int = capacity
+        self._acquire_timeout: float = acquire_timeout
         shm = shared_memory.SharedMemory(create=True, size=_HEADER_SIZE + capacity)
         self._shm_name: str = shm.name
         self._shm: shared_memory.SharedMemory | None = shm
         # pyrefly: ignore [bad-assignment]
         self._buf: "memoryview[bytes] | None" = shm.buf
         # pyrefly: ignore [bad-argument-type]
-        _HEADER.pack_into(shm.buf, 0, 0, 0)
+        _HEADER.pack_into(shm.buf, 0, 0, 0, 0)
+        # Process-shared condition variable used by the producer to block on
+        # ``tail`` advances by the consumer (or on a shutdown wakeup).
+        self._space_cv: _Condition = multiprocessing.Condition()
 
     # -- pickling: carry only the spec; attach lazily, once, per process --
 
     def __getstate__(self) -> _RingState:
-        return {"shm_name": self._shm_name, "capacity": self._capacity}
+        return {
+            "shm_name": self._shm_name,
+            "capacity": self._capacity,
+            "acquire_timeout": self._acquire_timeout,
+            "space_cv": self._space_cv,
+        }
 
     def __setstate__(self, state: _RingState) -> None:
         self._shm_name = state["shm_name"]
         self._capacity = state["capacity"]
+        self._acquire_timeout = state["acquire_timeout"]
+        self._space_cv = state["space_cv"]
         self._shm = None
         self._buf = None
 
@@ -121,6 +169,35 @@ class SharedMemoryRingBuffer:
     @tail.setter
     def tail(self, value: int) -> None:
         struct.pack_into("<Q", self._ensure(), 8, value)
+        # Wake any producer blocked in ``write_binary`` waiting for free space.
+        # Doing this in the setter (rather than only at the end_unit call site)
+        # also wakes the producer when tests or other consumers advance ``tail``
+        # directly.
+        with self._space_cv:
+            self._space_cv.notify_all()
+
+    @property
+    def _shutdown(self) -> bool:
+        return bool(_HEADER.unpack_from(self._ensure(), 0)[2])
+
+    @_shutdown.setter
+    def _shutdown(self, value: bool) -> None:
+        struct.pack_into("<B", self._ensure(), 16, 1 if value else 0)
+
+    def shutdown_arena(self) -> None:
+        """Wake any producer blocked in :py:meth:`_RingWriter.write_binary`.
+
+        Sets a sticky shutdown flag in the control header and broadcasts on the
+        space condition variable so a producer that is currently waiting for
+        free space exits the wait promptly with a :py:exc:`BufferError`. Safe
+        to call multiple times and from either process.
+        """
+        try:
+            self._shutdown = True
+        except Exception:  # noqa: BLE001 — buf may already be released
+            return
+        with self._space_cv:
+            self._space_cv.notify_all()
 
     def open_writer(self) -> _RingWriter:
         """Return the writer endpoint (call in the worker process)."""
@@ -132,6 +209,9 @@ class SharedMemoryRingBuffer:
 
     def close(self) -> None:
         """Release this process's mapping of the segment."""
+        # First wake any blocked producer so it exits its wait before we tear
+        # down the buffer it observes.
+        self.shutdown_arena()
         if self._buf is not None:
             self._buf.release()
             self._buf = None
@@ -167,6 +247,7 @@ class _RingWriter:
         self._b = buf
         self._mv = mv
         self._cap: int = buf.capacity
+        self._acquire_timeout: float = buf._acquire_timeout
         self._data_off: int = _HEADER_SIZE
         self._ustart: int = 0
         self._wpos: int = 0
@@ -179,6 +260,8 @@ class _RingWriter:
         iteration; any residual bytes from an abandoned iteration are discarded.
         """
         self._b.head = 0
+        # ``tail`` setter notifies the space cv, which is the right behavior
+        # here: a fresh iteration has the entire arena free.
         self._b.tail = 0
         self._ustart = self._wpos = 0
 
@@ -191,19 +274,64 @@ class _RingWriter:
     ) -> tuple[int, int]:
         """Copy one binary into the arena; return its ``(offset, nbytes)``.
 
-        Non-blocking: raises :py:exc:`BufferError` if the in-progress unit would
-        exceed the free space (Mode A relies on the queue backpressure keeping
-        the arena from filling; an overrun means the capacity is too small).
+        Blocks (up to ``acquire_timeout``) on the arena's process-shared
+        condition variable until the consumer has released enough space for the
+        write, then proceeds. With ``acquire_timeout=0`` the call instead raises
+        immediately when the in-progress unit would overflow the free space.
+
+        Raises:
+            BufferError: when ``n`` is larger than the entire ring (no amount of
+                consumer reclaim can ever satisfy it), when the in-progress unit
+                accumulates more bytes than the ring can ever hold (committing
+                it would never reclaim those bytes), when the consumer does not
+                free enough space within ``acquire_timeout``, when the arena is
+                shut down, or when ``acquire_timeout=0`` and the write would not
+                currently fit.
         """
         mv = memoryview(data).cast("B")
         n = mv.nbytes
-        used = self._wpos - self._b.tail
-        free = self._cap - used
-        if n > free:
+        # Hard guards: no amount of consumer progress will satisfy these.
+        if n > self._cap:
             raise BufferError(
-                f"shared-memory arena full: need {n} more bytes but only {free} "
-                "free; increase SharedMemoryRingBuffer capacity"
+                f"binary of {n} bytes exceeds ring capacity {self._cap}; "
+                "increase SharedMemoryRingBuffer capacity"
             )
+        in_unit = self._wpos - self._ustart
+        if in_unit + n > self._cap:
+            raise BufferError(
+                f"unit would exceed ring capacity ({self._cap}): {in_unit} "
+                f"already written + {n} new > capacity. Increase "
+                "SharedMemoryRingBuffer capacity."
+            )
+        b = self._b
+        free = self._cap - (self._wpos - b.tail)
+        if n > free:
+            if self._acquire_timeout == 0:
+                raise BufferError(
+                    f"shared-memory arena full: need {n} more bytes but only "
+                    f"{free} free and acquire_timeout=0; increase "
+                    "SharedMemoryRingBuffer capacity or acquire_timeout"
+                )
+            with b._space_cv:
+                # Re-evaluate ``tail`` on each wakeup; the cv predicate also
+                # exits if the arena is being shut down.
+                def _ready() -> bool:
+                    if b._shutdown:
+                        return True
+                    return self._cap - (self._wpos - b.tail) >= n
+
+                if not b._space_cv.wait_for(_ready, timeout=self._acquire_timeout):
+                    raise BufferError(
+                        f"shared-memory arena full: need {n} more bytes after "
+                        f"waiting {self._acquire_timeout:g}s — the consumer is "
+                        "releasing units too slowly or has stalled. Increase "
+                        "SharedMemoryRingBuffer capacity or acquire_timeout, "
+                        "or check the consumer."
+                    )
+                if b._shutdown:
+                    raise BufferError(
+                        "shared-memory ring shut down while waiting for free space"
+                    )
         buf = self._mv
         d = self._data_off
         idx = self._wpos % self._cap
@@ -268,6 +396,7 @@ class _RingReader:
 
         ``pinned`` is ignored: read_binary already copied the data out, so
         restored views alias the copy, not the ring, and the region is free to
-        reuse immediately.
+        reuse immediately. Advancing ``tail`` via the property setter wakes any
+        producer blocked in ``write_binary``.
         """
         self._b.tail = self._b.tail + span

--- a/src/spdl/pipeline/_iter_utils/_subprocess.py
+++ b/src/spdl/pipeline/_iter_utils/_subprocess.py
@@ -67,13 +67,21 @@ class _ipc(Generic[T]):
 
     def terminate(self) -> None:
         self.cmd_q.put(_Cmd.ABORT)
+        # Wake any worker that is currently blocked in ``write_binary`` /
+        # ``begin_unit`` on the arena's space condition variable. Without this,
+        # a producer waiting for a (never-coming) consumer reclaim would stay
+        # blocked through ``_join`` and hang teardown.
+        if (arena := self.arena) is not None:
+            shutdown = getattr(arena, "shutdown_arena", None)
+            if shutdown is not None:
+                shutdown()
         _drain(self.data_q)
         _join(self.process)
         # Unlink the shared-memory arena only after the worker is confirmed
         # dead, so nothing touches the segment afterwards. ``unlink`` runs in
         # ``finally`` so a failing ``close`` never leaves the OS-level shm
         # segment behind — teardown is the only place that calls ``unlink``.
-        if (arena := self.arena) is not None:
+        if arena is not None:
             try:
                 arena.close()
             finally:

--- a/tests/pipeline/arena_pool_test.py
+++ b/tests/pipeline/arena_pool_test.py
@@ -118,12 +118,58 @@ class SharedMemorySegmentPoolTest(unittest.TestCase):
         t = threading.Thread(target=_reclaim_soon)
         t.start()
         try:
-            # Blocks ~0.1s until the reclaim, then succeeds (does not raise).
+            t0 = time.monotonic()
             writer.begin_unit()
+            elapsed = time.monotonic() - t0
         finally:
             t.join()
         off, n = writer.write_binary(b"y" * 10)
         self.assertEqual(writer.commit_unit(), n)
+        # Producer wakes promptly (cv-driven, not poll-bounded).
+        self.assertLess(elapsed, 2.0)
+        self.assertGreaterEqual(elapsed, 0.05)
+
+    def test_begin_unit_timeout_raises(self) -> None:
+        """begin_unit raises BufferError after acquire_timeout when no reclaim."""
+        pool = self._pool(1 << 16, 1, acquire_timeout=0.05)
+        writer = pool.open_writer()
+        writer.begin_unit()
+        writer.write_binary(b"x" * 10)
+        writer.commit_unit()  # pool full
+        t0 = time.monotonic()
+        with self.assertRaises(BufferError):
+            writer.begin_unit()
+        elapsed = time.monotonic() - t0
+        self.assertGreaterEqual(elapsed, 0.04)
+        self.assertLess(elapsed, 2.0)
+
+    def test_shutdown_wakes_blocked_producer(self) -> None:
+        """shutdown_arena() wakes a blocked producer immediately.
+
+        Models the consumer-dies-first scenario: with no reclaim ever happening,
+        flipping the shutdown flag still lets the producer exit so the worker
+        process can shut down without hanging.
+        """
+        pool = self._pool(1 << 16, 1, acquire_timeout=10.0)
+        writer = pool.open_writer()
+        writer.begin_unit()
+        writer.write_binary(b"x" * 10)
+        writer.commit_unit()
+
+        def _shutdown_soon() -> None:
+            time.sleep(0.1)
+            pool.shutdown_arena()
+
+        t = threading.Thread(target=_shutdown_soon)
+        t.start()
+        try:
+            t0 = time.monotonic()
+            with self.assertRaises(BufferError):
+                writer.begin_unit()
+            elapsed = time.monotonic() - t0
+        finally:
+            t.join()
+        self.assertLess(elapsed, 2.0)
 
     def test_unit_larger_than_segment_raises(self) -> None:
         """A unit that does not fit a segment is refused, not truncated."""

--- a/tests/pipeline/arena_ring_test.py
+++ b/tests/pipeline/arena_ring_test.py
@@ -6,6 +6,8 @@
 
 # pyre-strict
 
+import threading
+import time
 import unittest
 from typing import Any, cast
 
@@ -15,8 +17,10 @@ from spdl.pipeline._arena._registry import _default_registry
 
 
 class SharedMemoryRingBufferTest(unittest.TestCase):
-    def _ring(self, capacity: int) -> SharedMemoryRingBuffer:
-        buf = SharedMemoryRingBuffer(capacity=capacity)
+    def _ring(
+        self, capacity: int, acquire_timeout: float = 60.0
+    ) -> SharedMemoryRingBuffer:
+        buf = SharedMemoryRingBuffer(capacity=capacity, acquire_timeout=acquire_timeout)
         self.addCleanup(buf.unlink)
         self.addCleanup(buf.close)
         return buf
@@ -75,12 +79,117 @@ class SharedMemoryRingBufferTest(unittest.TestCase):
         reader.end_unit(span, [])
 
     def test_overrun_raises(self) -> None:
-        """A write larger than the free space is refused, not truncated."""
+        """A write larger than the entire ring is refused immediately, not blocked."""
         buf = self._ring(64)
         writer = buf.open_writer()
         writer.begin_unit()
+        # 128 > capacity 64: no consumer reclaim could ever satisfy it, so the
+        # producer must raise promptly rather than block on the cv.
+        t0 = time.monotonic()
         with self.assertRaises(BufferError):
             writer.write_binary(b"x" * 128)
+        self.assertLess(time.monotonic() - t0, 1.0)
+
+    def test_unit_overflow_raises_promptly(self) -> None:
+        """A unit accumulating more bytes than the ring can ever hold raises fast."""
+        buf = self._ring(64)
+        writer = buf.open_writer()
+        writer.begin_unit()
+        writer.write_binary(b"a" * 50)
+        # The in-progress unit (50 + 30 = 80) exceeds capacity 64. Even with a
+        # fully drained tail, committing this unit could never make those bytes
+        # reclaimable, so the producer must raise instead of blocking.
+        t0 = time.monotonic()
+        with self.assertRaises(BufferError):
+            writer.write_binary(b"b" * 30)
+        self.assertLess(time.monotonic() - t0, 1.0)
+
+    def test_nonblocking_full_raises(self) -> None:
+        """With acquire_timeout=0, a write that would not currently fit raises."""
+        buf = self._ring(64, acquire_timeout=0.0)
+        writer = buf.open_writer()
+        writer.begin_unit()
+        writer.write_binary(b"x" * 50)
+        writer.commit_unit()
+        writer.begin_unit()
+        with self.assertRaises(BufferError):
+            writer.write_binary(b"y" * 50)  # 50 > free 14
+
+    def test_blocking_then_resume(self) -> None:
+        """A producer blocked on a full ring resumes when the consumer releases space."""
+        buf = self._ring(64, acquire_timeout=5.0)
+        writer = buf.open_writer()
+        reader = buf.open_reader()
+
+        # Fill the ring with one committed unit.
+        writer.begin_unit()
+        off0, n0 = writer.write_binary(b"x" * 50)
+        span0 = writer.commit_unit()
+
+        def _release_soon() -> None:
+            time.sleep(0.1)
+            reader.read_binary(off0, n0)
+            reader.end_unit(span0, [])
+
+        t = threading.Thread(target=_release_soon)
+        t.start()
+        try:
+            t0 = time.monotonic()
+            writer.begin_unit()
+            # 50 bytes is more than the 14 free; producer blocks until release.
+            off1, n1 = writer.write_binary(b"y" * 50)
+            elapsed = time.monotonic() - t0
+        finally:
+            t.join()
+        writer.commit_unit()
+        # Should have unblocked roughly when the consumer released, well under
+        # the 5s acquire_timeout, and not "instant" (proves it actually waited).
+        self.assertLess(elapsed, 2.0)
+        self.assertGreaterEqual(elapsed, 0.05)
+
+    def test_blocking_timeout_raises(self) -> None:
+        """A producer with no consumer raises BufferError after acquire_timeout."""
+        buf = self._ring(64, acquire_timeout=0.05)
+        writer = buf.open_writer()
+        writer.begin_unit()
+        writer.write_binary(b"x" * 50)
+        writer.commit_unit()
+        writer.begin_unit()
+        t0 = time.monotonic()
+        with self.assertRaises(BufferError):
+            writer.write_binary(b"y" * 50)
+        elapsed = time.monotonic() - t0
+        self.assertGreaterEqual(elapsed, 0.04)
+        self.assertLess(elapsed, 2.0)
+
+    def test_shutdown_wakes_blocked_producer(self) -> None:
+        """shutdown_arena() wakes a blocked producer immediately.
+
+        Models the consumer-dies-first scenario: even though no reclaim ever
+        happens, the parent flipping the shutdown flag must let the producer
+        exit cleanly so the worker process can shut down without hanging.
+        """
+        buf = self._ring(64, acquire_timeout=10.0)
+        writer = buf.open_writer()
+        writer.begin_unit()
+        writer.write_binary(b"x" * 50)
+        writer.commit_unit()
+        writer.begin_unit()
+
+        def _shutdown_soon() -> None:
+            time.sleep(0.1)
+            buf.shutdown_arena()
+
+        t = threading.Thread(target=_shutdown_soon)
+        t.start()
+        try:
+            t0 = time.monotonic()
+            with self.assertRaises(BufferError):
+                writer.write_binary(b"y" * 50)
+            elapsed = time.monotonic() - t0
+        finally:
+            t.join()
+        self.assertLess(elapsed, 2.0)
 
 
 class OffloadRestoreTest(unittest.TestCase):

--- a/tests/pipeline/iterate_in_subprocess_arena_test.py
+++ b/tests/pipeline/iterate_in_subprocess_arena_test.py
@@ -6,6 +6,7 @@
 
 # pyre-strict
 
+import time
 import unittest
 from collections.abc import Iterable, Iterator
 
@@ -19,6 +20,18 @@ def _make_items() -> list[dict[str, bytes | int]]:
 def _failing_iterable() -> Iterator[dict[str, bytes | int]]:
     yield {"i": 0, "blob": b"x" * 50_000}
     raise ValueError("boom")
+
+
+def _producer_blocking_then_dying() -> Iterator[dict[str, bytes | int]]:
+    """Yields one large item, then dies — modeling a producer crash mid-stream."""
+    yield {"i": 0, "blob": b"x" * 100_000}
+    raise RuntimeError("producer died")
+
+
+def _producer_blocked_on_full_arena() -> Iterator[dict[str, bytes | int]]:
+    """Pushes more units than the arena/queue can hold, exercising producer block."""
+    for i in range(200):
+        yield {"i": i, "blob": bytes([i % 256]) * 100_000}
 
 
 class IterateInSubprocessArenaTest(unittest.TestCase):
@@ -43,3 +56,45 @@ class IterateInSubprocessArenaTest(unittest.TestCase):
         it = iterate_in_subprocess(_failing_iterable, arena=buf, buffer_size=2)
         with self.assertRaises(RuntimeError):
             list(it)
+
+    def test_producer_death_does_not_hang_consumer(self) -> None:
+        """A worker that crashes mid-stream surfaces as an error within a bounded time."""
+        buf = SharedMemoryRingBuffer(capacity=1 << 20, acquire_timeout=2.0)
+        it = iterate_in_subprocess(
+            _producer_blocking_then_dying, arena=buf, buffer_size=2
+        )
+        t0 = time.monotonic()
+        with self.assertRaises(RuntimeError):
+            list(it)
+        # Whether we surface the producer's RuntimeError or the arena's
+        # acquire timeout, the consumer must not hang.
+        self.assertLess(time.monotonic() - t0, 30.0)
+
+    def test_consumer_exit_during_producer_block_is_clean(self) -> None:
+        """Closing the iterable while the producer is blocked tears down cleanly.
+
+        The producer is generating units faster than we consume them, so it
+        eventually blocks in ``write_binary`` waiting for the consumer to
+        release space. Closing the iterable from the consumer side must wake
+        the worker (via the arena's shutdown flag) so the process exits within
+        the teardown grace period instead of hanging at interpreter exit.
+        """
+        buf = SharedMemoryRingBuffer(capacity=1 << 18, acquire_timeout=30.0)
+        it = iterate_in_subprocess(
+            _producer_blocked_on_full_arena, arena=buf, buffer_size=1
+        )
+        iterator = iter(it)
+        # Pull just a few items so the producer fills the arena and queue, then
+        # blocks in ``write_binary`` for the rest of its 200-item sequence.
+        for _ in range(3):
+            next(iterator)
+        t0 = time.monotonic()
+        # Drop the iterator and the iterable; teardown should release the
+        # blocked worker and unlink the arena promptly.
+        del iterator
+        del it
+        # Allow GC to run teardown.
+        import gc as _gc
+
+        _gc.collect()
+        self.assertLess(time.monotonic() - t0, 15.0)


### PR DESCRIPTION
Summary:
The two `spdl.pipeline` shared-memory arenas — `SharedMemoryRingBuffer` and `SharedMemorySegmentPool` — both responded to a slow consumer the wrong way. The ring `_RingWriter.write_binary` raised `BufferError` the moment the in-progress unit didn't fit, failing the producer instead of throttling it. The pool already had blocking semantics in `_PoolWriter.begin_unit`, but it implemented them by busy-polling the shared `reclaimed` counter every 0.5 ms — wasted CPU on the producer side and poll-bounded wakeup latency on every reclaim.

Both arenas now back the producer's wait with a process-shared `multiprocessing.Condition`. When the arena is full the producer parks on the cv; the consumer's release path (`tail` advance on the ring, `reclaimed` advance on the pool) wakes it via `notify_all`. The cv is allocated in the parent and pickled through `__getstate__`/`__setstate__` like the rest of the arena, so it works across the parent ↔ worker process boundary that `iterate_in_subprocess` sets up.

`acquire_timeout` (existing on the pool, new on the ring) is still the backstop for a stalled or dead consumer; passing `acquire_timeout=0` keeps the legacy raise-immediately behavior for callers that want it.

A sticky `shutdown` flag is added to each arena's control header. `shutdown_arena()` flips the flag and broadcasts on the cv, so a producer parked in `wait_for` exits with a clean `BufferError` instead of waiting out the full timeout. `iterate_in_subprocess`'s `_ipc.terminate()` calls `shutdown_arena()` before joining the worker so a producer blocked at teardown unblocks immediately and the parent doesn't hang.

For the ring, `write_binary` also gains explicit fast-fail guards for the two cases where blocking would be a deadlock: a single binary larger than capacity, and an in-progress unit whose accumulated bytes would exceed capacity (those bytes can't be reclaimed until the unit commits, so no amount of consumer progress can satisfy them).

**No throughput regression.** Ran `spdl/examples:benchmark_arena_transport --sizes 2 8 32 --num-items 16 --runs 3` on the base commit and on this commit, back-to-back on the same idle host:

```
                           base                    head (this diff)
kind     size   no-arena   ring     pool       no-arena   ring     pool
-----------------------------------------------------------------------
bytes     2M       298      302      304          297      305      303
bytes     8M       817     1150     1167          797     1161     1162
bytes    32M       795     3439     4398          795     3438     4295
numpy     2M       297      297      301          300      306      301
numpy     8M       721     1164     1157          693     1158     1164
numpy    32M       584     3863     4333          573     3896     4345
torch     2M       293      296      292          290      297      297
torch     8M       776     1008     1031          765      867     1030
torch    32M      2388     2578     2743         2411     2694     2750
packets   2M       252      257      256          249      256      256
packets   8M       548      633      666          540      727      735
packets  32M       435      830      851          481      868      872
(throughput in MB/s)
```

Deltas are within run-to-run noise (typically ≤2%; a couple of ~10–14% outliers in both directions, normal for a 3-run mean on a shared host). This matches the design: the cv is on the slow path only (full arena, producer waiting); the steady-state writer/reader hot path is unchanged. The `torch 8M ring` row is the biggest single drop (1008 → 867 MB/s); the pool variant at the same size is unchanged (1031 → 1030), so it is run noise rather than something the cv could plausibly affect.