### PR TITLE
Fix Windows shared-memory worker crash + hang diagnostics (#1543)

### DIFF
--- a/.github/workflows/_build_windows.yml
+++ b/.github/workflows/_build_windows.yml
@@ -122,18 +122,26 @@ jobs:
 
           # Install PyTorch and others
           if [[ "${{ inputs.free-threaded }}" == 'ft' ]]; then
-            python -m pip install torch numpy pytest pytest-xdist parameterized matplotlib
+            python -m pip install torch numpy pytest pytest-xdist pytest-timeout parameterized matplotlib
           else
-            python -m pip install torch numpy numba pytest pytest-xdist parameterized matplotlib
+            python -m pip install torch numpy numba pytest pytest-xdist pytest-timeout parameterized matplotlib
           fi
 
           # Install FFmpeg
           conda install -q "ffmpeg==${{ matrix.ffmpeg-version }}"
 
       - name: Unit test
+        # Backstop so a hung subprocess/pipeline test fails the job in minutes
+        # instead of stalling until the global Actions limit. The per-test
+        # --timeout below should fire first; this only catches a wholesale hang.
+        timeout-minutes: 20
         run: |
           set -ex
+          # --timeout-method=thread because Windows has no SIGALRM (the default
+          # "signal" method is a no-op there). On firing, pytest-timeout dumps
+          # every thread's stack, pinpointing the blocking call.
           pytest -v -n ${{ inputs.test-concurrency }} \
+              --timeout=120 --timeout-method=thread \
               tests/io \
               tests/dataloader \
               tests/pipeline \

--- a/src/spdl/pipeline/_arena/_shm.py
+++ b/src/spdl/pipeline/_arena/_shm.py
@@ -10,6 +10,7 @@
 
 from __future__ import annotations
 
+import sys
 from multiprocessing import resource_tracker, shared_memory
 
 __all__ = ["_attach"]
@@ -30,8 +31,15 @@ def _attach(name: str) -> shared_memory.SharedMemory:
         named segment, detached from this process's resource tracker.
     """
     shm = shared_memory.SharedMemory(name=name)
-    try:
-        resource_tracker.unregister(shm._name, "shared_memory")  # type: ignore[attr-defined]
-    except (KeyError, AttributeError):
-        pass
+    # The ``resource_tracker`` only tracks shared memory on POSIX; Windows
+    # refcounts the mapping handle in the OS and never registers the segment.
+    # Worse, calling ``unregister`` on Windows when the tracker is not already
+    # running forces it to launch, and that launch imports ``_posixsubprocess``
+    # (a POSIX-only module), raising ``ModuleNotFoundError`` and killing the
+    # process. So only unregister where the tracker actually owns the segment.
+    if sys.platform != "win32":
+        try:
+            resource_tracker.unregister(shm._name, "shared_memory")  # type: ignore[attr-defined]
+        except (KeyError, AttributeError):
+            pass
     return shm

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,31 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Test-suite diagnostics.
+
+These tests spawn subprocesses and shut down pipelines, which has historically
+hung on Windows (no ``fork()``, different shared-memory and process-termination
+semantics, no POSIX signals). When that happens in CI the job stalls until the
+global timeout with no clue as to *where* it is stuck.
+
+``faulthandler.dump_traceback_later`` periodically prints the stack of every
+thread, so a hang leaves a trail of tracebacks pointing at the exact blocking
+call (a ``Queue.get``, ``Process.join``, pipe read, lock acquire, ...). It is
+armed on Windows, where the hangs occur; the periodic dump is harmless
+elsewhere but only adds noise, so we keep it scoped.
+"""
+
+import faulthandler
+import sys
+
+# Dump tracebacks on fatal errors (segfaults etc.) everywhere.
+faulthandler.enable(file=sys.stderr)
+
+if sys.platform == "win32":
+    # Dump all thread stacks every 90s while a test is running. The per-test
+    # pytest-timeout (set on the CI command line) fires after this, so a hung
+    # test produces at least one full stack dump before it is killed.
+    faulthandler.dump_traceback_later(90, repeat=True, file=sys.stderr)


### PR DESCRIPTION
Summary:

The continuous-pipeline and segment-pool subprocess tests stalled at ~38% on Windows CI with no timeout or output. This diff fixes the root cause and adds diagnostics so any future hang fails fast with a full traceback.

Root cause: `_attach()` in `_shm.py` called `resource_tracker.unregister()` unconditionally. On Windows, shared memory is not resource-tracked (the OS refcounts the mapping handle), and calling `unregister` when the tracker is not already running forces it to launch — and that launch does `import _posixsubprocess`, a POSIX-only module that does not exist on Windows. So every arena worker crashed with `ModuleNotFoundError: No module named '_posixsubprocess'` the moment it attached to a segment by name. With the parent's infinite inactivity timeout, the parent then waited forever for data that never came — the ~38% hang. Guarding the `unregister` call to non-Windows (`sys.platform != "win32"`) both fixes the crash and is semantically correct, since there is nothing to unregister on Windows.

Diagnostics (kept as a permanent safety net): `faulthandler.dump_traceback_later(90, repeat=True)` in `tests/conftest.py` (armed on Windows), plus `pytest-timeout` run with `--timeout=120 --timeout-method=thread` (the signal-based method is a no-op on Windows) and a job-level `timeout-minutes: 20` in `_build_windows.yml`. These converted the indefinite hang into a fast failure with the real exception — which is how the `_posixsubprocess` root cause was identified — and remain in place to catch future regressions.

Differential Revision: D108815664


