### PR TITLE
[Pipeline] support continuous mode with PathVariants

### DIFF
--- a/src/spdl/pipeline/_components/_variants.py
+++ b/src/spdl/pipeline/_components/_variants.py
@@ -21,7 +21,7 @@ from typing import Any
 
 from spdl.pipeline._common._convert import _to_async
 
-from ._common import _EOF, is_eof
+from ._common import _EOF, _EPOCH_END, is_eof, is_epoch_end
 from ._hook import _stage_hooks, TaskHook
 from ._queue import AsyncQueue
 
@@ -99,6 +99,11 @@ def _path_variants_router(
     On completion (EOF or error), the router sends EOF to ALL path queues in
     a ``finally`` block so that every path shuts down cleanly.
 
+    The epoch-end sentinel (emitted by a continuous source between epochs) is
+    not a routable item, so it is broadcast to ALL path queues rather than
+    passed to ``router``. This lets each path flush its in-flight work and lets
+    the downstream fan-in merge observe the epoch boundary on every input queue.
+
     Args:
         input_queue: The queue to consume items from.
         path_queues: Per-path output queues, one per variant path.
@@ -119,6 +124,11 @@ def _path_variants_router(
             item = await input_queue.get()
             if is_eof(item):
                 return
+
+            if is_epoch_end(item):
+                for q in path_queues:
+                    await q.put(_EPOCH_END)
+                continue
 
             idx = await arouter(item)
             if idx < 0 or idx >= num_paths:

--- a/src/spdl/pipeline/defs/_defs.py
+++ b/src/spdl/pipeline/defs/_defs.py
@@ -1079,6 +1079,9 @@ def PathVariants(
     uncached items go through full data loading, or splitting between local
     and remote processing.
 
+    .. versionchanged:: 0.6.0
+       Fixed to work with a continuous source.
+
     Args:
         router: A callable that takes an item and returns an int index
             selecting which path the item should be routed to. The returned

--- a/tests/pipeline/continuous_pipeline_test.py
+++ b/tests/pipeline/continuous_pipeline_test.py
@@ -6,6 +6,7 @@
 
 # pyre-unsafe
 
+import asyncio
 import functools
 import os
 import sys
@@ -23,7 +24,14 @@ from spdl.pipeline import (
     run_pipeline_in_subinterpreter,
     run_pipeline_in_subprocess,
 )
-from spdl.pipeline.defs import Merge, PipelineConfig, SinkConfig
+from spdl.pipeline.defs import (
+    Aggregate,
+    Merge,
+    PathVariants,
+    Pipe,
+    PipelineConfig,
+    SinkConfig,
+)
 
 
 def _ignore_fork_warning(fn):
@@ -51,6 +59,23 @@ class SourceIterable:
 
     def __iter__(self) -> Iterator[int]:
         yield from range(self.n)
+
+
+class EpochTaggedSource:
+    """Yields a disjoint block of values per epoch (epoch K -> K*100 + range(n)).
+
+    Successive epochs produce non-overlapping value ranges so a test can detect
+    an item leaking across the epoch boundary by value alone.
+    """
+
+    def __init__(self, n: int) -> None:
+        self.n = n
+        self._epoch = 0
+
+    def __iter__(self) -> Iterator[int]:
+        base = self._epoch * 100
+        self._epoch += 1
+        yield from range(base, base + self.n)
 
 
 class TestContinuousPipelineBasic(unittest.TestCase):
@@ -431,6 +456,145 @@ class TestContinuousPipelineShutdown(unittest.TestCase):
         finalizer()
         elapsed = time.monotonic() - t0
         self.assertLess(elapsed, 15, f"finalizer took {elapsed:.1f}s — likely hung")
+
+
+class TestContinuousPipelinePathVariants(unittest.TestCase):
+    def test_continuous_path_variants_multi_epoch(self) -> None:
+        """PathVariants epoch boundary propagates across epochs (no deadlock)."""
+        pipeline = (
+            PipelineBuilder()
+            .add_source(SourceIterable(6), continuous=True)
+            .path_variants(
+                router=lambda x: x % 2,
+                paths=[
+                    [Pipe(lambda x: x * 2)],  # path 0: even items doubled
+                    [Pipe(lambda x: x + 100)],  # path 1: odd items + 100
+                ],
+            )
+            .add_sink(buffer_size=10)
+            .build(num_threads=4)
+        )
+
+        with pipeline.auto_stop():
+            for epoch in range(3):
+                result = sorted(pipeline.get_iterator(timeout=5))
+                self.assertEqual(result, [0, 4, 8, 101, 103, 105], f"epoch {epoch}")
+
+    def test_continuous_path_variants_empty_epoch(self) -> None:
+        """PathVariants handles empty epochs from a continuous source."""
+        pipeline = (
+            PipelineBuilder()
+            .add_source(SourceIterable(0), continuous=True)
+            .path_variants(
+                router=lambda x: x % 2,
+                paths=[
+                    [Pipe(lambda x: x * 2)],
+                    [Pipe(lambda x: x + 100)],
+                ],
+            )
+            .add_sink(buffer_size=10)
+            .build(num_threads=2)
+        )
+
+        with pipeline.auto_stop():
+            for epoch in range(3):
+                result = list(pipeline.get_iterator(timeout=5))
+                self.assertEqual(result, [], f"epoch {epoch}")
+
+    def test_continuous_nested_path_variants_multi_epoch(self) -> None:
+        """Epoch boundary propagates through a PathVariants nested in a path."""
+        pipeline = (
+            PipelineBuilder()
+            .add_source(SourceIterable(8), continuous=True)
+            .path_variants(
+                router=lambda x: x % 2,
+                paths=[
+                    # path 0 (evens): nested PathVariants splitting on x % 4
+                    [
+                        PathVariants(
+                            router=lambda x: 0 if x % 4 == 0 else 1,
+                            paths=[
+                                [Pipe(lambda x: x)],  # multiples of 4 unchanged
+                                [Pipe(lambda x: x * 10)],  # other evens * 10
+                            ],
+                        )
+                    ],
+                    # path 1 (odds): + 100
+                    [Pipe(lambda x: x + 100)],
+                ],
+            )
+            .add_sink(buffer_size=16)
+            .build(num_threads=4)
+        )
+
+        with pipeline.auto_stop():
+            for epoch in range(3):
+                result = sorted(pipeline.get_iterator(timeout=5))
+                # evens 0,4 -> 0,4; evens 2,6 -> 20,60; odds 1,3,5,7 -> 101..107
+                self.assertEqual(
+                    result, [0, 4, 20, 60, 101, 103, 105, 107], f"epoch {epoch}"
+                )
+
+    def test_continuous_path_variants_aggregate_partial_flush(self) -> None:
+        """Partial aggregate batch inside a path is flushed at each epoch end."""
+        pipeline = (
+            PipelineBuilder()
+            .add_source(SourceIterable(6), continuous=True)
+            .path_variants(
+                router=lambda x: x % 2,
+                paths=[
+                    [Aggregate(2)],  # path 0: batch evens (0,2,4) by 2
+                    [Pipe(lambda x: x + 100)],  # path 1: odds + 100
+                ],
+            )
+            .add_sink(buffer_size=10)
+            .build(num_threads=2)
+        )
+
+        with pipeline.auto_stop():
+            for epoch in range(3):
+                result = list(pipeline.get_iterator(timeout=5))
+                # evens -> [0, 2] full batch + [4] partial flushed at epoch end;
+                # odds -> 101, 103, 105. Cross-path order is nondeterministic.
+                self.assertCountEqual(
+                    result, [[0, 2], [4], 101, 103, 105], f"epoch {epoch}"
+                )
+
+    def test_continuous_path_variants_no_epoch_crossing(self) -> None:
+        """Slow/fast path skew must not leak items across the epoch boundary."""
+
+        async def slow(x: int) -> int:
+            await asyncio.sleep(0.05)
+            return x
+
+        async def fast(x: int) -> int:
+            return x
+
+        pipeline = (
+            PipelineBuilder()
+            .add_source(EpochTaggedSource(4), continuous=True)
+            .path_variants(
+                router=lambda x: x % 2,
+                paths=[
+                    [Pipe(slow, concurrency=2)],  # even items: slow path
+                    [Pipe(fast, concurrency=2)],  # odd items: fast path
+                ],
+            )
+            .add_sink(buffer_size=16)
+            .build(num_threads=4)
+        )
+
+        with pipeline.auto_stop():
+            for epoch in range(4):
+                base = epoch * 100
+                result = sorted(pipeline.get_iterator(timeout=10))
+                # Each epoch must contain exactly its own disjoint block. A
+                # next-epoch fast-path item leaking in would show as a value
+                # >= base + 100; the fan-in barrier parks the fast path at the
+                # EOE until the slow path catches up, preventing that.
+                self.assertEqual(
+                    result, [base, base + 1, base + 2, base + 3], f"epoch {epoch}"
+                )
 
 
 class CustomError(ValueError):


### PR DESCRIPTION
`PipelineBuilder.add_source(..., continuous=True)` deadlocked any pipeline that also contained a `PathVariants` stage. A continuous source injects an epoch-end sentinel between epochs, but the PathVariants router only special-cased the EOF sentinel. The epoch-end sentinel therefore fell through to `router(item)` — passing the sentinel object to the user-supplied router, which crashes or returns a garbage index — and, at best, was delivered to a single path. The PathVariants fan-in merge forwards the epoch boundary downstream only after it has counted one epoch-end marker on every input queue, so the remaining paths blocked forever on the barrier at the end of each epoch.

Fix: the router now treats the epoch-end sentinel as a non-routable control signal and broadcasts it to all path queues, mirroring how it already broadcasts EOF on shutdown. Each path forwards the marker through its pipes/aggregates, the fan-in merge collapses the N copies back into a single marker, and the boundary propagates downstream. The router and the per-path functions are never invoked with the sentinel, so custom routers and processing functions need no changes. Nested `PathVariants` work for free because each level broadcasts and collapses independently. Items cannot cross the epoch boundary: the router broadcasts the marker before routing any next-epoch item, each pipe drains in-flight work before forwarding it, and the fan-in barrier parks each path at the marker until all paths arrive.

Continuous mode matters for small models where the per-step training time is small and rebuilding the pipeline each epoch is comparatively expensive, so making it compatible with `PathVariants` removes a sharp edge.

Also documents the interaction in the `PathVariants` / `path_variants` docstrings and the `continuous` argument.