### PR TITLE
Enforce pytest timeouts across all CI platforms

### DIFF
--- a/.github/workflows/_build_linux.yml
+++ b/.github/workflows/_build_linux.yml
@@ -163,7 +163,7 @@ jobs:
 
           # Install PyTorch and others
           conda run -n test_env python -m pip install numpy torch --index-url https://download.pytorch.org/whl/cpu
-          conda install -q numba pytest pytest-xdist parameterized matplotlib
+          conda install -q numba pytest pytest-xdist pytest-timeout parameterized matplotlib
 
           # Install FFmpeg
           # Note: Somehow FFmepg 5.1 does not install libiconv so specifying it here
@@ -172,11 +172,17 @@ jobs:
           echo "LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${CONDA_PREFIX}/lib" >> $GITHUB_ENV
 
       - name: Unit test
+        # Backstop so a hung test fails the job in minutes instead of stalling
+        # until the global Actions limit. The per-test --timeout below fires first.
+        timeout-minutes: 20
         run: |
           set -ex
 
           python -c 'import spdl.io.utils;assert not spdl.io.utils.built_with_cuda()'
+          # --timeout-method=thread works under pytest-xdist and on every
+          # platform; on firing it dumps each thread's stack, pinpointing a hang.
           pytest -v -n ${{ inputs.test-concurrency }} \
+              --timeout=120 --timeout-method=thread \
               tests/io/ \
               tests/dataloader/ \
               tests/pipeline/ \

--- a/.github/workflows/_build_linux_cuda.yml
+++ b/.github/workflows/_build_linux_cuda.yml
@@ -189,7 +189,7 @@ jobs:
           spdl --help
 
           # Install PyTorch and others
-          conda run -n test_env python -m pip install pytest pytest-xdist parameterized
+          conda run -n test_env python -m pip install pytest pytest-xdist pytest-timeout parameterized
 
           cu_ver="${{ inputs.cuda-version }}"
           cu_ver="${cu_ver//[.]/}"  # Remove dots  12.4.1 -> 1241
@@ -209,13 +209,19 @@ jobs:
           echo "LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${CONDA_PREFIX}/lib:${cudart_dir}" >> $GITHUB_ENV
 
       - name: Unit test
+        # Backstop so a hung test fails the job in minutes instead of stalling
+        # until the global Actions limit. The per-test --timeout below fires first.
+        timeout-minutes: 20
         run: |
           set -ex
 
           nvidia-smi
 
           python .github/scripts/check_cuda.py "${{inputs.use-nvdec}}"
+          # --timeout-method=thread works under pytest-xdist and on every
+          # platform; on firing it dumps each thread's stack, pinpointing a hang.
           pytest -v -n ${{ inputs.test-concurrency }} \
+              --timeout=120 --timeout-method=thread \
               tests/cuda/ \
               tests/io/
 
@@ -265,7 +271,7 @@ jobs:
 
           # Install PyTorch and others
           conda run -n test_env python -m pip install numpy torch --index-url https://download.pytorch.org/whl/cpu
-          conda install -q numba pytest pytest-xdist parameterized matplotlib
+          conda install -q numba pytest pytest-xdist pytest-timeout parameterized matplotlib
 
           # Install FFmpeg
           # Note: Somehow FFmepg 5.1 does not install libiconv so specifying it here
@@ -275,10 +281,16 @@ jobs:
           echo "LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${CONDA_PREFIX}/lib" >> $GITHUB_ENV
 
       - name: Unit test
+        # Backstop so a hung test fails the job in minutes instead of stalling
+        # until the global Actions limit. The per-test --timeout below fires first.
+        timeout-minutes: 20
         run: |
           set -ex
 
+          # --timeout-method=thread works under pytest-xdist and on every
+          # platform; on firing it dumps each thread's stack, pinpointing a hang.
           pytest -v -n ${{ inputs.test-concurrency }} \
+              --timeout=120 --timeout-method=thread \
               tests/io \
               tests/dataloader \
               tests/pipeline \

--- a/.github/workflows/_build_macos.yml
+++ b/.github/workflows/_build_macos.yml
@@ -116,18 +116,24 @@ jobs:
 
           # Install PyTorch and others
           if [[ "${{ inputs.free-threaded }}" == 'ft' ]]; then
-            pip install torch numpy pytest parameterized matplotlib
+            pip install torch numpy pytest pytest-timeout parameterized matplotlib
           else
-            pip install torch numpy numba pytest parameterized matplotlib
+            pip install torch numpy numba pytest pytest-timeout parameterized matplotlib
           fi
 
           # Install FFmpeg
           conda install -q -c conda-forge "ffmpeg==${{ matrix.ffmpeg-version }}"
 
       - name: Unit test
+        # Backstop so a hung test fails the job in minutes instead of stalling
+        # until the global Actions limit. The per-test --timeout below fires first.
+        timeout-minutes: 20
         run: |
           set -ex
+          # --timeout-method=thread works under pytest-xdist and on every
+          # platform; on firing it dumps each thread's stack, pinpointing a hang.
           pytest -v -n ${{ inputs.test-concurrency }} \
+              --timeout=120 --timeout-method=thread \
               tests/io \
               tests/dataloader \
               tests/pipeline \

--- a/.github/workflows/_build_windows.yml
+++ b/.github/workflows/_build_windows.yml
@@ -122,18 +122,25 @@ jobs:
 
           # Install PyTorch and others
           if [[ "${{ inputs.free-threaded }}" == 'ft' ]]; then
-            python -m pip install torch numpy pytest pytest-xdist parameterized matplotlib
+            python -m pip install torch numpy pytest pytest-xdist pytest-timeout parameterized matplotlib
           else
-            python -m pip install torch numpy numba pytest pytest-xdist parameterized matplotlib
+            python -m pip install torch numpy numba pytest pytest-xdist pytest-timeout parameterized matplotlib
           fi
 
           # Install FFmpeg
           conda install -q "ffmpeg==${{ matrix.ffmpeg-version }}"
 
       - name: Unit test
+        # Backstop so a hung test fails the job in minutes instead of stalling
+        # until the global Actions limit. The per-test --timeout below fires first.
+        timeout-minutes: 20
         run: |
           set -ex
+          # --timeout-method=thread works under pytest-xdist and on every
+          # platform (signal-based timeouts are a no-op on Windows); on firing it
+          # dumps each thread's stack, pinpointing a hang.
           pytest -v -n ${{ inputs.test-concurrency }} \
+              --timeout=120 --timeout-method=thread \
               tests/io \
               tests/dataloader \
               tests/pipeline \


### PR DESCRIPTION
Summary:
Adds a per-test timeout and a job-level backstop to every unit-test job across all GitHub CI platforms — Windows, Linux, Linux/CUDA (test-gpu and test-cpu), and macOS. Each job now installs `pytest-timeout` and runs with `--timeout=120 --timeout-method=thread` plus a job-level `timeout-minutes: 20`.

This is a follow-up to the Windows shared-memory worker crash fix (which landed separately): when a subprocess/pipeline test hangs, the job previously stalled until the global Actions limit with no diagnostic output. The `thread` timeout method is used uniformly because the signal-based method is a no-op on Windows and does not compose with pytest-xdist; on firing it dumps every thread's stack, so a future hang fails fast with a pinpointed traceback. The job-level `timeout-minutes: 20` is a coarse backstop in case the suite wedges before pytest can arm its own timeout.

These changes only affect the GitHub-synced workflows; fbcode does not run these tests under pytest.

Differential Revision: D109005884


