### PR TITLE
[pipeline] Fix Windows shared-memory worker crash

### DIFF
--- a/src/spdl/pipeline/_arena/_shm.py
+++ b/src/spdl/pipeline/_arena/_shm.py
@@ -10,6 +10,7 @@
 
 from __future__ import annotations
 
+import sys
 from multiprocessing import resource_tracker, shared_memory
 
 __all__ = ["_attach"]
@@ -30,8 +31,15 @@ def _attach(name: str) -> shared_memory.SharedMemory:
         named segment, detached from this process's resource tracker.
     """
     shm = shared_memory.SharedMemory(name=name)
-    try:
-        resource_tracker.unregister(shm._name, "shared_memory")  # type: ignore[attr-defined]
-    except (KeyError, AttributeError):
-        pass
+    # The ``resource_tracker`` only tracks shared memory on POSIX; Windows
+    # refcounts the mapping handle in the OS and never registers the segment.
+    # Worse, calling ``unregister`` on Windows when the tracker is not already
+    # running forces it to launch, and that launch imports ``_posixsubprocess``
+    # (a POSIX-only module), raising ``ModuleNotFoundError`` and killing the
+    # process. So only unregister where the tracker actually owns the segment.
+    if sys.platform != "win32":
+        try:
+            resource_tracker.unregister(shm._name, "shared_memory")  # type: ignore[attr-defined]
+        except (KeyError, AttributeError):
+            pass
     return shm


### PR DESCRIPTION
`_attach()` in _shm.py called resource_tracker.unregister() unconditionally. On Windows, shared memory is not resource-tracked (the OS refcounts the mapping handle), and calling unregister when the tracker is not already running forces it to launch — and that launch does import _posixsubprocess, a POSIX-only module that does not exist on Windows. So every arena worker crashed with ModuleNotFoundError: No module named '_posixsubprocess' the moment it attached to a segment by name. With the parent's infinite inactivity timeout, the parent then waited forever for data that never came — the ~38% hang. Guarding the unregister call to non-Windows (sys.platform != "win32") both fixes the crash and is semantically correct, since there is nothing to unregister on Windows.