### PR TITLE
[spdl] Document continuous source support in run_pipeline_in_subprocess

### DIFF
--- a/docs/source/getting_started/parallelism.rst
+++ b/docs/source/getting_started/parallelism.rst
@@ -443,3 +443,12 @@ The MTP mode helps the OS to schedule GPU kernel launches from the main thread
 (where the training loop is running) in timely manner, and reduces the
 number of Python objects that the Python interpreter in the main process
 has to handle.
+
+For multi-epoch training, build the subprocess source with a continuous
+source (``add_source(..., continuous=True)``). The pipeline is then built and
+started once inside the subprocess and reused across epochs, keeping the
+prefetch buffer warm and avoiding a per-epoch rebuild gap. This is especially
+important when the training step is short (e.g. small models), where a rebuild
+gap would otherwise stall the GPU between epochs. The outer (main-process)
+pipeline can likewise use ``continuous=True`` so that the GPU-transfer stage
+keeps running across epoch boundaries.

--- a/src/spdl/pipeline/_build.py
+++ b/src/spdl/pipeline/_build.py
@@ -373,6 +373,36 @@ def run_pipeline_in_subprocess(
             for batch in src:
                 train(batch)
 
+    If the given config has a continuous source (built with
+    :py:meth:`PipelineBuilder.add_source(..., continuous=True)
+    <spdl.pipeline.PipelineBuilder.add_source>`), the pipeline is built and
+    started once inside the subprocess and then **reused** across epochs: it
+    keeps running in the background between epochs instead of being torn down
+    and rebuilt. This keeps the prefetch buffer warm and removes the per-epoch
+    rebuild gap, which matters most when the training step is short (e.g. small
+    models)::
+
+        config = (
+            PipelineBuilder()
+            .add_source(dataset, continuous=True)
+            .pipe(load, concurrency=4)
+            .aggregate(batch_size)
+            .add_sink(buffer_size=3)
+            .get_config()
+        )
+        src = run_pipeline_in_subprocess(config, num_threads=4)
+        for epoch in range(num_epochs):
+            for batch in src:  # one epoch; subprocess pipeline stays warm
+                train(batch)
+
+    Each iteration yields exactly one epoch (the epoch boundary is handled
+    internally), so the loop above iterates one epoch per ``for`` pass just as
+    in the non-continuous case. The continuous setting only changes *how* the
+    subprocess manages the pipeline between epochs. To run continuous
+    GPU-transfer stages in the main process, an outer pipeline can wrap ``src``
+    with ``add_source(src, continuous=True)`` (see the MTP pattern in the
+    parallelism guide).
+
     Args:
         config_or_builder: The definition of :py:class:`Pipeline`. Can be either a
             :py:class:`PipelineConfig` or :py:class:`PipelineBuilder`.

--- a/tests/pipeline/continuous_pipeline_test.py
+++ b/tests/pipeline/continuous_pipeline_test.py
@@ -568,6 +568,41 @@ class TestContinuousSubprocessPipelineReuse(unittest.TestCase):
             "Process IDs changed between epoch 1 and 2",
         )
 
+    @_ignore_fork_warning
+    def test_continuous_subprocess_concurrent_aggregate_crisp_boundary(self) -> None:
+        """A continuous subprocess pipeline with a concurrent pipe stage and
+        aggregation keeps crisp epoch boundaries across epochs.
+
+        Concurrency can reorder items and aggregation buffers partial batches,
+        so this guards against epochs bleeding into one another (e.g. a partial
+        batch from one epoch being emitted in the next) when the pipeline is
+        reused across epochs in the subprocess.
+        """
+
+        def double(x: int) -> int:
+            return x * 2
+
+        backend = (
+            PipelineBuilder()
+            .add_source(SourceIterable(10), continuous=True)
+            .pipe(double, concurrency=4)
+            .aggregate(3, drop_last=False)
+            .add_sink(buffer_size=2)
+        )
+        source = run_pipeline_in_subprocess(
+            backend.get_config(),
+            num_threads=4,
+            timeout=10,
+        )
+
+        # 10 items, batch_size=3, drop_last=False -> batches of [3, 3, 3, 1].
+        expected_items = sorted(x * 2 for x in range(10))
+        for epoch in range(3):
+            batches = list(source)
+            self.assertEqual(len(batches), 4, f"epoch {epoch}: batch count")
+            flat = sorted(v for batch in batches for v in batch)
+            self.assertEqual(flat, expected_items, f"epoch {epoch}: items")
+
 
 @unittest.skipIf(
     sys.version_info < (3, 14),


### PR DESCRIPTION
Continuous sources have been supported in subprocess execution since #1369 and #1376, where `_Wrapper` detects a continuous source via `_has_continuous_source`, eagerly builds and starts the pipeline once, and reuses it across epochs (keeping the prefetch buffer warm instead of rebuilding the pipeline every epoch).

`run_pipeline_in_subprocess` never mentioning `continuous` in its docstring, so users assumed it was unsupported and that forcing `continuous=False` in the subprocess (relying on a continuous frontend) was required. That workaround is slower: with a non-continuous backend, `_Wrapper.__iter__` calls `_build()` + `auto_stop()` on every epoch, reintroducing the per-epoch rebuild gap that continuous mode exists to remove. This gap matters significantly when the training step is short (small models), where it stalls the GPU between epochs.

This change is documentation plus test hardening only — no behavior change:
- Document continuous-source reuse (with an example) in the `run_pipeline_in_subprocess` docstring, and clarify that each iteration yields exactly one epoch.
- Add a note to the MTP section of the parallelism guide.
- Add a regression test covering the previously uncovered combination of subprocess + `continuous=True` + concurrent `pipe` + `aggregate`, asserting crisp epoch boundaries across epochs (no item bleed between epochs).

Verified on trunk: the full continuous suite passes, and a manual experiment confirms crisp boundaries, no hangs, and ~2x faster epoch turnaround for continuous vs non-continuous backends under a short-step consumer.