### PR TITLE
[BC-breaking] Ensure pipeline iterator is single-use (one epoch)

### DIFF
--- a/src/spdl/pipeline/_pipeline.py
+++ b/src/spdl/pipeline/_pipeline.py
@@ -572,8 +572,26 @@ class Pipeline(Generic[T]):
     def get_iterator(self, *, timeout: float | None = None) -> Iterator[T]:
         """Get an iterator, which iterates over the pipeline outputs.
 
+        The returned iterator covers a single epoch (one pass over the source),
+        regardless of whether the source is continuous (see the ``continuous``
+        argument of :py:meth:`PipelineBuilder.add_source
+        <spdl.pipeline.PipelineBuilder.add_source>`). Call this method again to
+        iterate each subsequent epoch:
+
+        .. code-block:: python
+
+            for epoch in range(num_epochs):
+                for item in pipeline.get_iterator(timeout=...):
+                    ...
+
         Args:
             timeout: Timeout value used for each `get_item` call.
+
+        .. versionchanged:: 0.6.0
+           Fixed reuse with a continuous source: an iterator that reached its
+           epoch boundary used to resume into the next epoch when reused, but
+           now stays exhausted, consistent with non-continuous sources. Use one
+           iterator per epoch.
         """
         return PipelineIterator(self, timeout)
 
@@ -588,12 +606,20 @@ class PipelineIterator(Generic[T]):
     def __init__(self, pipeline: Pipeline[T], timeout: float | None) -> None:
         self._pipeline = pipeline
         self._timeout = timeout
+        self._epoch_ended: bool = False
 
     def __iter__(self) -> "PipelineIterator[T]":
         return self
 
     def __next__(self) -> T:
+        # Each iterator covers a single epoch and is single-use: once it reaches
+        # the epoch boundary it stays exhausted, so its behavior is the same
+        # whether or not the source is continuous. Iterate the next epoch by
+        # obtaining a fresh iterator via `Pipeline.get_iterator()`.
+        if self._epoch_ended:
+            raise StopIteration
         try:
             return self._pipeline.get_item(timeout=self._timeout)
         except EOFError:
+            self._epoch_ended = True
             raise StopIteration from None

--- a/tests/pipeline/continuous_pipeline_test.py
+++ b/tests/pipeline/continuous_pipeline_test.py
@@ -276,6 +276,23 @@ class TestContinuousPipelineShutdown(unittest.TestCase):
             self.assertEqual(r2, [0, 1, 2])
             self.assertEqual(r3, [0, 1, 2])
 
+    def test_same_iterator_is_single_use(self) -> None:
+        """An iterator covers one epoch: reuse yields nothing, in either mode."""
+        for continuous in (False, True):
+            with self.subTest(continuous=continuous):
+                pipeline = (
+                    PipelineBuilder()
+                    .add_source(SourceIterable(3), continuous=continuous)
+                    .add_sink(buffer_size=3)
+                    .build(num_threads=1)
+                )
+
+                with pipeline.auto_stop():
+                    it = pipeline.get_iterator(timeout=5)
+                    self.assertEqual(list(it), [0, 1, 2])
+                    # Reusing the same iterator does not start a new epoch.
+                    self.assertEqual(list(it), [])
+
     def test_continuous_stop_with_pipe_stage(self) -> None:
         """Continuous pipeline with pipe stage can be stopped after epochs."""
 


### PR DESCRIPTION
`Pipeline.get_iterator()` returns an iterator that covers exactly one epoch (one pass over the source); the epoch boundary surfaces as `StopIteration`. The intended multi-epoch pattern is to call `get_iterator()` again per epoch.

Previously the iterator was not single-use, and its behavior depended on the source: with a continuous source, reusing an already-exhausted iterator instance silently resumed into the next epoch; with a finite source it yielded nothing. This mode-dependent behavior was an easy footgun in a training/benchmark consume loop.

Make `PipelineIterator` single-use and consistent across modes: once it reaches the epoch boundary it stays exhausted and yields nothing on reuse, regardless of whether the source is continuous. Iterating the next epoch by calling `get_iterator()` again (or `for item in pipeline:`) is unaffected, since that creates a fresh iterator each pass.

Behavior change (BC-breaking): code that reused a single iterator instance across epochs with a continuous source previously advanced into the next epoch on reuse; it now yields nothing. Use one `get_iterator()` call per epoch.

Also documents the one-epoch-per-iterator contract in the `get_iterator` docstring.