### PR TITLE
[pipeline] Support `ProcessPoolExecutor` in `run_pipeline_in_subprocess`

### DIFF
--- a/src/spdl/pipeline/_build.py
+++ b/src/spdl/pipeline/_build.py
@@ -36,6 +36,11 @@ from spdl.pipeline._components import (
 )
 from spdl.pipeline._executor_proxy import _make_config_executors_picklable
 from spdl.pipeline._iter_utils import iterate_in_subinterpreter, iterate_in_subprocess
+from spdl.pipeline._subprocess_worker_pool import (
+    _hoist_process_pools,
+    _IterableWithPoolShutdown,
+    _shutdown_pools,
+)
 from spdl.pipeline.defs import MergeConfig, PipelineConfig, SourceConfig
 
 from ._pipeline import Pipeline
@@ -407,12 +412,41 @@ def run_pipeline_in_subprocess(
     .. note::
 
        Pipe stages configured with a stdlib
-       :py:class:`concurrent.futures.ThreadPoolExecutor` or (on Python 3.14+)
+       :py:class:`concurrent.futures.ThreadPoolExecutor`,
+       :py:class:`concurrent.futures.ProcessPoolExecutor` or (on Python 3.14+)
        ``InterpreterPoolExecutor`` are explicitly supported, even though these executors are
-       not picklable: their constructor arguments are serialized and an equivalent executor
-       (same type, same ``max_workers``) is reconstructed inside the subprocess. Their workers
-       (threads / subinterpreters) live inside the subprocess and are cleaned up when it
-       exits.
+       not picklable.
+
+       Such an executor must be **freshly constructed** — handed over without any work
+       submitted yet — because its workers are (re)created as part of running the pipeline in
+       the subprocess (the whole point of moving execution there). Passing one that has already
+       spawned workers (i.e. been used) lifts it mid-lifecycle and raises :py:exc:`ValueError`.
+
+       - ``ThreadPoolExecutor`` / ``InterpreterPoolExecutor``: their constructor arguments are
+         serialized and an equivalent executor (same type, same ``max_workers``) is
+         reconstructed inside the subprocess. Their workers (threads / subinterpreters) live
+         inside the subprocess and are cleaned up when it exits.
+
+       - ``ProcessPoolExecutor``: its worker processes are spawned in the **main** process (as
+         children of the main process, not grandchildren via the pipeline subprocess) and the
+         executor is replaced with a queue-backed proxy that the subprocess submits to. This
+         keeps ownership of the worker processes in the main process, which reaps them when the
+         returned iterable is garbage-collected, so they cannot be orphaned if the pipeline
+         subprocess is force-killed. The worker count (``max_workers``) and
+         ``initializer``/``initargs`` are preserved; other construction options (e.g.
+         ``mp_context``, ``max_tasks_per_child``) are not honored.
+
+         .. warning::
+
+            Those worker processes are spawned with the start method named by ``mp_context``
+            (default: the platform default start method — ``fork`` on Linux through Python
+            3.13, ``forkserver`` from Python 3.14). Spawning them with ``fork`` from a process
+            that already has other live threads can deadlock — ``fork``
+            copies only the calling thread, so a lock held by another thread is never released
+            in the child. If you attach a ``ProcessPoolExecutor`` and the main process is (or
+            may become) multi-threaded, pass ``mp_context="spawn"`` or ``"forkserver"``, or
+            build the pipeline before any other threads start. A :py:exc:`RuntimeWarning` is
+            emitted when this risky combination is detected.
 
        SPDL's own :py:class:`~spdl.pipeline.PriorityThreadPoolExecutor` and related pool
        executors are already picklable and pass through unchanged.
@@ -435,9 +469,11 @@ def run_pipeline_in_subprocess(
 
     .. versionchanged:: 0.6.0
        Pipe stages configured with a stdlib
-       :py:class:`~concurrent.futures.ThreadPoolExecutor` or (on Python 3.14+)
-       ``InterpreterPoolExecutor`` are now supported; an equivalent executor is reconstructed
-       inside the subprocess.
+       :py:class:`~concurrent.futures.ThreadPoolExecutor`,
+       :py:class:`~concurrent.futures.ProcessPoolExecutor`, or (on Python 3.14+)
+       ``InterpreterPoolExecutor`` are now supported. Thread/interpreter pools are
+       reconstructed inside the subprocess; a ``ProcessPoolExecutor``'s worker processes are
+       spawned in (and owned by) the main process.
 
     .. seealso::
 
@@ -458,27 +494,46 @@ def run_pipeline_in_subprocess(
         else config_or_builder.get_config()  # pyre-ignore[16]
     )
 
-    # The stdlib thread-based executors (Thread/Interpreter pools, whose workers live inside
-    # the subprocess and die with it) are not picklable, so make them picklable via
-    # lazy-reconstruction proxies before the config is shipped to the subprocess.
-    config = _make_config_executors_picklable(config)
+    # Spawn workers for any stdlib ``ProcessPoolExecutor`` in the main process (as children of
+    # main, not grandchildren via the pipeline subprocess), then replace the executor with a
+    # queue-backed proxy that the subprocess submits to. The remaining stdlib executors
+    # (Thread/Interpreter pools, whose workers live inside the subprocess and die with it) are
+    # made picklable via lazy-reconstruction proxies.
+    config, pools = _hoist_process_pools(config, kwargs.get("mp_context"))
+    try:
+        config = _make_config_executors_picklable(config)
 
-    initializer = _get_initializer(kwargs)
-    return iterate_in_subprocess(
-        fn=partial(
-            _Wrapper,
-            config=config,
-            num_threads=num_threads,
-            max_failures=max_failures,
-            report_stats_interval=report_stats_interval,
-            queue_class=queue_class,
-            task_hook_factory=task_hook_factory,
-            background_tasks=background_tasks,
-            use_thread_output_queue=use_thread_output_queue,
-        ),
-        initializer=initializer,
-        **kwargs,
-    )
+        initializer = _get_initializer(kwargs)
+        iterable = iterate_in_subprocess(
+            fn=partial(
+                _Wrapper,
+                config=config,
+                num_threads=num_threads,
+                max_failures=max_failures,
+                report_stats_interval=report_stats_interval,
+                queue_class=queue_class,
+                task_hook_factory=task_hook_factory,
+                background_tasks=background_tasks,
+                use_thread_output_queue=use_thread_output_queue,
+            ),
+            initializer=initializer,
+            **kwargs,
+        )
+    except BaseException:
+        # If anything between the hoist and the iterable raises (e.g.
+        # ``iterate_in_subprocess`` fails to start the subprocess), the iterable is never
+        # returned to the caller — reap the pools here so their worker processes and pipe
+        # fds do not leak.
+        _shutdown_pools(pools)
+        raise
+    # The hoisted ``ProcessPoolExecutor`` workers are owned by this (the main) process and
+    # must outlive every iteration (they are reused across epochs). Wrap the iterable so the
+    # pools are reaped via the wrapper's finalizer when it is torn down — after the epoch loop,
+    # not at the end of each iteration — rather than threading a dedicated callback through the
+    # generic ``iterate_in_subprocess`` API.
+    if pools:
+        iterable = _IterableWithPoolShutdown(iterable, pools)
+    return iterable
 
 
 ################################################################################

--- a/src/spdl/pipeline/_executor_proxy.py
+++ b/src/spdl/pipeline/_executor_proxy.py
@@ -19,6 +19,9 @@ perform surgery on the config: each non-picklable stdlib executor is replaced wi
 :py:class:`_ExecutorProxy` that records the executor's type and constructor arguments and
 lazily reconstructs an equivalent executor on first use inside the subprocess. Their workers
 (threads / subinterpreters) live inside the subprocess and are cleaned up when it exits.
+
+``ProcessPoolExecutor`` is handled separately — its workers are hoisted into the main process;
+see :py:mod:`spdl.pipeline._subprocess_worker_pool`.
 """
 
 from __future__ import annotations
@@ -40,6 +43,7 @@ from spdl.pipeline.defs import (
 __all__ = [
     "_ensure_executor_unused",
     "_make_config_executors_picklable",
+    "_rewrite_config_executors",
 ]
 
 

--- a/src/spdl/pipeline/_subprocess_worker_pool.py
+++ b/src/spdl/pipeline/_subprocess_worker_pool.py
@@ -1,0 +1,442 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""Main-process-owned worker pools for ``run_pipeline_in_subprocess``.
+
+When a pipe stage uses a stdlib :py:class:`~concurrent.futures.ProcessPoolExecutor` and the
+pipeline is moved to a subprocess, naively reconstructing the executor *inside* that
+subprocess spawns its worker processes as grandchildren of the main process. If the pipeline
+subprocess is force-killed, those workers are never told to stop and become orphans.
+
+This module avoids the nesting. When :py:func:`_hoist_process_pools` finds a stdlib
+``ProcessPoolExecutor`` in a config, it spawns the worker processes in the **main** process
+(as children of main, siblings of the pipeline subprocess) and replaces the executor with a
+:py:class:`_RemoteExecutor` that merely holds the shared input/output queues. The pipeline
+subprocess submits work onto those queues; the main process owns the workers and reaps them at
+teardown.
+
+``ProcessPoolExecutor``'s own design couples "submits work" with "owns workers" in a single
+process, which is exactly what forces the grandchild nesting. By splitting those roles across
+a small purpose-built executor we keep ownership in the main process without reaching into
+CPython executor internals.
+"""
+
+from __future__ import annotations
+
+import itertools
+import multiprocessing as mp
+import threading
+import warnings
+import weakref
+from collections.abc import Callable, Iterable, Iterator
+from concurrent.futures import (
+    BrokenExecutor,
+    Executor,
+    Future,
+    InvalidStateError,
+    ProcessPoolExecutor,
+)
+from typing import Any, TypeVar
+
+from spdl.pipeline._executor_proxy import (
+    _ensure_executor_unused,
+    _rewrite_config_executors,
+)
+from spdl.pipeline.defs import PipelineConfig
+
+__all__ = [
+    "_hoist_process_pools",
+    "_IterableWithPoolShutdown",
+    "_shutdown_pools",
+]
+
+_T = TypeVar("_T")
+
+# Sentinel placed on the input queue (one per worker) to request shutdown.
+_SHUTDOWN = None
+
+
+def _worker_loop(
+    in_q: Any,
+    out_q: Any,
+    initializer: Callable[..., object] | None,
+    initargs: tuple[Any, ...],
+) -> None:
+    """Worker body: run tasks pulled from ``in_q`` and push results onto ``out_q``.
+
+    Each task is ``(task_id, fn, args, kwargs)``; each result is ``(task_id, ok, payload)``
+    where ``payload`` is the return value when ``ok`` else the raised exception. Exceptions
+    must be picklable to travel back over ``out_q`` (the same constraint that already applies
+    to everything crossing a process boundary in SPDL).
+
+    If the ``initializer`` raises, the worker keeps draining ``in_q`` and fails every routed
+    task with a fresh, plainly-picklable error derived from it (rather than exiting and
+    leaving the submitters' futures to hang forever on tasks that never get a response).
+    """
+    init_error: BaseException | None = None
+    if initializer is not None:
+        try:
+            initializer(*initargs)
+        except BaseException as e:  # noqa: B036 - relayed to every submitter below
+            init_error = e
+    while True:
+        task = in_q.get()
+        if task is _SHUTDOWN:
+            return
+        task_id, fn, args, kwargs = task
+        if init_error is not None:
+            # Fail each task with a fresh, plainly-picklable error rather than re-sending the
+            # original exception instance: the original may not be picklable (``mp.Queue.put``
+            # pickles asynchronously, so an unpicklable payload silently fails to arrive and
+            # hangs the future), and sharing one instance aliases its traceback and context
+            # across every future it is set on.
+            out_q.put(
+                (
+                    task_id,
+                    False,
+                    RuntimeError(f"Worker pool initializer failed: {init_error!r}"),
+                )
+            )
+            continue
+        try:
+            out_q.put((task_id, True, fn(*args, **kwargs)))
+        except BaseException as e:  # noqa: B036 - relay any failure to the submitter
+            out_q.put((task_id, False, e))
+
+
+class _RemoteExecutor(Executor):
+    """Submit side of a main-owned worker pool, designed to live in the pipeline subprocess.
+
+    Holds only the shared input/output queues (no worker handles), so it is cheap to pickle
+    into the subprocess. On first :py:meth:`submit` it starts a daemon routing thread that
+    reads results off ``out_q`` and resolves the matching
+    :py:class:`~concurrent.futures.Future`.
+
+    It exposes ``_pool_executor_class = ProcessPoolExecutor`` so SPDL's ``_is_process_pool``
+    detection treats it like a process pool (correct sync-generator batching and traceback
+    wrapping). The workers themselves are owned and reaped by the main process, so
+    :py:meth:`shutdown` here is intentionally a no-op.
+    """
+
+    _pool_executor_class: type[ProcessPoolExecutor] = ProcessPoolExecutor
+
+    def __init__(self, in_q: Any, out_q: Any, max_workers: int) -> None:
+        self._in_q = in_q
+        self._out_q = out_q
+        # Mirror ``ProcessPoolExecutor._max_workers`` so consumers that introspect a process
+        # pool (e.g. pipeline-stats logging) can read the worker count off this proxy too —
+        # it advertises ``_pool_executor_class = ProcessPoolExecutor``, so they expect it.
+        self._max_workers = max_workers
+        self._counter: itertools.count[int] = itertools.count()
+        self._lock = threading.Lock()
+        self._futures: dict[int, Future[Any]] = {}
+        self._thread: threading.Thread | None = None
+        # Set (under ``_lock``) when the router thread exits because ``_out_q`` closed: the
+        # router never restarts, so further ``submit`` calls must fail fast rather than hang.
+        self._broken: str | None = None
+
+    def _ensure_router(self) -> None:
+        # Double-checked locking so concurrent ``submit`` calls start exactly one router; two
+        # routers would race on ``_out_q`` and each could claim results destined for the other,
+        # silently dropping them and leaving callers blocked on ``Future.result()``.
+        if self._thread is None:
+            with self._lock:
+                if self._thread is None:
+                    self._thread = threading.Thread(
+                        target=self._route,
+                        name="spdl_remote_executor_router",
+                        daemon=True,
+                    )
+                    self._thread.start()
+
+    def _route(self) -> None:
+        while True:
+            try:
+                task_id, ok, payload = self._out_q.get()
+            except (EOFError, OSError):
+                # The queue was closed (e.g. teardown) before every result arrived. The router
+                # is the sole consumer of ``_out_q`` and never restarts, so mark the executor
+                # broken (failing the still-pending futures and any later ``submit``) instead of
+                # leaving callers to hang forever on results that can no longer come back.
+                self._fail_pending(
+                    "Worker pool output queue closed before the result was received."
+                )
+                return
+            except BaseException as e:  # noqa: B036 - relayed to every pending future below
+                # Any other failure reading a result (e.g. ``get`` raising while unpickling a
+                # malformed payload) would otherwise kill this sole, non-restarting router
+                # thread silently and hang every pending future. Fail them fast with the cause.
+                self._fail_pending(f"Worker pool result router failed: {e!r}")
+                return
+            with self._lock:
+                fut = self._futures.pop(task_id, None)
+            if fut is None:
+                continue
+            # The caller may have cancelled (or otherwise resolved) the future between
+            # ``submit`` and now. Guard against ``InvalidStateError`` so one such future does
+            # not kill the router thread and strand every later submission unresolved.
+            try:
+                if ok:
+                    fut.set_result(payload)
+                else:
+                    fut.set_exception(payload)
+            except InvalidStateError:
+                pass
+
+    def _fail_pending(self, reason: str) -> None:
+        # Flip ``_broken`` and snapshot the pending futures under the same lock that ``submit``
+        # uses to register, so there is no window where a future is enqueued after the snapshot
+        # yet before ``_broken`` is visible — every future is either failed here or rejected by
+        # ``submit``'s ``_broken`` check.
+        with self._lock:
+            self._broken = reason
+            pending = list(self._futures.values())
+            self._futures.clear()
+        for fut in pending:
+            if not fut.done():
+                fut.set_exception(BrokenExecutor(reason))
+
+    def submit(  # pyre-ignore[14]
+        self, fn: Callable[..., Any], /, *args: Any, **kwargs: Any
+    ) -> Future[Any]:
+        self._ensure_router()
+        fut: Future[Any] = Future()
+        task_id = next(self._counter)
+        with self._lock:
+            if self._broken is not None:
+                # The router has exited and will not restart; consuming ``_out_q`` is no longer
+                # possible, so a future registered now would never resolve. Fail fast.
+                raise BrokenExecutor(self._broken)
+            self._futures[task_id] = fut
+        try:
+            self._in_q.put((task_id, fn, args, kwargs))
+        except BaseException:
+            # The task never reached the queue, so no result will ever come back for it. Drop
+            # the registration so it does not linger unresolved, then surface the error.
+            with self._lock:
+                self._futures.pop(task_id, None)
+            raise
+        return fut
+
+    def shutdown(self, wait: bool = True, cancel_futures: bool = False) -> None:
+        # The worker processes are owned by the main process and torn down there; the submit
+        # side holds no worker handles, so there is nothing to shut down here.
+        pass
+
+    def __getstate__(self) -> dict[str, Any]:
+        # Only the queues + worker count cross the pickle boundary; the router thread and
+        # pending futures are process-local and recreated lazily in the subprocess.
+        return {
+            "in_q": self._in_q,
+            "out_q": self._out_q,
+            "max_workers": self._max_workers,
+        }
+
+    def __setstate__(self, state: dict[str, Any]) -> None:
+        self._in_q = state["in_q"]
+        self._out_q = state["out_q"]
+        self._max_workers = state["max_workers"]
+        self._counter = itertools.count()
+        self._lock = threading.Lock()
+        self._futures = {}
+        self._thread = None
+        self._broken = None
+
+
+class _WorkerPool:
+    """Main-process handle to a set of worker processes feeding a single queue pair."""
+
+    def __init__(
+        self,
+        ctx: Any,
+        max_workers: int,
+        initializer: Callable[..., object] | None,
+        initargs: tuple[Any, ...],
+    ) -> None:
+        self._in_q: Any = ctx.Queue()
+        self._out_q: Any = ctx.Queue()
+        self._max_workers = max_workers
+        self._procs: list[Any] = [
+            ctx.Process(
+                target=_worker_loop,
+                args=(self._in_q, self._out_q, initializer, initargs),
+                daemon=True,
+            )
+            for _ in range(max_workers)
+        ]
+        started: list[Any] = []
+        try:
+            for p in self._procs:
+                p.start()
+                started.append(p)
+        except BaseException:
+            # A ``start()`` partway through the loop (e.g. resource exhaustion) leaves the
+            # already-started workers running with no owner: this half-constructed pool is
+            # discarded by the caller and never reaches ``_shutdown_pools``. Tear the started
+            # workers down and close the queues before propagating, so the failure does not
+            # leak processes or pipe fds.
+            self._terminate(started)
+            for q in (self._in_q, self._out_q):
+                q.close()
+                q.join_thread()
+            raise
+
+    def make_executor(self) -> _RemoteExecutor:
+        """Create the submit-side executor that rides in the pipeline config."""
+        return _RemoteExecutor(self._in_q, self._out_q, self._max_workers)
+
+    @staticmethod
+    def _terminate(procs: list[Any]) -> None:
+        """Join the given worker processes, escalating to terminate/kill if they don't exit."""
+        for p in procs:
+            p.join(3)
+            if p.exitcode is None:
+                p.terminate()
+                p.join(5)
+            if p.exitcode is None:
+                p.kill()
+                p.join(5)
+
+    def shutdown(self) -> None:
+        for _ in self._procs:
+            try:
+                self._in_q.put(_SHUTDOWN)
+            except Exception:
+                # A failed sentinel for one worker should not prevent the others from
+                # receiving theirs; fall through to the join/terminate/kill escalation below.
+                continue
+        self._terminate(self._procs)
+        # Close this process's queue handles so the feeder thread started when the main
+        # process put the shutdown sentinels exits; otherwise a long-lived main process that
+        # creates and destroys many pipelines leaks feeder threads and pipe fds.
+        for q in (self._in_q, self._out_q):
+            q.close()
+            q.join_thread()
+
+
+def _hoist_process_pools(
+    config: PipelineConfig[Any],
+    mp_context: str | None = None,
+) -> tuple[PipelineConfig[Any], list[_WorkerPool]]:
+    """Move stdlib ``ProcessPoolExecutor`` workers into the main process.
+
+    Returns a rewritten config in which each stdlib
+    :py:class:`~concurrent.futures.ProcessPoolExecutor` attached to a pipe is replaced with a
+    :py:class:`_RemoteExecutor`, plus the list of :py:class:`_WorkerPool` handles that own the
+    spawned workers (the caller must :py:func:`_shutdown_pools` them at teardown).
+
+    ``mp_context`` is the multiprocessing start-method name (as accepted by
+    :py:func:`multiprocessing.get_context`). The context is created lazily, only when a
+    ``ProcessPoolExecutor`` is actually found, so configs without one incur no cost.
+
+    A single ``ProcessPoolExecutor`` instance reused across multiple pipes maps to one shared
+    pool (and one shared ``_RemoteExecutor``), preserving the user's intent to share workers.
+    Non-``ProcessPoolExecutor`` executors (``ThreadPoolExecutor``, SPDL ``Priority*`` pools,
+    ``None``) are left untouched. The input ``config`` is not mutated.
+    """
+    pools: list[_WorkerPool] = []
+    seen: dict[int, _RemoteExecutor] = {}
+    ctx_box: list[Any] = []  # one-element cache for the lazily-created context
+
+    def convert(executor: Any) -> Any:
+        if type(executor) is not ProcessPoolExecutor:
+            return executor
+        key = id(executor)
+        if key in seen:
+            return seen[key]
+        _ensure_executor_unused(executor)
+        if not ctx_box:
+            ctx = mp.get_context(mp_context)
+            if ctx.get_start_method() == "fork" and threading.active_count() > 1:
+                # Spawning the worker pool with ``fork`` from a multi-threaded process can
+                # deadlock: ``fork`` copies only the calling thread, so a lock another thread
+                # holds is never released in the child. Warn (not raise) — a single-threaded
+                # caller is fine, and the user may knowingly accept the risk.
+                warnings.warn(
+                    "Hoisting a ProcessPoolExecutor for run_pipeline_in_subprocess with the "
+                    "'fork' start method from a multi-threaded process can deadlock. Pass "
+                    "mp_context='spawn' or 'forkserver', or build the pipeline before other "
+                    "threads start.",
+                    RuntimeWarning,
+                    stacklevel=2,
+                )
+            ctx_box.append(ctx)
+        # ``executor`` is statically a ``ProcessPoolExecutor`` here, whose private worker
+        # config attributes are not part of its declared type; read them off an ``Any`` alias.
+        ppe: Any = executor
+        pool = _WorkerPool(
+            ctx_box[0],
+            ppe._max_workers,
+            ppe._initializer,
+            ppe._initargs,
+        )
+        pools.append(pool)
+        remote = pool.make_executor()
+        seen[key] = remote
+        return remote
+
+    try:
+        new_config = _rewrite_config_executors(config, convert)
+    except BaseException:
+        # If ``convert`` raises after earlier pools were already constructed (e.g. a later
+        # ``_WorkerPool`` fails on OOM or fork/spawn failure), the partially-built ``pools``
+        # never reach the caller, so reap them here before propagating instead of leaking
+        # their worker processes and pipe fds.
+        _shutdown_pools(pools)
+        raise
+    return new_config, pools
+
+
+def _shutdown_pools(pools: list[_WorkerPool]) -> None:
+    for pool in pools:
+        pool.shutdown()
+
+
+def _teardown_inner_then_pools(
+    inner: Iterable[object], pools: list[_WorkerPool]
+) -> None:
+    # Join the worker subprocess first (the iterable's own finalizer terminates and joins it),
+    # then reap the pools it submits to. Reaping the pools while the subprocess is still live
+    # could close the shared queues from under a mid-submit worker and produce broken-pipe
+    # noise or dropped results. The ``_finalizer`` attribute is the iterable's documented
+    # teardown handle; ``test_subprocess_iterable_exposes_finalizer`` guards against a rename
+    # silently turning this into a no-op (which would skip the join and leave the hazard).
+    if (inner_finalizer := getattr(inner, "_finalizer", None)) is not None:
+        inner_finalizer()
+    _shutdown_pools(pools)
+
+
+class _IterableWithPoolShutdown(Iterable[_T]):
+    """Wraps an iterable so hoisted worker pools are reaped once the wrapper is torn down.
+
+    ``run_pipeline_in_subprocess`` returns an :py:class:`~collections.abc.Iterable`, so the
+    concrete class can be swapped without changing the public contract. The hoisted
+    :py:class:`~concurrent.futures.ProcessPoolExecutor` workers live in the main process and
+    must outlive every iteration: the returned iterable is re-iterated once per epoch and the
+    subprocess keeps submitting to the pools across epochs (a continuous source keeps the
+    pipeline running between them). So the teardown is tied to this wrapper's finalizer rather
+    than to :py:meth:`__iter__` — the pools persist across re-iterations and are reaped exactly
+    once, when the wrapper is garbage-collected after the epoch loop (or eagerly, if the caller
+    never iterates it). This keeps the pool lifetime out of the generic
+    :py:func:`~spdl.pipeline._iter_utils.iterate_in_subprocess` API.
+
+    Args:
+        inner: The iterable returned by
+            :py:func:`~spdl.pipeline._iter_utils.iterate_in_subprocess`.
+        pools: The hoisted worker pools to shut down once the wrapper is torn down.
+    """
+
+    def __init__(self, inner: Iterable[_T], pools: list[_WorkerPool]) -> None:
+        self._inner = inner
+        self._pools = pools
+        self._finalizer: weakref.finalize = weakref.finalize(
+            self, _teardown_inner_then_pools, inner, pools
+        )
+
+    def __iter__(self) -> Iterator[_T]:
+        return iter(self._inner)

--- a/tests/pipeline/pipeline_builder_test.py
+++ b/tests/pipeline/pipeline_builder_test.py
@@ -8,6 +8,7 @@
 
 import asyncio
 import functools
+import multiprocessing as mp
 import os
 import pickle
 import platform
@@ -19,11 +20,16 @@ import time
 import unittest
 import warnings
 from collections.abc import Iterator
-from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor
+from concurrent.futures import (
+    BrokenExecutor,
+    Future,
+    ProcessPoolExecutor,
+    ThreadPoolExecutor,
+)
 from contextlib import asynccontextmanager
 from functools import partial
 from multiprocessing import Process
-from typing import cast, TypeVar
+from typing import Any, cast, TypeVar
 
 from parameterized import parameterized
 from spdl.pipeline import (
@@ -35,6 +41,7 @@ from spdl.pipeline import (
     TaskHook,
     TaskStatsHook,
 )
+from spdl.pipeline._common._convert import _is_process_pool
 from spdl.pipeline._components import _get_global_id, _set_global_id
 from spdl.pipeline._components._common import _EOF, StageInfo
 from spdl.pipeline._components._hook import _periodic_dispatch
@@ -50,6 +57,12 @@ from spdl.pipeline._executor_proxy import (
     _ExecutorProxy,
     _interpreter_pool_kwargs,
     _make_config_executors_picklable,
+)
+from spdl.pipeline._subprocess_worker_pool import (
+    _hoist_process_pools,
+    _RemoteExecutor,
+    _shutdown_pools,
+    _WorkerPool,
 )
 from spdl.pipeline.defs import (
     Aggregator,
@@ -105,6 +118,11 @@ _RUN_PIPELINE_DEPRECATION = {
 
 _UNAWAITED_COROUTINE = {
     "message": "coroutine .* was never awaited",
+    "category": RuntimeWarning,
+}
+
+_PROCESSPOOL_FORK_WARNING = {
+    "message": r"Hoisting a ProcessPoolExecutor .* 'fork' start method .* can deadlock\..*",
     "category": RuntimeWarning,
 }
 
@@ -2255,6 +2273,15 @@ def _route_zero(_: int) -> int:
     return 0
 
 
+def _raise_value_error(_: int) -> int:
+    raise ValueError("boom")
+
+
+def _sync_double_gen(x: int):
+    yield 2 * x
+    yield 2 * x + 1
+
+
 def _noop_initializer(_: int) -> None:
     pass
 
@@ -2281,6 +2308,10 @@ class _FakeInterpreterPoolExecutor:
 
     def _create_worker_context(self) -> _FakeInterpreterWorkerContext:
         return _FakeInterpreterWorkerContext(self._initdata)
+
+
+def _failing_initializer() -> None:
+    raise ValueError("init boom")
 
 
 def hook_factory(_: StageInfo) -> list[TaskHook]:
@@ -2910,6 +2941,264 @@ class TestExecutorProxy(unittest.TestCase):
                 _make_config_executors_picklable(_config_with_executor(tpe))
         finally:
             tpe.shutdown()
+
+
+class TestHoistProcessPools(unittest.TestCase):
+    """run_pipeline_in_subprocess hoists ProcessPoolExecutor workers into the main process."""
+
+    def test_hoist_replaces_with_remote_executor(self) -> None:
+        """A stdlib ProcessPoolExecutor is replaced by a _RemoteExecutor; original untouched."""
+        ppe = ProcessPoolExecutor(max_workers=2)
+        try:
+            config = _config_with_executor(ppe)
+            new_config, pools = _hoist_process_pools(config)
+            try:
+                self.assertEqual(len(pools), 1)
+                self.assertIsInstance(_first_pipe_executor(new_config), _RemoteExecutor)
+                # Original config is left untouched.
+                self.assertIs(_first_pipe_executor(config), ppe)
+            finally:
+                _shutdown_pools(pools)
+        finally:
+            ppe.shutdown()
+
+    def test_hoist_dedupes_shared_pool(self) -> None:
+        """The same ProcessPoolExecutor on two pipes maps to one shared pool/executor."""
+        ppe = ProcessPoolExecutor(max_workers=2)
+        try:
+            config = (
+                PipelineBuilder()
+                .add_source(_PicklableSource(10))
+                .pipe(_sync_double, executor=ppe)
+                .pipe(_sync_double, executor=ppe)
+                .add_sink(10)
+                .get_config()
+            )
+            new_config, pools = _hoist_process_pools(config)
+            try:
+                self.assertEqual(len(pools), 1)
+                ex0 = _pipe_executor(new_config.pipes[0])
+                ex1 = _pipe_executor(new_config.pipes[1])
+                self.assertIsInstance(ex0, _RemoteExecutor)
+                self.assertIs(ex0, ex1)
+            finally:
+                _shutdown_pools(pools)
+        finally:
+            ppe.shutdown()
+
+    def test_hoist_leaves_threadpool_untouched(self) -> None:
+        """Non-ProcessPoolExecutor executors are not hoisted (no pools spawned)."""
+        tpe = ThreadPoolExecutor(max_workers=2)
+        try:
+            config = _config_with_executor(tpe)
+            new_config, pools = _hoist_process_pools(config)
+            self.assertEqual(pools, [])
+            self.assertIs(new_config, config)
+        finally:
+            tpe.shutdown()
+
+    def test_remote_executor_is_detected_as_process_pool(self) -> None:
+        """_RemoteExecutor must look like a process pool (for sync-generator batching)."""
+        ctx = mp.get_context()
+        pool = _WorkerPool(ctx, 2, None, ())
+        try:
+            self.assertTrue(_is_process_pool(pool.make_executor()))
+        finally:
+            _shutdown_pools([pool])
+
+    def test_remote_executor_exposes_max_workers(self) -> None:
+        """The proxy mirrors ProcessPoolExecutor._max_workers (read by stats logging)."""
+        ctx = mp.get_context()
+        pool = _WorkerPool(ctx, 3, None, ())
+        try:
+            ex = pool.make_executor()
+            self.assertEqual(ex._max_workers, 3)
+            # __setstate__ restores it (the queues themselves only pickle via process
+            # inheritance, so exercise the state round-trip directly rather than pickling).
+            restored = _RemoteExecutor.__new__(_RemoteExecutor)
+            restored.__setstate__(ex.__getstate__())
+            self.assertEqual(restored._max_workers, 3)
+        finally:
+            _shutdown_pools([pool])
+
+    def test_hoist_rejects_used_process_pool(self) -> None:
+        """A ProcessPoolExecutor that already ran work is rejected (must be freshly built)."""
+        ppe = ProcessPoolExecutor(max_workers=2)
+        try:
+            ppe.submit(_sync_double, 1).result(timeout=30)  # spawns worker processes
+            with self.assertRaises(ValueError):
+                _hoist_process_pools(_config_with_executor(ppe))
+        finally:
+            ppe.shutdown()
+
+    def test_worker_pool_roundtrip_and_teardown(self) -> None:
+        """Workers run submitted tasks, propagate exceptions, and are reaped on shutdown."""
+        ctx = mp.get_context()
+        pool = _WorkerPool(ctx, 2, None, ())
+        try:
+            ex = pool.make_executor()
+            self.assertEqual(ex.submit(_sync_double, 21).result(timeout=30), 42)
+            with self.assertRaises(ValueError):
+                ex.submit(_raise_value_error, 0).result(timeout=30)
+        finally:
+            _shutdown_pools([pool])
+        for p in pool._procs:
+            self.assertFalse(p.is_alive())
+
+    def test_worker_pool_initializer_failure_fails_tasks(self) -> None:
+        """If the pool initializer raises, every task fails with a picklable error (no hang)."""
+        ctx = mp.get_context()
+        pool = _WorkerPool(ctx, 2, _failing_initializer, ())
+        try:
+            ex = pool.make_executor()
+            # Submit more tasks than workers: each must get its own failure response, proving
+            # the workers keep serving (rather than dying on an unpicklable re-send) and that
+            # no future is left hanging.
+            futures = [ex.submit(_sync_double, i) for i in range(5)]
+            for fut in futures:
+                with self.assertRaises(RuntimeError):
+                    fut.result(timeout=30)
+        finally:
+            _shutdown_pools([pool])
+
+    def test_remote_executor_breaks_after_router_exit(self) -> None:
+        """When the router exits on a closed out queue, pending and future submits fail fast."""
+        ctx = mp.get_context()
+        pool = _WorkerPool(ctx, 1, None, ())
+        try:
+            ex = pool.make_executor()
+            # Register a pending future, then simulate the router thread exiting because
+            # ``_out_q`` was closed (EOFError/OSError) before the result came back.
+            pending: Future[int] = Future()
+            ex._futures[next(ex._counter)] = pending
+            ex._fail_pending("out queue closed")
+            # The previously pending future is failed rather than left hanging forever.
+            self.assertIsInstance(pending.exception(timeout=5), BrokenExecutor)
+            # A later submit must fail fast (the router will not restart to drain its result)
+            # rather than silently registering a future that never resolves.
+            with self.assertRaises(BrokenExecutor):
+                ex.submit(_sync_double, 1)
+        finally:
+            _shutdown_pools([pool])
+
+    def test_worker_pool_cleans_up_on_partial_start_failure(self) -> None:
+        """If a worker fails to start partway, already-started workers are torn down."""
+        real_ctx = mp.get_context()
+        started: list[Process] = []
+
+        class _FlakyCtx:
+            """Wraps a real context but fails the second ``Process.start`` call."""
+
+            def Queue(self, *args: Any, **kwargs: Any) -> object:
+                return real_ctx.Queue(*args, **kwargs)
+
+            def Process(self, *args: Any, **kwargs: Any) -> Process:
+                proc = real_ctx.Process(*args, **kwargs)
+                real_start = proc.start
+
+                def start() -> None:
+                    if len(started) >= 1:
+                        raise OSError("cannot allocate worker")
+                    real_start()
+                    started.append(proc)
+
+                proc.start = start  # pyre-ignore[8]
+                return proc
+
+        with self.assertRaises(OSError):
+            _WorkerPool(cast(mp.context.BaseContext, _FlakyCtx()), 3, None, ())
+        # The worker that did start is not left running with no owner.
+        self.assertEqual(len(started), 1)
+        for proc in started:
+            self.assertFalse(proc.is_alive())
+
+    @_ignore_warnings(_FORK_WARNING, _UNAWAITED_COROUTINE, _PROCESSPOOL_FORK_WARNING)
+    def test_run_in_subprocess_with_processpool(self) -> None:
+        """run_pipeline_in_subprocess works with a ProcessPoolExecutor on a pipe."""
+        config = _config_with_executor(ProcessPoolExecutor(max_workers=2))
+        results = list(run_pipeline_in_subprocess(config, num_threads=1))
+        self.assertEqual(sorted(results), [2 * i for i in range(10)])
+
+    @_ignore_warnings(_FORK_WARNING, _UNAWAITED_COROUTINE, _PROCESSPOOL_FORK_WARNING)
+    def test_run_in_subprocess_with_processpool_generator(self) -> None:
+        """A sync generator op + ProcessPoolExecutor runs end-to-end (batch materialized)."""
+        config = (
+            PipelineBuilder()
+            .add_source(_PicklableSource(5))
+            .pipe(_sync_double_gen, executor=ProcessPoolExecutor(max_workers=2))
+            .add_sink(10)
+            .get_config()
+        )
+        results = list(run_pipeline_in_subprocess(config, num_threads=1))
+        expected = []
+        for i in range(5):
+            expected.extend([2 * i, 2 * i + 1])
+        self.assertEqual(sorted(results), sorted(expected))
+
+    def test_hoist_warns_on_fork_from_multithreaded(self) -> None:
+        """fork start method + a live extra thread in the parent → deadlock warning."""
+        ppe = ProcessPoolExecutor(max_workers=2)
+        started, release = threading.Event(), threading.Event()
+
+        def _hold() -> None:
+            started.set()
+            release.wait()
+
+        t = threading.Thread(target=_hold, daemon=True)
+        t.start()
+        started.wait()
+        try:
+            with self.assertWarns(RuntimeWarning):
+                _, pools = _hoist_process_pools(_config_with_executor(ppe), "fork")
+            _shutdown_pools(pools)
+        finally:
+            release.set()
+            t.join()
+            ppe.shutdown()
+
+    def test_hoist_no_warn_with_spawn(self) -> None:
+        """The spawn start method never triggers the fork-deadlock warning."""
+        ppe = ProcessPoolExecutor(max_workers=2)
+        started, release = threading.Event(), threading.Event()
+
+        def _hold() -> None:
+            started.set()
+            release.wait()
+
+        t = threading.Thread(target=_hold, daemon=True)
+        t.start()
+        started.wait()
+        try:
+            with warnings.catch_warnings(record=True) as caught:
+                warnings.simplefilter("always")
+                _, pools = _hoist_process_pools(_config_with_executor(ppe), "spawn")
+            _shutdown_pools(pools)
+            self.assertEqual(
+                [w for w in caught if "can deadlock" in str(w.message)], []
+            )
+        finally:
+            release.set()
+            t.join()
+            ppe.shutdown()
+
+    @_ignore_warnings(_UNAWAITED_COROUTINE)
+    def test_run_in_subprocess_with_processpool_spawn(self) -> None:
+        """Non-fork (spawn) mp_context works end-to-end with a ProcessPoolExecutor."""
+        config = _config_with_executor(ProcessPoolExecutor(max_workers=2))
+        results = list(
+            run_pipeline_in_subprocess(config, num_threads=1, mp_context="spawn")
+        )
+        self.assertEqual(sorted(results), [2 * i for i in range(10)])
+
+    @_ignore_warnings(_FORK_WARNING, _UNAWAITED_COROUTINE, _PROCESSPOOL_FORK_WARNING)
+    def test_run_in_subprocess_processpool_reused_across_epochs(self) -> None:
+        """A ProcessPoolExecutor pipe survives re-iteration: pools are reaped at
+        teardown, not after each epoch."""
+        config = _config_with_executor(ProcessPoolExecutor(max_workers=2))
+        src = run_pipeline_in_subprocess(config, num_threads=1)
+        expected = [2 * i for i in range(10)]
+        for _ in range(3):
+            self.assertEqual(sorted(src), expected)
 
 
 class TestOverrideStage(unittest.TestCase):

--- a/tests/pipeline/subprocess_test.py
+++ b/tests/pipeline/subprocess_test.py
@@ -102,6 +102,14 @@ class TestIterateInSubprocess(unittest.TestCase):
         with self.assertRaises(StopIteration):
             next(ite)
 
+    def test_subprocess_iterable_exposes_finalizer(self) -> None:
+        """The iterable exposes a callable _finalizer (the teardown handle that
+        run_pipeline_in_subprocess relies on to join the worker before reaping pools)."""
+        src = iterate_in_subprocess(fn=partial(iter_range, n=3))
+        self.assertTrue(callable(getattr(src, "_finalizer", None)))
+        # Drain so the worker subprocess is torn down cleanly.
+        self.assertEqual(list(src), list(range(3)))
+
     def test_iterate_in_subprocess_multiple_initializer(self) -> None:
         """iterate_in_subprocess accepts multiple iterators"""
         N = 10


### PR DESCRIPTION
Builds on the thread-based executor support. A pipe stage can carry a stdlib `concurrent.futures.ProcessPoolExecutor`, but reconstructing it inside the pipeline subprocess would spawn its worker processes as grandchildren of the main process; if the subprocess is force-killed, those workers are never told to stop and become orphans. `ProcessPoolExecutor`'s design couples "submits work" with "owns workers" in one process, which is what forces that nesting.

So instead of reconstructing it in the subprocess, `_hoist_process_pools` spawns the worker processes in the main process (as children of main, siblings of the pipeline subprocess) and replaces the executor with a queue-backed `_RemoteExecutor` that the subprocess submits to. The submit side (futures + a result-routing thread) lives in the subprocess; the worker side lives in main-owned processes; they are connected by shared `multiprocessing` queues that ride inside the config. The main process owns the workers and reaps them when the returned iterable is garbage-collected (tied via `weakref.finalize`), so they cannot be orphaned. A single `ProcessPoolExecutor` instance reused across pipes maps to one shared pool. `_RemoteExecutor` advertises `_pool_executor_class = ProcessPoolExecutor` so the existing `_is_process_pool` detection keeps sync-generator batching and traceback wrapping correct, and exposes `_max_workers` so consumers that introspect a process pool (e.g. pipeline-stats logging) can read the worker count off the proxy. `max_workers` / `initializer` / `initargs` are preserved; other options (`mp_context`, `max_tasks_per_child`) are not honored.

Clean-handoff contract: the executor must be freshly constructed. One that has already been used (spawned workers or had work submitted) is rejected with `ValueError` via the shared `_ensure_executor_unused`, since the whole point of subprocess execution is to (re)create the workers as part of the run — passing a live executor means lifting it mid-lifecycle.

Robustness: if a worker's `initializer` raises, the worker keeps draining its queue and fails every routed task with a fresh, plainly-picklable `RuntimeError` (the original may be unpicklable, and `mp.Queue.put` pickles asynchronously, so an unpicklable payload silently never arrives and hangs the future) rather than exiting and stranding futures. The result router fails still-pending futures with `BrokenExecutor` if the output queue closes early, and guards `InvalidStateError` from futures resolved during teardown.

Fork safety: the workers are spawned with the start method named by `mp_context` (default: the platform default, `fork` on Linux). Spawning with `fork` from a multi-threaded process can deadlock — `fork` copies only the calling thread, so a lock another thread holds is never released in the child. When the resolved start method is `fork` and the process is multi-threaded, a `RuntimeWarning` steers to `mp_context='spawn'`/`'forkserver'`; the `run_pipeline_in_subprocess` docstring documents this and the freshly-constructed requirement.

This keeps the generic `iterate_in_subprocess` API unchanged: the worker-pool teardown is registered with `weakref.finalize` on the returned iterable rather than threaded through a new parameter.