### PR TITLE
[Pipeline] Support thread-based stdlib executors in subprocess

### DIFF
--- a/src/spdl/pipeline/_build.py
+++ b/src/spdl/pipeline/_build.py
@@ -34,6 +34,7 @@ from spdl.pipeline._components import (
     StageInfo,
     TaskHook,
 )
+from spdl.pipeline._executor_proxy import _make_config_executors_picklable
 from spdl.pipeline._iter_utils import iterate_in_subinterpreter, iterate_in_subprocess
 from spdl.pipeline.defs import MergeConfig, PipelineConfig, SourceConfig
 
@@ -403,6 +404,19 @@ def run_pipeline_in_subprocess(
     with ``add_source(src, continuous=True)`` (see the MTP pattern in the
     parallelism guide).
 
+    .. note::
+
+       Pipe stages configured with a stdlib
+       :py:class:`concurrent.futures.ThreadPoolExecutor` or (on Python 3.14+)
+       ``InterpreterPoolExecutor`` are explicitly supported, even though these executors are
+       not picklable: their constructor arguments are serialized and an equivalent executor
+       (same type, same ``max_workers``) is reconstructed inside the subprocess. Their workers
+       (threads / subinterpreters) live inside the subprocess and are cleaned up when it
+       exits.
+
+       SPDL's own :py:class:`~spdl.pipeline.PriorityThreadPoolExecutor` and related pool
+       executors are already picklable and pass through unchanged.
+
     Args:
         config_or_builder: The definition of :py:class:`Pipeline`. Can be either a
             :py:class:`PipelineConfig` or :py:class:`PipelineBuilder`.
@@ -418,6 +432,12 @@ def run_pipeline_in_subprocess(
 
     Yields:
         The results yielded from the pipeline.
+
+    .. versionchanged:: 0.6.0
+       Pipe stages configured with a stdlib
+       :py:class:`~concurrent.futures.ThreadPoolExecutor` or (on Python 3.14+)
+       ``InterpreterPoolExecutor`` are now supported; an equivalent executor is reconstructed
+       inside the subprocess.
 
     .. seealso::
 
@@ -437,6 +457,11 @@ def run_pipeline_in_subprocess(
         if isinstance(config_or_builder, PipelineConfig)
         else config_or_builder.get_config()  # pyre-ignore[16]
     )
+
+    # The stdlib thread-based executors (Thread/Interpreter pools, whose workers live inside
+    # the subprocess and die with it) are not picklable, so make them picklable via
+    # lazy-reconstruction proxies before the config is shipped to the subprocess.
+    config = _make_config_executors_picklable(config)
 
     initializer = _get_initializer(kwargs)
     return iterate_in_subprocess(

--- a/src/spdl/pipeline/_executor_proxy.py
+++ b/src/spdl/pipeline/_executor_proxy.py
@@ -1,0 +1,293 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""Make a :py:class:`~spdl.pipeline.defs.PipelineConfig` with stdlib executors picklable.
+
+The stdlib thread-based ``concurrent.futures`` executors
+(:py:class:`~concurrent.futures.ThreadPoolExecutor` and, on Python 3.14+,
+``InterpreterPoolExecutor``) are not picklable, so a :py:class:`PipelineConfig` that attaches
+one of them to a pipe stage cannot be moved to a subprocess as-is.
+
+For SPDL's purpose, what matters is that an executor of the same type with the same capacity
+(``max_workers``) is recreated in the subprocess. So rather than moving the live executor, we
+perform surgery on the config: each non-picklable stdlib executor is replaced with an
+:py:class:`_ExecutorProxy` that records the executor's type and constructor arguments and
+lazily reconstructs an equivalent executor on first use inside the subprocess. Their workers
+(threads / subinterpreters) live inside the subprocess and are cleaned up when it exits.
+"""
+
+from __future__ import annotations
+
+import sys
+import threading
+from collections.abc import Callable
+from concurrent.futures import Executor, ThreadPoolExecutor
+from dataclasses import replace
+from typing import Any
+
+from spdl.pipeline.defs import (
+    MergeConfig,
+    PathVariantsConfig,
+    PipeConfig,
+    PipelineConfig,
+)
+
+__all__ = [
+    "_ensure_executor_unused",
+    "_make_config_executors_picklable",
+]
+
+
+class _ExecutorProxy(Executor):
+    """Picklable, lazily-constructed stand-in for a non-picklable stdlib executor.
+
+    Records the executor's concrete type and constructor arguments instead of the live
+    executor. The real executor is created lazily, on first use, in whichever process holds
+    the proxy. This makes the proxy work uniformly regardless of the ``multiprocessing`` start
+    method:
+
+    - With ``spawn``/``forkserver``, the proxy is pickled (only the type and kwargs travel)
+      and the real executor is built on first use in the subprocess.
+    - With ``fork``, the proxy object is inherited as-is and the real executor is built on
+      first use in the subprocess.
+
+    The parent process never builds the pipeline, so the proxy never instantiates the real
+    executor there (no stray threads/processes are created in the parent).
+    """
+
+    def __init__(self, executor_class: type[Executor], kwargs: dict[str, Any]) -> None:
+        self._executor_class = executor_class
+        self._kwargs = kwargs
+        self._executor: Executor | None = None
+        self._shutdown = False
+        self._lock = threading.Lock()
+
+    def _ensure_executor(self) -> Executor:
+        # Double-checked locking: concurrent ``submit`` calls must build exactly one executor,
+        # otherwise the extra executors (and their threads) leak unshut down.
+        if self._executor is None:
+            with self._lock:
+                if self._shutdown:
+                    # Honor the Executor contract: no new work after shutdown. Without this,
+                    # a ``submit`` after ``shutdown`` on a never-built proxy would silently
+                    # construct a fresh executor instead of raising.
+                    raise RuntimeError("cannot schedule new futures after shutdown")
+                if self._executor is None:
+                    self._executor = self._executor_class(**self._kwargs)
+        return self._executor
+
+    def submit(  # pyre-ignore[14]
+        self, fn: Callable[..., Any], /, *args: Any, **kwargs: Any
+    ) -> Any:
+        # If the executor was already built and then shut down, the underlying executor raises
+        # on submit; the ``_shutdown`` guard in ``_ensure_executor`` covers the never-built
+        # case.
+        return self._ensure_executor().submit(fn, *args, **kwargs)
+
+    def shutdown(self, wait: bool = True, cancel_futures: bool = False) -> None:
+        with self._lock:
+            self._shutdown = True
+            executor = self._executor
+        if executor is not None:
+            executor.shutdown(wait=wait, cancel_futures=cancel_futures)
+
+    def __getstate__(self) -> dict[str, Any]:
+        # Never carry the live executor across the pickle boundary.
+        return {"executor_class": self._executor_class, "kwargs": self._kwargs}
+
+    def __setstate__(self, state: dict[str, Any]) -> None:
+        self._executor_class = state["executor_class"]
+        self._kwargs = state["kwargs"]
+        self._executor = None
+        self._shutdown = False
+        self._lock = threading.Lock()
+
+
+def _thread_pool_initializer(executor: Any) -> tuple[Any, tuple[Any, ...]]:
+    # Python < 3.14 stores ``initializer``/``initargs`` directly on the executor. Python 3.14+
+    # captures them inside a worker-context factory (``_create_worker_context``) instead, so
+    # recover them by building a context (construction is side-effect-free: it just stashes the
+    # values, without spawning any worker threads).
+    if hasattr(executor, "_initializer"):
+        return executor._initializer, executor._initargs
+    factory = getattr(executor, "_create_worker_context", None)
+    if factory is not None:
+        ctx = factory()
+        return getattr(ctx, "initializer", None), getattr(ctx, "initargs", ())
+    return None, ()
+
+
+def _thread_pool_kwargs(executor: Any) -> dict[str, Any]:
+    initializer, initargs = _thread_pool_initializer(executor)
+    return {
+        "max_workers": executor._max_workers,
+        "thread_name_prefix": executor._thread_name_prefix,
+        "initializer": initializer,
+        "initargs": initargs,
+    }
+
+
+def _interpreter_pool_initializer(executor: Any) -> tuple[Any, tuple[Any, ...]]:
+    # InterpreterPoolExecutor does not keep ``initializer``/``initargs`` as attributes; it
+    # stores them as ``initdata`` -- a ``(fn, args, kwargs)`` tuple, or ``None`` when no
+    # initializer was given -- on the worker context produced by its ``_create_worker_context``
+    # factory. Building that context is side-effect-free (no interpreter is created until the
+    # context is later initialized), so recover the original ``(initializer, initargs)`` here
+    # rather than silently dropping them.
+    factory = getattr(executor, "_create_worker_context", None)
+    if factory is None:
+        return None, ()
+    initdata = getattr(factory(), "initdata", None)
+    if not initdata:
+        return None, ()
+    return initdata[0], initdata[1]
+
+
+def _interpreter_pool_kwargs(executor: Any) -> dict[str, Any]:
+    kwargs: dict[str, Any] = {
+        "max_workers": executor._max_workers,
+        "thread_name_prefix": executor._thread_name_prefix,
+    }
+    initializer, initargs = _interpreter_pool_initializer(executor)
+    if initializer is not None:
+        kwargs["initializer"] = initializer
+        kwargs["initargs"] = initargs
+    return kwargs
+
+
+# Exact-type registry (not ``isinstance``) so that ``InterpreterPoolExecutor`` (a
+# ``ThreadPoolExecutor`` subclass) and any user-defined subclasses are matched precisely or
+# left untouched.
+_EXECUTOR_ARG_EXTRACTORS: dict[type[Executor], Callable[[Any], dict[str, Any]]] = {
+    ThreadPoolExecutor: _thread_pool_kwargs,
+}
+
+if sys.version_info >= (3, 14):
+    from concurrent.futures.interpreter import (  # pyre-ignore[21]
+        InterpreterPoolExecutor,
+    )
+
+    _EXECUTOR_ARG_EXTRACTORS[InterpreterPoolExecutor] = _interpreter_pool_kwargs
+
+
+def _ensure_executor_unused(executor: Executor) -> None:
+    """Reject a stdlib pool executor that has already been used.
+
+    Moving a pipeline to a subprocess recreates the executor's workers as part of running it
+    there (thread / interpreter pools are reconstructed in the subprocess; a
+    :py:class:`~concurrent.futures.ProcessPoolExecutor`'s workers are hoisted into the main
+    process). The executor must therefore be freshly constructed — one that has already
+    spawned workers or had work submitted is being lifted mid-lifecycle, which is not the
+    supported contract: the whole point is that execution, including the pool's worker startup,
+    happens as part of the run. Construct the executor and hand it over without using it first.
+    """
+    if (
+        getattr(
+            executor, "_threads", None
+        )  # Thread/Interpreter pool: spawned worker threads
+        or getattr(
+            executor, "_processes", None
+        )  # Process pool: spawned worker processes
+        or getattr(executor, "_queue_count", 0)  # Process pool: work already submitted
+    ):
+        raise ValueError(
+            "run_pipeline_in_subprocess() requires a freshly constructed executor with no "
+            "work submitted yet: its workers are (re)created when the pipeline runs in the "
+            "subprocess. Construct the executor and pass it without using it first."
+        )
+
+
+def _maybe_proxy(executor: Executor | None) -> Executor | _ExecutorProxy | None:
+    """Replace a non-picklable stdlib executor with a picklable proxy.
+
+    Executors of other types (e.g. SPDL's ``Priority*PoolExecutor``, which are already
+    picklable) and ``None`` are returned unchanged.
+    """
+    if executor is None:
+        return None
+    extractor = _EXECUTOR_ARG_EXTRACTORS.get(type(executor))
+    if extractor is None:
+        return executor
+    _ensure_executor_unused(executor)
+    return _ExecutorProxy(type(executor), extractor(executor))
+
+
+def _rewrite_pipe(pipe: Any, convert: Callable[[Any], Any]) -> Any:
+    if isinstance(pipe, PipeConfig):
+        executor = pipe._args.executor
+        new_executor = convert(executor)
+        if new_executor is executor:
+            return pipe
+        return replace(pipe, _args=replace(pipe._args, executor=new_executor))
+    if isinstance(pipe, PathVariantsConfig):
+        new_paths = tuple(
+            tuple(_rewrite_pipe(p, convert) for p in path) for path in pipe.paths
+        )
+        # Identity check (mirroring the MergeConfig branch in _rewrite_config_executors)
+        # rather than ``==`` so a future value-based ``__eq__`` on a nested config element
+        # cannot mask an actual rewrite.
+        changed = any(
+            np is not op
+            for new_path, old_path in zip(new_paths, pipe.paths)
+            for np, op in zip(new_path, old_path)
+        )
+        if not changed:
+            return pipe
+        return replace(pipe, paths=new_paths)
+    return pipe
+
+
+def _rewrite_config_executors(
+    config: PipelineConfig[Any],
+    convert: Callable[[Any], Any],
+) -> PipelineConfig[Any]:
+    """Return a copy of ``config`` with each pipe executor passed through ``convert``.
+
+    Walks the config — including nested :py:class:`PathVariantsConfig` paths and
+    :py:class:`MergeConfig` sub-configs — and replaces each pipe's executor with
+    ``convert(executor)``. ``convert`` receives the executor (or ``None``) and must return the
+    replacement (returning the same object signals "no change"). The input ``config`` is not
+    mutated; a new config is returned (and shared unchanged where ``convert`` is a no-op).
+    """
+    new_src = config.src
+    if isinstance(new_src, MergeConfig):
+        new_configs = tuple(
+            _rewrite_config_executors(plc, convert) for plc in new_src.pipeline_configs
+        )
+        # Identity check (mirroring the pipes branch) rather than ``!=`` so a future
+        # value-based ``__eq__`` on a nested element cannot mask an actual rewrite.
+        if any(nc is not oc for nc, oc in zip(new_configs, new_src.pipeline_configs)):
+            # pyre-ignore[6]: MergeConfig annotates a 1-tuple but holds N configs.
+            new_src = replace(new_src, pipeline_configs=new_configs)
+
+    new_pipes = [_rewrite_pipe(p, convert) for p in config.pipes]
+
+    src_changed = new_src is not config.src
+    pipes_changed = any(np is not op for np, op in zip(new_pipes, config.pipes))
+    if not src_changed and not pipes_changed:
+        return config
+
+    return replace(config, src=new_src, pipes=new_pipes)
+
+
+def _make_config_executors_picklable(
+    config: PipelineConfig[Any],
+) -> PipelineConfig[Any]:
+    """Return a copy of ``config`` with non-picklable stdlib executors replaced by proxies.
+
+    Walks the config (including nested :py:class:`PathVariantsConfig` paths and
+    :py:class:`MergeConfig` sub-configs) and swaps each stdlib
+    :py:class:`~concurrent.futures.ThreadPoolExecutor` or (on Python 3.14+)
+    ``InterpreterPoolExecutor`` attached to a pipe with an :py:class:`_ExecutorProxy`. The
+    proxy reconstructs an equivalent executor (same type, same ``max_workers``) when unpickled
+    in a subprocess.
+
+    The input ``config`` is not mutated; a new config is returned (and shared unchanged where
+    no surgery is needed).
+    """
+    return _rewrite_config_executors(config, _maybe_proxy)

--- a/tests/pipeline/pipeline_builder_test.py
+++ b/tests/pipeline/pipeline_builder_test.py
@@ -9,6 +9,7 @@
 import asyncio
 import functools
 import os
+import pickle
 import platform
 import random
 import re
@@ -22,13 +23,14 @@ from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor
 from contextlib import asynccontextmanager
 from functools import partial
 from multiprocessing import Process
-from typing import TypeVar
+from typing import cast, TypeVar
 
 from parameterized import parameterized
 from spdl.pipeline import (
     AsyncQueue,
     PipelineBuilder,
     PipelineFailure,
+    PriorityThreadPoolExecutor,
     run_pipeline_in_subprocess,
     TaskHook,
     TaskStatsHook,
@@ -44,7 +46,23 @@ from spdl.pipeline._components._pipe import (
 )
 from spdl.pipeline._components._sink import _sink
 from spdl.pipeline._components._source import _source
-from spdl.pipeline.defs import Aggregator
+from spdl.pipeline._executor_proxy import (
+    _ExecutorProxy,
+    _interpreter_pool_kwargs,
+    _make_config_executors_picklable,
+)
+from spdl.pipeline.defs import (
+    Aggregator,
+    Merge,
+    MergeConfig,
+    PathVariants,
+    PathVariantsConfig,
+    Pipe,
+    PipeConfig,
+    PipelineConfig,
+    SinkConfig,
+    SourceConfig,
+)
 from spdl.source.utils import embed_shuffle
 
 T = TypeVar("T")
@@ -2229,6 +2247,42 @@ def plusN(x: int, N: int) -> int:
     return x + N
 
 
+def _sync_double(x: int) -> int:
+    return 2 * x
+
+
+def _route_zero(_: int) -> int:
+    return 0
+
+
+def _noop_initializer(_: int) -> None:
+    pass
+
+
+class _FakeInterpreterWorkerContext:
+    """Mimics an InterpreterPoolExecutor worker context (carries ``initdata``)."""
+
+    def __init__(self, initdata: object) -> None:
+        self.initdata = initdata
+
+
+class _FakeInterpreterPoolExecutor:
+    """Stub with the attributes ``_interpreter_pool_kwargs`` reads (3.14 layout).
+
+    Lets the recovery logic be tested on any Python version without a real
+    InterpreterPoolExecutor (3.14+ only).
+    """
+
+    _max_workers = 3
+    _thread_name_prefix = "interp"
+
+    def __init__(self, initdata: object) -> None:
+        self._initdata = initdata
+
+    def _create_worker_context(self) -> _FakeInterpreterWorkerContext:
+        return _FakeInterpreterWorkerContext(self._initdata)
+
+
 def hook_factory(_: StageInfo) -> list[TaskHook]:
     return [CountHook()]
 
@@ -2629,6 +2683,233 @@ class TestRunPipeline(unittest.TestCase):
 
         for _ in iterable:
             pass
+
+
+def _interpreter_pool_available() -> bool:
+    if sys.version_info < (3, 14):
+        return False
+    try:
+        from concurrent.futures.interpreter import InterpreterPoolExecutor  # noqa: F401
+    except ImportError:
+        return False
+    return True
+
+
+def _config_with_executor(executor) -> PipelineConfig:
+    return (
+        PipelineBuilder()
+        .add_source(_PicklableSource(10))
+        .pipe(_sync_double, executor=executor)
+        .add_sink(10)
+        .get_config()
+    )
+
+
+def _pipe_executor(pipe):
+    return cast(PipeConfig, pipe)._args.executor
+
+
+def _first_pipe_executor(config: PipelineConfig):
+    return _pipe_executor(config.pipes[0])
+
+
+class TestExecutorProxy(unittest.TestCase):
+    """Surgery that makes stdlib executors in a config picklable for subprocess."""
+
+    def test_proxy_submit_after_shutdown_raises(self) -> None:
+        """submit() after shutdown() raises, even when the executor was never built."""
+        proxy = _ExecutorProxy(
+            ThreadPoolExecutor,
+            {
+                "max_workers": 2,
+                "thread_name_prefix": "",
+                "initializer": None,
+                "initargs": (),
+            },
+        )
+        # Shut down before any submit, so the underlying executor was never constructed.
+        proxy.shutdown()
+        with self.assertRaises(RuntimeError):
+            proxy.submit(_sync_double, 1)
+        # Nothing should have been constructed by the rejected submit.
+        self.assertIsNone(proxy._executor)
+
+    def test_interpreter_pool_kwargs_recovers_initializer(self) -> None:
+        """initializer/initargs are recovered from an interpreter pool's initdata."""
+        executor = _FakeInterpreterPoolExecutor(initdata=(_noop_initializer, (7,), {}))
+        kwargs = _interpreter_pool_kwargs(executor)
+        self.assertEqual(kwargs["max_workers"], 3)
+        self.assertEqual(kwargs["thread_name_prefix"], "interp")
+        self.assertIs(kwargs["initializer"], _noop_initializer)
+        self.assertEqual(kwargs["initargs"], (7,))
+
+    def test_interpreter_pool_kwargs_without_initializer(self) -> None:
+        """With no initializer (initdata is None), no initializer kwargs are emitted."""
+        executor = _FakeInterpreterPoolExecutor(initdata=None)
+        kwargs = _interpreter_pool_kwargs(executor)
+        self.assertEqual(kwargs, {"max_workers": 3, "thread_name_prefix": "interp"})
+
+    def test_proxy_pickle_roundtrip(self) -> None:
+        """An `_ExecutorProxy` survives pickling and builds the right executor lazily."""
+        proxy = _ExecutorProxy(
+            ThreadPoolExecutor,
+            {
+                "max_workers": 3,
+                "thread_name_prefix": "",
+                "initializer": None,
+                "initargs": (),
+            },
+        )
+        restored = pickle.loads(pickle.dumps(proxy))
+        try:
+            self.assertIsInstance(restored, _ExecutorProxy)
+            self.assertIs(restored._executor_class, ThreadPoolExecutor)
+            self.assertEqual(restored._kwargs["max_workers"], 3)
+            # The underlying executor is built lazily on first use.
+            self.assertEqual(restored.submit(_sync_double, 21).result(), 42)
+            self.assertIsInstance(restored._executor, ThreadPoolExecutor)
+            self.assertEqual(restored._executor._max_workers, 3)
+        finally:
+            restored.shutdown()
+
+    def test_threadpool_replaced_and_original_untouched(self) -> None:
+        """ThreadPoolExecutor on a pipe is replaced; the input config is not mutated."""
+        executor = ThreadPoolExecutor(max_workers=2)
+        try:
+            config = _config_with_executor(executor)
+            new_config = _make_config_executors_picklable(config)
+
+            proxy = _first_pipe_executor(new_config)
+            self.assertIsInstance(proxy, _ExecutorProxy)
+            self.assertIs(proxy._executor_class, ThreadPoolExecutor)
+            self.assertEqual(proxy._kwargs["max_workers"], 2)
+            # Original config is left untouched.
+            self.assertIs(_first_pipe_executor(config), executor)
+            # The whole rewritten config is now picklable.
+            restored = pickle.loads(pickle.dumps(new_config))
+            restored_proxy = _first_pipe_executor(restored)
+            self.assertIsInstance(restored_proxy, _ExecutorProxy)
+            self.assertIs(restored_proxy._executor_class, ThreadPoolExecutor)
+            self.assertEqual(restored_proxy._kwargs["max_workers"], 2)
+        finally:
+            executor.shutdown()
+
+    def test_threadpool_initializer_preserved(self) -> None:
+        """A ThreadPoolExecutor's initializer/initargs survive surgery and pickling.
+
+        Guards the version-specific extraction: Python 3.14 moved these off the executor's
+        ``_initializer``/``_initargs`` attributes into a worker-context factory.
+        """
+        executor = ThreadPoolExecutor(
+            max_workers=2, initializer=_noop_initializer, initargs=(7,)
+        )
+        try:
+            config = _config_with_executor(executor)
+            new_config = _make_config_executors_picklable(config)
+            proxy = _first_pipe_executor(new_config)
+            self.assertIs(proxy._kwargs["initializer"], _noop_initializer)
+            self.assertEqual(proxy._kwargs["initargs"], (7,))
+            # The recovered initializer survives the pickle round-trip too.
+            restored_proxy = pickle.loads(pickle.dumps(proxy))
+            self.assertIs(restored_proxy._kwargs["initializer"], _noop_initializer)
+            self.assertEqual(restored_proxy._kwargs["initargs"], (7,))
+        finally:
+            executor.shutdown()
+
+    def test_priority_executor_left_untouched(self) -> None:
+        """Already-picklable executors (e.g. Priority*) pass through unchanged."""
+        pool = PriorityThreadPoolExecutor(max_workers=2)
+        try:
+            entrypoint = pool.get_executor()
+            config = _config_with_executor(entrypoint)
+            new_config = _make_config_executors_picklable(config)
+            self.assertIs(new_config, config)
+            self.assertIs(_first_pipe_executor(new_config), entrypoint)
+        finally:
+            pool.shutdown()
+
+    def test_no_executor_returns_same_config(self) -> None:
+        """A config with no custom executor is returned unchanged."""
+        config = (
+            PipelineBuilder()
+            .add_source(_PicklableSource(10))
+            .pipe(_sync_double)
+            .add_sink(10)
+            .get_config()
+        )
+        self.assertIs(_make_config_executors_picklable(config), config)
+
+    def test_nested_path_variants_replaced(self) -> None:
+        """Executors inside PathVariants paths are rewritten too."""
+        executor = ThreadPoolExecutor(max_workers=2)
+        try:
+            config = PipelineConfig(
+                src=SourceConfig(_PicklableSource(10)),
+                pipes=[
+                    PathVariants(
+                        router=_route_zero,
+                        paths=[[Pipe(_sync_double, executor=executor)]],
+                    ),
+                ],
+                sink=SinkConfig(buffer_size=10),
+            )
+            new_config = _make_config_executors_picklable(config)
+            nested_pipe = cast(PathVariantsConfig, new_config.pipes[0]).paths[0][0]
+            self.assertIsInstance(_pipe_executor(nested_pipe), _ExecutorProxy)
+            # Original untouched.
+            orig_pipe = cast(PathVariantsConfig, config.pipes[0]).paths[0][0]
+            self.assertIs(_pipe_executor(orig_pipe), executor)
+        finally:
+            executor.shutdown()
+
+    def test_nested_merge_replaced(self) -> None:
+        """Executors inside Merge sub-configs are rewritten too."""
+        executor = ThreadPoolExecutor(max_workers=2)
+        try:
+            plc = _config_with_executor(executor)
+            config = PipelineConfig(
+                src=Merge([plc]),
+                pipes=[],
+                sink=SinkConfig(buffer_size=10),
+            )
+            new_config = _make_config_executors_picklable(config)
+            nested = cast(MergeConfig, new_config.src).pipeline_configs[0]
+            self.assertIsInstance(_first_pipe_executor(nested), _ExecutorProxy)
+        finally:
+            executor.shutdown()
+
+    @_ignore_warnings(_FORK_WARNING, _UNAWAITED_COROUTINE)
+    def test_run_in_subprocess_with_threadpool(self) -> None:
+        """run_pipeline_in_subprocess works with a ThreadPoolExecutor on a pipe."""
+        config = _config_with_executor(ThreadPoolExecutor(max_workers=2))
+        results = list(run_pipeline_in_subprocess(config, num_threads=1))
+        self.assertEqual(sorted(results), [2 * i for i in range(10)])
+
+    @unittest.skipUnless(
+        _interpreter_pool_available(),
+        "InterpreterPoolExecutor requires Python 3.14+",
+    )
+    @_ignore_warnings(_FORK_WARNING, _UNAWAITED_COROUTINE)
+    def test_run_in_subprocess_with_interpreterpool(self) -> None:
+        """run_pipeline_in_subprocess works with an InterpreterPoolExecutor on a pipe."""
+        import importlib
+
+        interpreter_mod = importlib.import_module("concurrent.futures.interpreter")
+        executor = interpreter_mod.InterpreterPoolExecutor(max_workers=2)
+
+        config = _config_with_executor(executor)
+        results = list(run_pipeline_in_subprocess(config, num_threads=1))
+        self.assertEqual(sorted(results), [2 * i for i in range(10)])
+
+    def test_used_thread_pool_is_rejected(self) -> None:
+        """A ThreadPoolExecutor that already ran work is rejected (must be freshly built)."""
+        tpe = ThreadPoolExecutor(max_workers=2)
+        try:
+            tpe.submit(_sync_double, 1).result(timeout=30)  # spawns a worker thread
+            with self.assertRaises(ValueError):
+                _make_config_executors_picklable(_config_with_executor(tpe))
+        finally:
+            tpe.shutdown()
 
 
 class TestOverrideStage(unittest.TestCase):


### PR DESCRIPTION
`run_pipeline_in_subprocess` ships a `PipelineConfig` to a child process by pickling it through stdlib `multiprocessing`. A pipe stage may carry a per-stage executor (`PipeConfig._args.executor`). SPDL's own `Priority*PoolExecutor` types implement the pickle protocol and survive the trip, but the stdlib `concurrent.futures.ThreadPoolExecutor` and (on Python 3.14+) `InterpreterPoolExecutor` are not picklable, so a config that attaches one of them to a pipe could not be moved to the subprocess.

This commit makes `run_pipeline_in_subprocess` support `ThreadPoolExecutor` and `InterpreterPoolExecutor`. `ProcessPoolExecutor` support is handled in a follow-up because its worker-ownership model needs different treatment.

The approach is to performs targeted surgery on the config just before it is handed to `iterate_in_subprocess`: each non-picklable thread-based stdlib executor is replaced with a small picklable `_ExecutorProxy` that records the executor's concrete type and constructor arguments and lazily reconstructs an equivalent executor on first use inside the subprocess. Lazy construction makes it work uniformly across `fork`, `spawn`, and `forkserver`. Their workers (threads / subinterpreters) live inside the subprocess and are cleaned up when it exits.

`_make_config_executors_picklable` walks the config — including nested `PathVariants` paths and `Merge` sub-configs — and returns a new config without mutating the caller's object. Already-picklable executors (e.g. `Priority*`) and configs without a custom executor pass through unchanged. Scope is the subprocess path only; `run_pipeline_in_subinterpreter` is untouched.

