### PR TITLE
[pipeline] Fuse adjacent same-pool subprocess pipe stages

### DIFF
--- a/docs/source/getting_started/parallelism.rst
+++ b/docs/source/getting_started/parallelism.rst
@@ -305,6 +305,61 @@ if you want to ensure the size of the batch to be consistent,
 then all items must be dropped too.
 The other approach does not suffer from this.
 
+It is also cumbersome: you must hand-combine the stages into one function,
+which collapses the per-stage performance stats into a single number and
+discards each stage's individual ``concurrency``.
+
+Multi-processing (fused)
+------------------------
+
+Instead of hand-combining stages, you can ask the builder to fuse them for
+you by passing ``fuse_subprocess_stages=True`` to
+:py:meth:`~spdl.pipeline.PipelineBuilder.build`. Runs of consecutive
+:py:meth:`~spdl.pipeline.PipelineBuilder.pipe` stages that share the **same**
+process-pool (or interpreter-pool) executor instance are fused into a single
+stage that runs the run as one nested :py:class:`Pipeline` inside the worker
+pool:
+
+.. code-block::
+
+   executor = ProcessPoolExecutor(max_workers=4)
+
+   pipeline = (
+       PipelineBuilder()
+       .add_source(...)
+       .pipe(op1, executor=executor, concurrency=2)
+       .pipe(op2, executor=executor, concurrency=3)
+       .add_sink(...)
+       .build(num_threads=..., fuse_subprocess_stages=True)
+   )
+
+Because ``op1`` and ``op2`` now run back-to-back inside one worker, the
+intermediate value is **not** copied back to the main process between them.
+This removes the inter-stage IPC entirely, and — unlike the per-stage
+multi-processing above — the value handed from ``op1`` to ``op2`` does **not**
+need to be picklable. Each fused stage keeps its own ``concurrency`` and its
+own per-stage performance stats (the nested pipeline is built with the usual
+hooks, so the stats are reported from inside the worker).
+
+Only *adjacent* pool stages on the same executor are fused. An
+:py:meth:`~spdl.pipeline.PipelineBuilder.aggregate` or
+:py:meth:`~spdl.pipeline.PipelineBuilder.disaggregate` between two pool stages
+is **not** fused — it runs in the main process and keeps its usual batching
+semantics, and it splits the surrounding pool stages into separate runs (so
+each side fuses on its own only if it has two or more adjacent pool stages).
+
+The same option is accepted by
+:py:func:`spdl.pipeline.run_pipeline_in_subprocess`, where the fused worker
+pool is owned by the main process and the run executes in those workers — so
+the per-stage round-trip between the pipeline subprocess and the pool is
+removed as well.
+
+.. note::
+
+   Fusion preserves results but produces them in completion order across the
+   pool workers. Stages built with ``output_order="input"`` are not fused, and
+   fusion has no effect on continuous-source pipelines.
+
 Multi-threading in subprocess
 -----------------------------
 

--- a/src/spdl/pipeline/_build.py
+++ b/src/spdl/pipeline/_build.py
@@ -35,7 +35,9 @@ from spdl.pipeline._components import (
     TaskHook,
 )
 from spdl.pipeline._executor_proxy import _make_config_executors_picklable
+from spdl.pipeline._fuse import _fuse_subprocess_stages
 from spdl.pipeline._iter_utils import iterate_in_subinterpreter, iterate_in_subprocess
+from spdl.pipeline._subprocess_pipeline_pool import _shutdown_pipeline_pools
 from spdl.pipeline._subprocess_worker_pool import (
     _hoist_process_pools,
     _IterableWithPoolShutdown,
@@ -135,12 +137,22 @@ def _build_pipeline(
     stage_id: int = 0,
     background_tasks: list[BackgroundTaskFactory] | None = None,
     use_thread_output_queue: bool = False,
+    fuse_subprocess_stages: bool = False,
 ) -> Pipeline[U]:
     if _DEFAULT_BUILD_CALLBACK is not None:
         try:
             _DEFAULT_BUILD_CALLBACK(pipeline_cfg)
         except Exception:
             _LG.exception("Build callback failed.")
+
+    pools: list[Any] = []
+    if fuse_subprocess_stages:
+        # Fuse consecutive same-pool stages so each run executes as one nested pipeline inside a
+        # worker pool, eliminating the inter-stage IPC. The pools are owned by the returned
+        # Pipeline and reaped when it stops.
+        pipeline_cfg, pools = _fuse_subprocess_stages(
+            pipeline_cfg, report_stats_interval=report_stats_interval
+        )
 
     desc = repr(pipeline_cfg)
 
@@ -169,7 +181,7 @@ def _build_pipeline(
         max_workers=num_threads,
         thread_name_prefix="spdl_worker_thread_",
     )
-    return Pipeline(coro, queue, executor, desc=desc)
+    return Pipeline(coro, queue, executor, desc=desc, pools=pools)
 
 
 def build_pipeline(
@@ -184,6 +196,7 @@ def build_pipeline(
     stage_id: int = 0,
     background_tasks: list[BackgroundTaskFactory] | None = None,
     use_thread_output_queue: bool = False,
+    fuse_subprocess_stages: bool = False,
 ) -> Pipeline[U]:
     """Build a pipeline from the config.
 
@@ -255,6 +268,19 @@ def build_pipeline(
             background event loop to the foreground consumer thread. This bypasses
             ``asyncio.run_coroutine_threadsafe``, reducing per-batch latency from
             ~200-400us to ~10us. Default: ``False``.
+
+        fuse_subprocess_stages: If ``True``, fuse runs of two or more adjacent pipe stages that
+            share the same process-pool (or interpreter-pool) executor instance into a single
+            stage that executes the run as one nested pipeline inside a worker pool. This
+            eliminates the inter-stage IPC that otherwise round-trips data back to this process
+            between each stage (so intermediate values need not be picklable), while each fused
+            stage keeps its own ``concurrency`` and per-stage stats. Only adjacent pool stages
+            fuse: an ``aggregate``/``disaggregate`` between two pool stages is not fused (it
+            keeps its main-process batching) and splits them into separate runs. Has no effect on
+            continuous-source pipelines. Default: ``False``.
+
+            .. versionadded:: 0.6.0
+               The ``fuse_subprocess_stages`` argument.
     """
     from . import _profile
 
@@ -271,6 +297,7 @@ def build_pipeline(
         stage_id=stage_id,
         background_tasks=background_tasks,
         use_thread_output_queue=use_thread_output_queue,
+        fuse_subprocess_stages=fuse_subprocess_stages,
     )
 
 
@@ -360,6 +387,7 @@ def run_pipeline_in_subprocess(
     task_hook_factory: Callable[[StageInfo], list[TaskHook]] | None = None,
     background_tasks: list[BackgroundTaskFactory] | None = None,
     use_thread_output_queue: bool = False,
+    fuse_subprocess_stages: bool = False,
     **kwargs: Any,
 ) -> Iterable[T]:
     """Run the given Pipeline in a subprocess, and iterate on the result.
@@ -462,6 +490,17 @@ def run_pipeline_in_subprocess(
 
         num_threads,max_failures,report_stats_interval,queue_class,task_hook_factory,background_tasks:
             Passed to :py:func:`build_pipeline`.
+        fuse_subprocess_stages: If ``True``, fuse runs of consecutive pipe stages that share the
+            same process-pool (or interpreter-pool) executor instance into a single stage that
+            runs the run as one nested pipeline inside a worker pool. The worker processes are
+            spawned in (and owned by) the main process, exactly like a hoisted
+            ``ProcessPoolExecutor``; the pipeline subprocess drives them through a queue handle.
+            This removes the per-stage round-trip between the pipeline subprocess and the pool
+            workers (so intermediate values need not be picklable). Has no effect on
+            continuous-source pipelines. Default: ``False``.
+
+            .. versionadded:: 0.6.0
+               The ``fuse_subprocess_stages`` argument.
         kwargs: Passed to :py:func:`iterate_in_subprocess`.
 
     Yields:
@@ -494,6 +533,19 @@ def run_pipeline_in_subprocess(
         else config_or_builder.get_config()  # pyre-ignore[16]
     )
 
+    # Fuse runs of same-pool stages into nested-pipeline stages first, so a fused run executes
+    # as one pipeline inside the (main-owned) worker pool instead of round-tripping per stage.
+    # Runs before hoisting so only the *non-fused* ProcessPoolExecutor stages remain to be
+    # hoisted. The fused stage's queue handle is picklable and rides into the pipeline
+    # subprocess with the config, where the bridge stage drives the main-owned workers.
+    fuse_pools: list[Any] = []
+    if fuse_subprocess_stages:
+        config, fuse_pools = _fuse_subprocess_stages(
+            config,
+            mp_context=kwargs.get("mp_context"),
+            report_stats_interval=report_stats_interval,
+        )
+
     # Spawn workers for any stdlib ``ProcessPoolExecutor`` in the main process (as children of
     # main, not grandchildren via the pipeline subprocess), then replace the executor with a
     # queue-backed proxy that the subprocess submits to. The remaining stdlib executors
@@ -525,14 +577,16 @@ def run_pipeline_in_subprocess(
         # returned to the caller — reap the pools here so their worker processes and pipe
         # fds do not leak.
         _shutdown_pools(pools)
+        _shutdown_pipeline_pools(fuse_pools)
         raise
-    # The hoisted ``ProcessPoolExecutor`` workers are owned by this (the main) process and
-    # must outlive every iteration (they are reused across epochs). Wrap the iterable so the
-    # pools are reaped via the wrapper's finalizer when it is torn down — after the epoch loop,
-    # not at the end of each iteration — rather than threading a dedicated callback through the
-    # generic ``iterate_in_subprocess`` API.
-    if pools:
-        iterable = _IterableWithPoolShutdown(iterable, pools)
+    # The hoisted ``ProcessPoolExecutor`` workers and the fused-stage worker pools are all owned
+    # by this (the main) process and must outlive every iteration (they are reused across
+    # epochs). Wrap the iterable so they are reaped via the wrapper's finalizer when it is torn
+    # down — after the epoch loop, not at the end of each iteration. Both kinds share queues with
+    # the pipeline subprocess, so the wrapper joins that subprocess before reaping them.
+    all_pools: list[Any] = [*pools, *fuse_pools]
+    if all_pools:
+        iterable = _IterableWithPoolShutdown(iterable, all_pools)
     return iterable
 
 

--- a/src/spdl/pipeline/_builder.py
+++ b/src/spdl/pipeline/_builder.py
@@ -292,6 +292,7 @@ class PipelineBuilder(Generic[T, U]):
         task_hook_factory: Callable[[StageInfo], list[TaskHook]] | None = None,
         stage_id: int = 0,
         use_thread_output_queue: bool = False,
+        fuse_subprocess_stages: bool = False,
     ) -> Pipeline[U]:
         """Build the pipeline.
 
@@ -333,6 +334,18 @@ class PipelineBuilder(Generic[T, U]):
             use_thread_output_queue: If ``True``, replace the sink's output queue with a
                 ``queue.Queue``-backed queue for lower-latency batch handoff.
                 Default: ``False``.
+
+            fuse_subprocess_stages: If ``True``, fuse runs of two or more adjacent pipe stages
+                that share the same process-pool (or interpreter-pool) executor instance into a
+                single stage that runs the run as one nested pipeline inside a worker pool. This
+                eliminates the inter-stage IPC that otherwise round-trips data back to this
+                process between each stage (so intermediate values need not be picklable), while
+                each fused stage keeps its own ``concurrency`` and per-stage stats. Only adjacent
+                pool stages fuse; an ``aggregate``/``disaggregate`` between them is not fused and
+                runs in the main process with its usual batching. Default: ``False``.
+
+                .. versionadded:: 0.6.0
+                   The ``fuse_subprocess_stages`` argument.
         """
         return build_pipeline(
             self.get_config(),
@@ -343,4 +356,5 @@ class PipelineBuilder(Generic[T, U]):
             task_hook_factory=task_hook_factory,
             stage_id=stage_id,
             use_thread_output_queue=use_thread_output_queue,
+            fuse_subprocess_stages=fuse_subprocess_stages,
         )

--- a/src/spdl/pipeline/_common/_convert.py
+++ b/src/spdl/pipeline/_common/_convert.py
@@ -8,6 +8,7 @@
 
 __all__ = [
     "convert_to_async",
+    "_is_process_pool",
     "_to_async_gen",
 ]
 

--- a/src/spdl/pipeline/_components/__init__.py
+++ b/src/spdl/pipeline/_components/__init__.py
@@ -21,9 +21,25 @@ from ._queue import (
     set_default_queue_class,
     StatsQueue,
 )
+from ._subprocess_pipe import (
+    _DONE,
+    _ERROR,
+    _ITEM,
+    _POOL_SHUTDOWN,
+    _RESULT,
+    _SESSION_END,
+    _subprocess_pipeline,
+)
 
 __all__ = [
     "_build_pipeline_coro",
+    "_DONE",
+    "_ERROR",
+    "_ITEM",
+    "_POOL_SHUTDOWN",
+    "_RESULT",
+    "_SESSION_END",
+    "_subprocess_pipeline",
     "_get_global_id",
     "_set_global_id",
     "get_default_hook_class",

--- a/src/spdl/pipeline/_components/_node.py
+++ b/src/spdl/pipeline/_components/_node.py
@@ -19,6 +19,7 @@ from spdl.pipeline._common._misc import create_task
 from spdl.pipeline.defs import (
     _PipeArgs,
     _PipeType,
+    _SubprocessPipelineConfig,
     AggregateConfig,
     DisaggregateConfig,
     MergeConfig,
@@ -43,6 +44,7 @@ from ._pipe import (
 from ._queue import _ThreadBasedAsyncQueue, AsyncQueue, get_default_queue_class
 from ._sink import _sink
 from ._source import _source, _source_continuous
+from ._subprocess_pipe import _subprocess_pipeline
 from ._variants import _path_variants_router
 
 T = TypeVar("T")
@@ -147,6 +149,7 @@ class _Node(_NodeMixin):
         | AggregateConfig
         | DisaggregateConfig
         | PathVariantsConfig
+        | _SubprocessPipelineConfig
         | SinkConfig
     )
     """The configuration object that defines the behavior of this stage."""
@@ -276,6 +279,8 @@ def _get_stage_info(cfg: object, pipeline_id: int, stage_id: _MutableInt) -> Sta
             base = cfg.name or repr(cfg.op)
         case DisaggregateConfig():
             base = "disaggregate"
+        case _SubprocessPipelineConfig():
+            base = cfg.name
         case MergeConfig():
             base = "merge"
         case PathVariantsConfig():
@@ -302,7 +307,11 @@ _BUFFER_SIZE: int = 2
 
 def _convert_pipes(
     pipes: Sequence[
-        PipeConfig | AggregateConfig | DisaggregateConfig | PathVariantsConfig
+        PipeConfig
+        | AggregateConfig
+        | DisaggregateConfig
+        | PathVariantsConfig
+        | _SubprocessPipelineConfig
     ],
     n: _TNodes,
     q_class: type[AsyncQueue],
@@ -621,6 +630,13 @@ def _build_node(
                     fc = fc_class(max_failures)
                     args = _PipeArgs(op=_disaggregate)  # pyre-ignore[6]
                     node._coro = _pipe(node.info, in_q, out_q, args, fc, hooks, False)
+
+                case _SubprocessPipelineConfig():
+                    # The fused run executes as a nested pipeline inside the worker pool; the
+                    # per-stage hooks/stats fire there, so this bridge stage needs none here.
+                    node._coro = _subprocess_pipeline(
+                        node.input_queue, node.output_queue, cfg.handle
+                    )
 
                 case _:  # pragma: no cover
                     raise ValueError(

--- a/src/spdl/pipeline/_components/_subprocess_pipe.py
+++ b/src/spdl/pipeline/_components/_subprocess_pipe.py
@@ -1,0 +1,140 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""The main-side bridge stage for a fused subprocess sub-pipeline.
+
+A fused run of pipe stages (see :py:mod:`spdl.pipeline._fuse`) is replaced by a single stage
+whose coroutine, defined here, streams items to a worker pool that runs the run as a nested
+:py:class:`~spdl.pipeline.Pipeline`, and streams the results back. The pool itself lives in
+:py:mod:`spdl.pipeline._subprocess_pipeline_pool`; this stage only talks to it through the
+shared queues carried by a handle.
+
+The wire protocol uses small integer message kinds (not sentinel objects): a sentinel pickled
+onto a multiprocessing queue is a different object on the other side, so identity comparison
+would not survive the trip.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import queue as _queue
+from concurrent.futures import Executor, ThreadPoolExecutor
+from typing import Any
+
+from spdl.pipeline._common._misc import create_task
+
+from ._common import is_eof
+from ._queue import _queue_stage_hook, AsyncQueue
+
+__all__ = [
+    "_subprocess_pipeline",
+    "_ITEM",
+    "_SESSION_END",
+    "_POOL_SHUTDOWN",
+    "_RESULT",
+    "_ERROR",
+    "_DONE",
+]
+
+# Input-queue message kinds (this stage -> worker).
+_ITEM = 0  # (_ITEM, value): one item for the sub-pipeline source
+_SESSION_END = 1  # (_SESSION_END, None): end of one input stream; finish the session
+_POOL_SHUTDOWN = 2  # (_POOL_SHUTDOWN, None): tear the worker down entirely
+
+# Output-queue message kinds (worker -> this stage).
+_RESULT = 0  # (_RESULT, value): one produced item
+_ERROR = 1  # (_ERROR, exc): the sub-pipeline failed
+_DONE = 2  # (_DONE, None): a worker finished the current session
+
+# How long a blocking get may wait before yielding control, so the awaiting coroutine can
+# observe cancellation between polls instead of parking a thread on an indefinite get.
+_GET_TIMEOUT: float = 0.5
+
+
+def _put(q: Any, msg: tuple[int, Any]) -> None:
+    q.put(msg)
+
+
+def _drain_one(q: Any) -> tuple[int, Any] | None:
+    try:
+        return q.get(timeout=_GET_TIMEOUT)
+    except _queue.Empty:
+        return None
+
+
+async def _feed(
+    input_queue: AsyncQueue, in_q: Any, num_workers: int, executor: Executor
+) -> None:
+    """Forward items from the stage's input queue to the worker pool, then end the session.
+
+    Sends exactly one ``_SESSION_END`` per worker: a worker stops pulling the instant it
+    receives one, so the per-worker count guarantees each worker ends exactly once even though
+    the input queue is shared.
+    """
+    loop = asyncio.get_running_loop()
+    while True:
+        item = await input_queue.get()
+        if is_eof(item):
+            break
+        await loop.run_in_executor(executor, _put, in_q, (_ITEM, item))
+    for _ in range(num_workers):
+        await loop.run_in_executor(executor, _put, in_q, (_SESSION_END, None))
+
+
+async def _collect(
+    out_q: Any, num_workers: int, output_queue: AsyncQueue, executor: Executor
+) -> None:
+    """Forward worker results to the stage's output queue until every worker is done."""
+    loop = asyncio.get_running_loop()
+    done = 0
+    while done < num_workers:
+        res = await loop.run_in_executor(executor, _drain_one, out_q)
+        if res is None:
+            continue  # timeout — loop so cancellation can be observed
+        kind, payload = res
+        if kind == _DONE:
+            done += 1
+        elif kind == _ERROR:
+            raise payload
+        elif kind == _RESULT:
+            await output_queue.put(payload)
+
+
+async def _subprocess_pipeline(
+    input_queue: AsyncQueue, output_queue: AsyncQueue, handle: Any
+) -> None:
+    """Stream this stage's input through a worker pool and its results to the output queue.
+
+    The fused run executes as a nested pipeline inside the pool's workers, so the handoff
+    between the fused stages stays in-process. Worker failures are relayed as ``_ERROR`` and
+    re-raised here so the enclosing pipeline fails as usual; the output queue's EOF is emitted by
+    :py:func:`_queue_stage_hook` on both success and failure.
+
+    The blocking multiprocessing-queue gets/puts run on a small dedicated thread pool so they do
+    not occupy the enclosing pipeline's shared worker threads (which would starve its other
+    stages).
+    """
+    in_q, out_q, num_workers = handle.in_q, handle.out_q, handle.max_workers
+    # Two threads: one parked on the feeder put, one on the collector get.
+    executor = ThreadPoolExecutor(
+        max_workers=2, thread_name_prefix="spdl_fused_bridge_"
+    )
+    async with _queue_stage_hook(output_queue):
+        feeder = create_task(_feed(input_queue, in_q, num_workers, executor))
+        collector = create_task(_collect(out_q, num_workers, output_queue, executor))
+        try:
+            await asyncio.gather(feeder, collector)
+        except BaseException:
+            feeder.cancel()
+            collector.cancel()
+            await asyncio.gather(feeder, collector, return_exceptions=True)
+            raise
+        finally:
+            # Don't wait on threads still parked in a blocking get/put — the pool teardown
+            # unblocks them. ``cancel_futures`` discards anything not yet started.
+            executor.shutdown(wait=False, cancel_futures=True)

--- a/src/spdl/pipeline/_fuse.py
+++ b/src/spdl/pipeline/_fuse.py
@@ -1,0 +1,358 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""Detect runs of consecutive pipe stages that can be fused into one subprocess sub-pipeline.
+
+When several consecutive :py:func:`~spdl.pipeline.defs.Pipe` stages share the **same**
+process-pool (or interpreter-pool) executor instance, SPDL round-trips data back to the main
+process between every stage (each stage compiles to ``loop.run_in_executor(executor, op, item)``
+in :py:mod:`spdl.pipeline._common._convert`). That inter-stage IPC is wasteful and fails
+outright when an intermediate value is unpicklable.
+
+This module finds the maximal *fusable runs* — spans of the config's ``pipes`` that can be
+combined into a single nested :py:class:`~spdl.pipeline.Pipeline` executed inside the worker
+pool, so the op→op handoff stays in-process. The actual config rewrite and worker-pool spawning
+build on the runs found here.
+
+The detection is a pure function over the stage configs (no process spawning), which keeps the
+fusion policy easy to reason about and to test in isolation.
+"""
+
+from __future__ import annotations
+
+import multiprocessing as mp
+import os
+import sys
+import threading
+import warnings
+from collections.abc import Sequence
+from concurrent.futures import Executor
+from dataclasses import dataclass, replace
+from functools import partial
+from typing import Any
+
+from spdl.pipeline._common._convert import _is_process_pool
+from spdl.pipeline._components import _get_global_id, _set_global_id
+from spdl.pipeline._executor_proxy import _ensure_executor_unused
+from spdl.pipeline._subprocess_pipeline_pool import _SubprocessPipelinePool
+from spdl.pipeline.defs._defs import (
+    _PipeType,
+    _SubprocessPipelineConfig,
+    MergeConfig,
+    PipeConfig,
+    PipelineConfig,
+    SinkConfig,
+    SourceConfig,
+)
+
+__all__ = [
+    "_FusableRun",
+    "_find_fusable_runs",
+    "_fuse_subprocess_stages",
+    "_is_interpreter_pool",
+    "_is_isolating_pool",
+]
+
+# Buffer size for the fused sub-pipeline's sink. Small: the worker drains it straight onto the
+# result queue, so a deep buffer only adds latency.
+_FUSED_SINK_BUFFER: int = 3
+
+
+# Declared before the branch so its type stays ``type[Executor] | None`` on every Python
+# version; otherwise, on versions without ``InterpreterPoolExecutor`` the ``else`` assignment
+# narrows it to ``None`` and the isinstance/issubclass checks below fail to type-check.
+_INTERPRETER_POOL_CLASS: type[Executor] | None
+if sys.version_info >= (3, 14):
+    from concurrent.futures.interpreter import (  # pyre-ignore[21]
+        InterpreterPoolExecutor,
+    )
+
+    _INTERPRETER_POOL_CLASS = InterpreterPoolExecutor
+else:
+    _INTERPRETER_POOL_CLASS = None
+
+
+def _is_interpreter_pool(executor: Executor | type[Executor] | None) -> bool:
+    """Check whether ``executor`` is or wraps an ``InterpreterPoolExecutor``.
+
+    Mirrors :py:func:`spdl.pipeline._common._convert._is_process_pool`: matches the stdlib
+    ``InterpreterPoolExecutor`` (Python 3.14+) directly, SPDL pool wrappers via their
+    ``_pool_executor_class``, and a ``PriorityExecutorEntrypoint`` via its ``_owner``.
+
+    Args:
+        executor: The executor (or executor class, or ``None``) to inspect.
+
+    Returns:
+        ``True`` if the executor isolates work in a subinterpreter, else ``False``. Always
+        ``False`` on Python versions without ``InterpreterPoolExecutor``.
+    """
+    if _INTERPRETER_POOL_CLASS is None or executor is None:
+        return False
+    if isinstance(executor, _INTERPRETER_POOL_CLASS):
+        return True
+    pool_cls = getattr(executor, "_pool_executor_class", None)
+    if pool_cls is not None:
+        return issubclass(pool_cls, _INTERPRETER_POOL_CLASS)
+    owner = getattr(executor, "_owner", None)
+    if owner is not None:
+        return _is_interpreter_pool(owner)
+    return False
+
+
+def _is_isolating_pool(executor: Executor | type[Executor] | None) -> bool:
+    """Check whether ``executor`` runs work in a separate process or subinterpreter.
+
+    These are exactly the executors whose inter-stage handoff crosses an IPC / pickling
+    boundary, and therefore the executors that fusion targets. Thread pools (which share
+    address space) and ``None`` (the default thread pool) are not isolating.
+
+    Args:
+        executor: The executor (or executor class, or ``None``) to inspect.
+
+    Returns:
+        ``True`` if the executor is a process pool or interpreter pool, else ``False``.
+    """
+    return _is_process_pool(executor) or _is_interpreter_pool(executor)
+
+
+@dataclass(frozen=True)
+class _FusableRun:
+    """A maximal span of ``pipes`` that can be fused into one subprocess sub-pipeline.
+
+    The fused stages are ``pipes[start:stop]`` — two or more *adjacent* pool-pipes sharing
+    :py:attr:`executor`. Only consecutive pool-pipes fuse; aggregate/disaggregate micro-stages
+    are never absorbed (so their batching semantics are unchanged) and instead bound a run.
+    """
+
+    start: int
+    """Index of the first fused stage in ``pipes`` (inclusive)."""
+
+    stop: int
+    """Index just past the last fused stage in ``pipes`` (exclusive)."""
+
+    executor: Executor
+    """The isolating-pool executor instance shared by every pool-pipe in the run."""
+
+
+def _fusable_pool_executor(cfg: object) -> Executor | None:
+    """Return the executor if ``cfg`` is a completion-ordered isolating-pool pipe.
+
+    Returns ``None`` otherwise. Input-ordered (``output_order="input"``) pipes are not fusable:
+    their global input order cannot be preserved across a pool of independent workers.
+    """
+    if not isinstance(cfg, PipeConfig):
+        return None
+    if cfg._type is not _PipeType.Pipe:
+        return None
+    executor = cfg._args.executor
+    if executor is not None and _is_isolating_pool(executor):
+        return executor
+    return None
+
+
+def _scan_run(
+    pipes: Sequence[object], start: int, executor: Executor
+) -> tuple[_FusableRun | None, int]:
+    """Scan one fusable run of adjacent same-executor pool-pipes from ``pipes[start]``.
+
+    Greedily consumes the immediately-following pool-pipes that share ``executor``, stopping at
+    the first stage that is anything else — a different executor, a thread/None/async pipe, an
+    aggregate/disaggregate micro-stage, a path-variant stage, an input-ordered pool-pipe, or the
+    end. Only adjacent pool-pipes fuse, so a micro-stage between two pool-pipes splits them into
+    separate (and therefore unfused) runs and keeps its main-process batching semantics.
+
+    Returns:
+        A tuple ``(run, next_index)``. ``run`` is the emitted :py:class:`_FusableRun`, or
+        ``None`` for a lone pool-pipe with no same-executor neighbour. ``next_index`` is where
+        the outer scan should resume.
+    """
+    j = start + 1
+    n = len(pipes)
+    while j < n and _fusable_pool_executor(pipes[j]) is executor:
+        j += 1
+    if j - start >= 2:
+        return _FusableRun(start, j, executor), j
+    return None, j
+
+
+def _find_fusable_runs(pipes: Sequence[object]) -> list[_FusableRun]:
+    """Find all maximal fusable runs in a pipeline config's ``pipes``.
+
+    A run is a span of ≥2 adjacent completion-ordered :py:func:`~spdl.pipeline.defs.Pipe`
+    stages sharing the same isolating-pool executor instance. A lone pool-pipe, and any
+    aggregate/disaggregate micro-stage, break a run and are left unchanged in the main process.
+    Returned runs are ordered by position and never overlap.
+
+    Args:
+        pipes: The ordered stage configs from a :py:class:`~spdl.pipeline.defs.PipelineConfig`.
+
+    Returns:
+        The list of fusable runs; empty when no fusion applies.
+    """
+    runs: list[_FusableRun] = []
+    i = 0
+    n = len(pipes)
+    while i < n:
+        executor = _fusable_pool_executor(pipes[i])
+        if executor is None:
+            i += 1
+            continue
+        run, i = _scan_run(pipes, i, executor)
+        if run is not None:
+            runs.append(run)
+    return runs
+
+
+################################################################################
+# Config rewrite: replace each fusable run with one subprocess-pipeline stage.
+################################################################################
+
+
+def _has_continuous_source(config: PipelineConfig[Any]) -> bool:
+    """Whether any source in the (possibly merged) config re-iterates continuously."""
+    src = config.src
+    if isinstance(src, SourceConfig):
+        return src.continuous
+    if isinstance(src, MergeConfig):
+        return any(_has_continuous_source(plc) for plc in src.pipeline_configs)
+    return False
+
+
+def _strip_executor(cfg: object) -> object:
+    """Return ``cfg`` with a pool-pipe's executor removed so it runs on the worker's own pool."""
+    if isinstance(cfg, PipeConfig):
+        return replace(cfg, _args=replace(cfg._args, executor=None))
+    return cfg
+
+
+def _stage_name(cfg: object) -> str:
+    return getattr(cfg, "name", type(cfg).__name__)
+
+
+def _worker_initializer(
+    global_id: int,
+    user_initializer: Any,
+    user_initargs: tuple[Any, ...],
+) -> None:
+    """Run inside each worker before the sub-pipeline is built.
+
+    Aligns the worker's pipeline-id base with the parent so per-stage stats are attributed
+    consistently, then runs the user's executor initializer (if any), preserving the side
+    effects (e.g. dataset setup) the user attached to their pool.
+    """
+    _set_global_id(global_id)
+    if user_initializer is not None:
+        user_initializer(*user_initargs)
+
+
+def _pool_params(executor: Executor) -> tuple[int, Any, tuple[Any, ...]]:
+    """Read worker count and initializer off a fresh pool executor without using it."""
+    _ensure_executor_unused(executor)
+    max_workers = getattr(executor, "_max_workers", None) or os.cpu_count() or 1
+    user_initializer = getattr(executor, "_initializer", None)
+    user_initargs = getattr(executor, "_initargs", ()) or ()
+    return max_workers, user_initializer, user_initargs
+
+
+def _warn_fork_with_threads(ctx: Any) -> None:
+    if ctx.get_start_method() == "fork" and threading.active_count() > 1:
+        warnings.warn(
+            "Fusing subprocess pipeline stages with the 'fork' start method from a "
+            "multi-threaded process can deadlock. Pass mp_context='spawn' or 'forkserver', "
+            "or build the pipeline before other threads start.",
+            RuntimeWarning,
+            stacklevel=3,
+        )
+
+
+def _build_fused_stage(
+    stages: Sequence[object],
+    executor: Executor,
+    ctx: Any,
+    report_stats_interval: float,
+) -> tuple[_SubprocessPipelineConfig, _SubprocessPipelinePool]:
+    """Build the worker pool and replacement stage for one fusable run."""
+    stripped = [_strip_executor(s) for s in stages]
+    num_threads = max(
+        1, sum(s._args.concurrency for s in stages if isinstance(s, PipeConfig))
+    )
+    sub_config: PipelineConfig[Any] = PipelineConfig(
+        src=SourceConfig(
+            []
+        ),  # placeholder; the worker sets the real source per session
+        pipes=stripped,  # pyre-ignore[6]
+        sink=SinkConfig(_FUSED_SINK_BUFFER),
+    )
+    max_workers, user_initializer, user_initargs = _pool_params(executor)
+    build_kwargs = {
+        "num_threads": num_threads,
+        "report_stats_interval": report_stats_interval,
+    }
+    initializer = partial(
+        _worker_initializer, _get_global_id(), user_initializer, user_initargs
+    )
+    pool = _SubprocessPipelinePool(
+        ctx, max_workers, sub_config, build_kwargs, initializer, ()
+    )
+    name = "subprocess_pipeline(" + "+".join(_stage_name(s) for s in stages) + ")"
+    return _SubprocessPipelineConfig(name=name, handle=pool.make_handle()), pool
+
+
+def _fuse_subprocess_stages(
+    config: PipelineConfig[Any],
+    *,
+    mp_context: str | None = None,
+    report_stats_interval: float = -1,
+) -> tuple[PipelineConfig[Any], list[_SubprocessPipelinePool]]:
+    """Replace fusable runs of pool-pipe stages with single subprocess-pipeline stages.
+
+    For each run found by :py:func:`_find_fusable_runs`, spawns a worker pool that runs the run
+    as a nested pipeline and replaces the run with a :py:class:`_SubprocessPipelineConfig`. The
+    spawned pools are returned so the caller can reap them at teardown. The input ``config`` is
+    not mutated.
+
+    Fusion is skipped for continuous-source pipelines (epoch-end markers would be mishandled by
+    the fused source); such configs are returned unchanged.
+
+    Args:
+        config: The pipeline configuration to rewrite.
+        mp_context: Multiprocessing start-method name, as accepted by
+            :py:func:`multiprocessing.get_context`.
+        report_stats_interval: Forwarded to the nested ``build_pipeline`` so per-stage stats are
+            reported from inside the workers.
+
+    Returns:
+        A tuple ``(new_config, pools)``. ``pools`` is empty when no fusion applies.
+    """
+    if _has_continuous_source(config):
+        return config, []
+    runs = _find_fusable_runs(config.pipes)
+    if not runs:
+        return config, []
+
+    ctx = mp.get_context(mp_context)
+    _warn_fork_with_threads(ctx)
+
+    pools: list[_SubprocessPipelinePool] = []
+    by_start = {r.start: r for r in runs}
+    pipes = list(config.pipes)
+    new_pipes: list[object] = []
+    i = 0
+    while i < len(pipes):
+        run = by_start.get(i)
+        if run is None:
+            new_pipes.append(pipes[i])
+            i += 1
+            continue
+        fused, pool = _build_fused_stage(
+            pipes[run.start : run.stop], run.executor, ctx, report_stats_interval
+        )
+        pools.append(pool)
+        new_pipes.append(fused)
+        i = run.stop
+    return replace(config, pipes=new_pipes), pools  # pyre-ignore[6]

--- a/src/spdl/pipeline/_pipeline.py
+++ b/src/spdl/pipeline/_pipeline.py
@@ -14,7 +14,7 @@ import time
 import warnings
 import weakref
 from asyncio import AbstractEventLoop, Queue as AsyncQueue
-from collections.abc import Coroutine, Iterator
+from collections.abc import Coroutine, Iterator, Sequence
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
 from enum import IntEnum
@@ -206,12 +206,16 @@ class _PipelineImpl(Generic[T]):
         executor: ThreadPoolExecutor,
         *,
         desc: str,
+        pools: Sequence[Any] = (),
     ) -> None:
         self._str: str = "\n".join([repr(self), desc])
 
         self._output_queue: AsyncQueue = output_queue
         self._event_loop = _EventLoop(coro, executor)
         self._event_loop_state: _EventLoopState = _EventLoopState.NOT_STARTED
+        # Worker pools owned by this pipeline (from subprocess-stage fusion). They are reaped in
+        # ``stop`` (and via the Pipeline finalizer), exactly once.
+        self._pools: list[Any] = list(pools)
 
     def __str__(self) -> str:
         return self._str
@@ -265,8 +269,19 @@ class _PipelineImpl(Generic[T]):
                 self._event_loop.join(timeout=to2)
             self._event_loop_state = _EventLoopState.STOPPED
 
+        self._shutdown_pools()
+
         if self._event_loop._task_exception is not None:
             raise self._event_loop._task_exception
+
+    def _shutdown_pools(self) -> None:
+        """Reap any owned worker pools exactly once (safe to call repeatedly)."""
+        pools, self._pools = self._pools, []
+        for pool in pools:
+            try:
+                pool.shutdown()
+            except Exception:
+                _LG.debug("Exception during worker pool shutdown.", exc_info=True)
 
     def get_item(self, *, timeout: float | None = None) -> T:
         """Get the next item.
@@ -496,9 +511,10 @@ class Pipeline(Generic[T]):
         executor: ThreadPoolExecutor,
         *,
         desc: str,
+        pools: Sequence[Any] = (),
     ) -> None:
         self._impl: _PipelineImpl[T] = _PipelineImpl(
-            coro, output_queue, executor, desc=desc
+            coro, output_queue, executor, desc=desc, pools=pools
         )
         self._finalizer = weakref.finalize(self, _stop_impl, self._impl)
 

--- a/src/spdl/pipeline/_profile.py
+++ b/src/spdl/pipeline/_profile.py
@@ -18,6 +18,7 @@ from spdl.pipeline._common._misc import _get_env_bool
 from spdl.pipeline.defs import (
     _PipeArgs,
     _PipeType,
+    _SubprocessPipelineConfig,
     AggregateConfig,
     DisaggregateConfig,
     MergeConfig,
@@ -262,8 +263,10 @@ def _profile_pipeline(
         raise ValueError(f"Unexpected source type {type(cfg.src)}")
 
     for pipe in cfg.pipes:
-        if isinstance(pipe, PathVariantsConfig):
-            _LG.warning("Skipping PathVariants stage in profiling (not supported).")
+        if isinstance(pipe, (PathVariantsConfig, _SubprocessPipelineConfig)):
+            _LG.warning(
+                "Skipping %s stage in profiling (not supported).", type(pipe).__name__
+            )
             continue
         _LG.info("Profiling Stage: %s", pipe.name)
         inputs, result = _profile_pipe(inputs, pipe, hook, callback)

--- a/src/spdl/pipeline/_subprocess_pipeline_pool.py
+++ b/src/spdl/pipeline/_subprocess_pipeline_pool.py
@@ -1,0 +1,199 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""Main-process-owned worker pools that run a fused sub-pipeline inside each worker.
+
+This is the streaming counterpart of :py:mod:`spdl.pipeline._subprocess_worker_pool`. Where that
+module runs one submitted ``fn(*args)`` per task, here each worker process runs a long-lived
+nested :py:class:`~spdl.pipeline.Pipeline` (built from the fused stages by
+:py:func:`~spdl.pipeline._build.build_pipeline`). Items stream in over a shared input queue and
+results stream back over a shared output queue, so the op→op handoff between fused stages stays
+inside one worker process — no inter-stage IPC, and intermediate values need not be picklable.
+
+Like :py:class:`spdl.pipeline._subprocess_worker_pool._WorkerPool`, the worker processes are
+owned by the main process (spawned here, reaped in :py:meth:`_SubprocessPipelinePool.shutdown`).
+The submit side is a small picklable :py:class:`_SubprocessPipelineHandle` carrying only the
+shared queues, so the fused stage can drive the pool whether its node runs in the main process
+(a normal ``build``) or in a pipeline subprocess (``run_pipeline_in_subprocess``).
+
+Messages are tagged with small integer kinds rather than sentinel objects: a sentinel pickled
+onto a queue is a *different* object on the other side, so identity (``is``) comparison would
+break across the process boundary.
+"""
+
+from __future__ import annotations
+
+import traceback
+from collections.abc import Callable, Sequence
+from dataclasses import replace
+from typing import Any
+
+from spdl.pipeline._components import (
+    _DONE,
+    _ERROR,
+    _ITEM,
+    _POOL_SHUTDOWN,
+    _RESULT,
+    _SESSION_END,
+)
+from spdl.pipeline.defs._defs import PipelineConfig, SourceConfig
+
+__all__ = [
+    "_SubprocessPipelineHandle",
+    "_SubprocessPipelinePool",
+    "_shutdown_pipeline_pools",
+]
+
+
+def _to_picklable_error(err: BaseException, tb: str) -> RuntimeError:
+    """Reduce an arbitrary exception to a plainly-picklable error for the result queue.
+
+    The original exception (e.g. a :py:class:`~spdl.pipeline.PipelineFailure` wrapping several
+    sub-exceptions) may not be picklable, and ``mp.Queue.put`` pickles asynchronously — an
+    unpicklable payload silently fails to arrive and hangs the consumer. So always relay a fresh
+    ``RuntimeError`` carrying the text and the worker-side traceback (otherwise the traceback,
+    the most useful part for debugging a fused run, is lost crossing the process boundary).
+    """
+    return RuntimeError(
+        f"Fused subprocess pipeline failed: {type(err).__name__}: {err}\n{tb}"
+    )
+
+
+def _pipeline_worker_loop(
+    in_q: Any,
+    out_q: Any,
+    sub_config: PipelineConfig[Any],
+    build_kwargs: dict[str, Any],
+    initializer: Callable[..., object] | None,
+    initargs: tuple[Any, ...],
+) -> None:
+    """Worker body: repeatedly build and run the fused sub-pipeline over one input stream.
+
+    Each session drains ``in_q`` into the sub-pipeline's source until a ``_SESSION_END`` (next
+    session) or ``_POOL_SHUTDOWN`` (exit) message, streams the results onto ``out_q``, then
+    emits ``_DONE``. The pipeline is rebuilt per session so its single-use source iterator is
+    fresh, which keeps the pool reusable across epochs without an explicit control channel.
+    """
+    # Imported lazily: ``build_pipeline``'s module (transitively) imports this one.
+    from spdl.pipeline._build import build_pipeline
+
+    if initializer is not None:
+        initializer(*initargs)
+
+    exiting = False
+
+    def _drain() -> Any:
+        nonlocal exiting
+        while True:
+            kind, payload = in_q.get()
+            if kind == _ITEM:
+                yield payload
+            elif kind == _SESSION_END:
+                return
+            else:  # _POOL_SHUTDOWN
+                exiting = True
+                return
+
+    while not exiting:
+        cfg = replace(sub_config, src=SourceConfig(_drain()))
+        try:
+            pipeline = build_pipeline(cfg, **build_kwargs)
+            with pipeline.auto_stop():
+                for out in pipeline:
+                    out_q.put((_RESULT, out))
+        except BaseException as err:  # noqa: B036 - relayed to the submitter below
+            out_q.put((_ERROR, _to_picklable_error(err, traceback.format_exc())))
+        out_q.put((_DONE, None))
+
+
+class _SubprocessPipelineHandle:
+    """Picklable submit side of a :py:class:`_SubprocessPipelinePool`.
+
+    Holds only the shared queues and worker count, so it is cheap to carry inside a
+    :py:class:`~spdl.pipeline.defs.PipelineConfig` — including across the pickle boundary into a
+    pipeline subprocess (the queues travel as ``Process`` spawn arguments, the only context in
+    which an ``mp.Queue`` may be pickled). The worker processes themselves are owned by the main
+    process, so this handle holds no process references.
+    """
+
+    def __init__(self, in_q: Any, out_q: Any, max_workers: int) -> None:
+        self.in_q = in_q
+        self.out_q = out_q
+        self.max_workers = max_workers
+
+
+class _SubprocessPipelinePool:
+    """Main-process handle to a set of workers running a fused sub-pipeline."""
+
+    def __init__(
+        self,
+        ctx: Any,
+        max_workers: int,
+        sub_config: PipelineConfig[Any],
+        build_kwargs: dict[str, Any],
+        initializer: Callable[..., object] | None,
+        initargs: tuple[Any, ...],
+    ) -> None:
+        # Bound the queues so a slow consumer/producer applies backpressure rather than
+        # buffering without limit. Sized to keep every worker fed, plus in-flight slack.
+        size = max(4, max_workers * 2)
+        self._in_q: Any = ctx.Queue(maxsize=size)
+        self._out_q: Any = ctx.Queue(maxsize=size)
+        self._max_workers = max_workers
+        self._procs: list[Any] = [
+            ctx.Process(
+                target=_pipeline_worker_loop,
+                args=(
+                    self._in_q,
+                    self._out_q,
+                    sub_config,
+                    build_kwargs,
+                    initializer,
+                    initargs,
+                ),
+                daemon=True,
+            )
+            for _ in range(max_workers)
+        ]
+        for p in self._procs:
+            p.start()
+
+    def make_handle(self) -> _SubprocessPipelineHandle:
+        """Create the picklable submit-side handle that rides in the pipeline config."""
+        return _SubprocessPipelineHandle(self._in_q, self._out_q, self._max_workers)
+
+    def shutdown(self) -> None:
+        """Tell every worker to exit, then reap the processes (join → terminate → kill)."""
+        for _ in self._procs:
+            try:
+                self._in_q.put((_POOL_SHUTDOWN, None))
+            except Exception:
+                # A failed sentinel for one worker should not block the others; fall through to
+                # the join/terminate/kill escalation below.
+                continue
+        for p in self._procs:
+            p.join(3)
+            if p.exitcode is None:
+                p.terminate()
+                p.join(5)
+            if p.exitcode is None:
+                p.kill()
+                p.join(5)
+        # Close this process's queue handles so the feeder threads created on first ``put``
+        # exit; otherwise a process that creates many pipelines leaks threads and pipe fds.
+        for q in (self._in_q, self._out_q):
+            q.close()
+            try:
+                q.join_thread()
+            except Exception:
+                pass
+
+
+def _shutdown_pipeline_pools(pools: Sequence[_SubprocessPipelinePool]) -> None:
+    for pool in pools:
+        pool.shutdown()

--- a/src/spdl/pipeline/defs/__init__.py
+++ b/src/spdl/pipeline/defs/__init__.py
@@ -28,6 +28,7 @@ The following step explains the steps to build a pipeline using the building blo
 from ._defs import (
     _PipeArgs,
     _PipeType,
+    _SubprocessPipelineConfig,
     _TPipeInputs,
     Aggregate,
     AggregateConfig,
@@ -49,6 +50,7 @@ from ._defs import (
 __all__ = [
     "_PipeArgs",
     "_PipeType",
+    "_SubprocessPipelineConfig",
     # pyrefly: ignore [bad-dunder-all]
     "_TAsyncCallables",
     # pyrefly: ignore [bad-dunder-all]

--- a/src/spdl/pipeline/defs/_defs.py
+++ b/src/spdl/pipeline/defs/_defs.py
@@ -38,6 +38,7 @@ __all__ = [
     "AggregateConfig",
     "Collate",
     "DisaggregateConfig",
+    "_SubprocessPipelineConfig",
     "PipelineConfig",
     "SinkConfig",
     "SourceConfig",
@@ -411,6 +412,23 @@ class DisaggregateConfig(Generic[T]):
         return self.name or "disaggregate"
 
 
+@dataclass(frozen=True)
+class _SubprocessPipelineConfig:
+    """Internal config for a fused run of pipe stages run in a subprocess worker pool.
+
+    Not user-facing. Produced by the fusion pass (``_fuse_subprocess_stages``), which replaces a
+    span of consecutive pool-pipe stages with a single stage that executes the run as one nested
+    pipeline inside the worker pool — eliminating the inter-stage IPC of running each stage on a
+    process/interpreter pool separately.
+    """
+
+    name: str
+    """Name of the fused stage."""
+
+    handle: Any
+    """The picklable submit-side handle (``_SubprocessPipelineHandle``) for the worker pool."""
+
+
 ################################################################################
 # PathVariants
 ################################################################################
@@ -581,6 +599,7 @@ class PipelineConfig(Generic[U]):
         | AggregateConfig[Any]
         | DisaggregateConfig[Any]
         | PathVariantsConfig[Any]
+        | _SubprocessPipelineConfig
     ]
     """Pipe configurations."""
 

--- a/tests/pipeline/fuse_test.py
+++ b/tests/pipeline/fuse_test.py
@@ -1,0 +1,162 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import unittest
+from collections.abc import Callable
+from concurrent.futures import Executor, ProcessPoolExecutor
+from typing import Any
+
+from spdl.pipeline._fuse import _find_fusable_runs, _FusableRun
+from spdl.pipeline.defs import Aggregate, Disaggregate, Pipe
+
+
+def op(x: int) -> int:
+    return x
+
+
+async def aop(x: int) -> int:
+    return x
+
+
+class _FakeProcessPool(Executor):
+    """Stand-in that ``_is_process_pool`` recognizes, without spawning processes."""
+
+    _pool_executor_class: type[Executor] = ProcessPoolExecutor
+
+    def submit(self, fn: Callable[..., Any], /, *args: Any, **kwargs: Any) -> Any:
+        raise NotImplementedError
+
+
+class _FakeThreadPool(Executor):
+    """Stand-in for a non-isolating (thread) executor — not a fusion target."""
+
+    def submit(self, fn: Callable[..., Any], /, *args: Any, **kwargs: Any) -> Any:
+        raise NotImplementedError
+
+
+def _pool_pipe(executor: Executor) -> Any:
+    return Pipe(op, executor=executor, concurrency=2)
+
+
+class FindFusableRunsTest(unittest.TestCase):
+    def test_empty_pipes(self) -> None:
+        """No pipes yields no fusable runs."""
+        self.assertEqual(_find_fusable_runs([]), [])
+
+    def test_two_same_executor_pipes_fuse(self) -> None:
+        """Two adjacent pipes on the same pool executor fuse into one run."""
+        ex = _FakeProcessPool()
+        runs = _find_fusable_runs([_pool_pipe(ex), _pool_pipe(ex)])
+        self.assertEqual(runs, [_FusableRun(0, 2, ex)])
+
+    def test_aggregate_between_pool_pipes_breaks_run(self) -> None:
+        """An aggregate between two pool pipes is not absorbed; the lone pipes do not fuse."""
+        ex = _FakeProcessPool()
+        runs = _find_fusable_runs([_pool_pipe(ex), Aggregate(4), _pool_pipe(ex)])
+        self.assertEqual(runs, [])
+
+    def test_disaggregate_between_pool_pipes_breaks_run(self) -> None:
+        """A disaggregate between two pool pipes is not absorbed; the lone pipes do not fuse."""
+        ex = _FakeProcessPool()
+        runs = _find_fusable_runs([_pool_pipe(ex), Disaggregate(), _pool_pipe(ex)])
+        self.assertEqual(runs, [])
+
+    def test_aggregate_between_two_runs_fuses_each_side(self) -> None:
+        """An aggregate splits the pipes; each adjacent same-executor pair fuses on its own."""
+        ex = _FakeProcessPool()
+        runs = _find_fusable_runs(
+            [
+                _pool_pipe(ex),
+                _pool_pipe(ex),
+                Aggregate(4),
+                _pool_pipe(ex),
+                _pool_pipe(ex),
+            ]
+        )
+        self.assertEqual(runs, [_FusableRun(0, 2, ex), _FusableRun(3, 5, ex)])
+
+    def test_trailing_aggregate_not_fused(self) -> None:
+        """A trailing aggregate is left in the main process; only the pool pipes fuse."""
+        ex = _FakeProcessPool()
+        runs = _find_fusable_runs([_pool_pipe(ex), _pool_pipe(ex), Aggregate(4)])
+        self.assertEqual(runs, [_FusableRun(0, 2, ex)])
+
+    def test_single_pool_pipe_with_trailing_aggregate_not_fused(self) -> None:
+        """A lone pool pipe plus a trailing aggregate has no same-executor neighbour: no run."""
+        ex = _FakeProcessPool()
+        runs = _find_fusable_runs([_pool_pipe(ex), Aggregate(4)])
+        self.assertEqual(runs, [])
+
+    def test_trailing_disaggregate_not_fused(self) -> None:
+        """A trailing disaggregate is left in the main process; only the pool pipes fuse."""
+        ex = _FakeProcessPool()
+        runs = _find_fusable_runs([_pool_pipe(ex), _pool_pipe(ex), Disaggregate()])
+        self.assertEqual(runs, [_FusableRun(0, 2, ex)])
+
+    def test_different_executors_do_not_fuse(self) -> None:
+        """Adjacent pool pipes on different executor instances do not fuse."""
+        runs = _find_fusable_runs(
+            [_pool_pipe(_FakeProcessPool()), _pool_pipe(_FakeProcessPool())]
+        )
+        self.assertEqual(runs, [])
+
+    def test_thread_pool_breaks_run(self) -> None:
+        """A thread-pool stage between two pool pipes breaks the run (no fusion)."""
+        ex = _FakeProcessPool()
+        runs = _find_fusable_runs(
+            [_pool_pipe(ex), _pool_pipe(_FakeThreadPool()), _pool_pipe(ex)]
+        )
+        self.assertEqual(runs, [])
+
+    def test_default_executor_breaks_run(self) -> None:
+        """A stage with no executor (default thread pool) breaks the run."""
+        ex = _FakeProcessPool()
+        runs = _find_fusable_runs([_pool_pipe(ex), Pipe(op), _pool_pipe(ex)])
+        self.assertEqual(runs, [])
+
+    def test_async_op_breaks_run(self) -> None:
+        """An async stage breaks the run."""
+        ex = _FakeProcessPool()
+        runs = _find_fusable_runs([_pool_pipe(ex), Pipe(aop), _pool_pipe(ex)])
+        self.assertEqual(runs, [])
+
+    def test_input_ordered_pool_pipe_not_fused(self) -> None:
+        """An input-ordered pool pipe is not fusable and breaks the run."""
+        ex = _FakeProcessPool()
+        ordered = Pipe(op, executor=ex, output_order="input")
+        runs = _find_fusable_runs([_pool_pipe(ex), ordered, _pool_pipe(ex)])
+        self.assertEqual(runs, [])
+
+    def test_lone_pool_pipe_untouched(self) -> None:
+        """A single pool pipe with nothing to combine is left unchanged."""
+        self.assertEqual(_find_fusable_runs([_pool_pipe(_FakeProcessPool())]), [])
+
+    def test_leading_micro_stage_stays_in_main(self) -> None:
+        """A micro-stage before the first pool pipe stays in the main process."""
+        ex = _FakeProcessPool()
+        runs = _find_fusable_runs([Aggregate(4), _pool_pipe(ex), _pool_pipe(ex)])
+        self.assertEqual(runs, [_FusableRun(1, 3, ex)])
+
+    def test_multiple_runs(self) -> None:
+        """Several disjoint fusable runs are all detected."""
+        ex1, ex2 = _FakeProcessPool(), _FakeProcessPool()
+        pipes = [
+            _pool_pipe(ex1),
+            _pool_pipe(ex1),
+            Pipe(op),  # breaker
+            _pool_pipe(ex2),
+            _pool_pipe(ex2),
+        ]
+        runs = _find_fusable_runs(pipes)
+        self.assertEqual(runs, [_FusableRun(0, 2, ex1), _FusableRun(3, 5, ex2)])
+
+    def test_same_executor_separated_by_breaker_not_fused(self) -> None:
+        """The same executor reused across a breaker yields no paying run."""
+        ex = _FakeProcessPool()
+        runs = _find_fusable_runs([_pool_pipe(ex), Pipe(op), _pool_pipe(ex)])
+        self.assertEqual(runs, [])

--- a/tests/pipeline/subprocess_pipeline_fuse_test.py
+++ b/tests/pipeline/subprocess_pipeline_fuse_test.py
@@ -1,0 +1,177 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import sys
+import unittest
+from concurrent.futures import ProcessPoolExecutor
+from typing import Any
+
+from spdl.pipeline import Pipeline, PipelineBuilder, run_pipeline_in_subprocess
+
+
+def add_one(x: int) -> int:
+    return x + 1
+
+
+def times_two(x: int) -> int:
+    return x * 2
+
+
+class _Unpicklable:
+    """An object that refuses to be pickled, to prove it never crosses a process boundary."""
+
+    def __init__(self, value: int) -> None:
+        self.value = value
+
+    def __reduce__(self) -> Any:
+        raise TypeError("_Unpicklable must not be pickled")
+
+
+def wrap(x: int) -> _Unpicklable:
+    return _Unpicklable(x + 1)
+
+
+def unwrap(o: _Unpicklable) -> int:
+    return o.value * 2
+
+
+def _run(pipeline: Pipeline[Any], timeout: float = 60.0) -> list[Any]:
+    with pipeline.auto_stop():
+        return list(pipeline.get_iterator(timeout=timeout))
+
+
+class SubprocessPipelineFuseTest(unittest.TestCase):
+    def test_two_pool_stages_fused_match_unfused(self) -> None:
+        """A fused two-stage process-pool pipeline matches the unfused result."""
+        n = 16
+        ref = sorted((x + 1) * 2 for x in range(n))
+
+        ex = ProcessPoolExecutor(max_workers=2)
+        fused = (
+            PipelineBuilder()
+            .add_source(range(n))
+            .pipe(add_one, executor=ex, concurrency=2)
+            .pipe(times_two, executor=ex, concurrency=3)
+            .add_sink(n)
+            .build(num_threads=4, fuse_subprocess_stages=True)
+        )
+        self.assertEqual(sorted(_run(fused)), ref)
+
+    def test_unpicklable_intermediate_passes_through_fused(self) -> None:
+        """A fused run keeps the op->op handoff in-process, so an unpicklable value works."""
+        n = 12
+        ref = sorted((x + 1) * 2 for x in range(n))
+
+        ex = ProcessPoolExecutor(max_workers=2)
+        fused = (
+            PipelineBuilder()
+            .add_source(range(n))
+            .pipe(wrap, executor=ex, concurrency=2)
+            .pipe(unwrap, executor=ex, concurrency=2)
+            .add_sink(n)
+            .build(num_threads=4, fuse_subprocess_stages=True)
+        )
+        self.assertEqual(sorted(_run(fused)), ref)
+
+    def test_aggregate_between_pool_stages_not_absorbed(self) -> None:
+        """An aggregate between two pool stages stays in the main process (not absorbed).
+
+        Its main-process batching semantics are unchanged: each batch holds exactly
+        ``aggregate``'s size.
+        """
+        n = 12
+        ex = ProcessPoolExecutor(max_workers=2)
+        fused = (
+            PipelineBuilder()
+            .add_source(range(n))
+            .pipe(add_one, executor=ex, concurrency=2)
+            .aggregate(3)
+            .pipe(len, executor=ex, concurrency=2)
+            .add_sink(n)
+            .build(num_threads=4, fuse_subprocess_stages=True)
+        )
+        # Each aggregated batch has exactly 3 items, so every produced value is 3.
+        out = _run(fused)
+        self.assertTrue(all(v == 3 for v in out))
+        self.assertEqual(sum(out), n)
+
+    @unittest.skipUnless(
+        sys.version_info >= (3, 14), "InterpreterPoolExecutor requires Python 3.14+"
+    )
+    def test_interpreter_pool_stages_fused(self) -> None:
+        """Stages sharing an InterpreterPoolExecutor are recognized and fused."""
+        from concurrent.futures import InterpreterPoolExecutor  # pyre-ignore[21]
+
+        n = 12
+        ref = sorted((x + 1) * 2 for x in range(n))
+        ex = InterpreterPoolExecutor(max_workers=2)
+        fused = (
+            PipelineBuilder()
+            .add_source(range(n))
+            .pipe(add_one, executor=ex, concurrency=2)
+            .pipe(times_two, executor=ex, concurrency=2)
+            .add_sink(n)
+            .build(num_threads=4, fuse_subprocess_stages=True)
+        )
+        self.assertEqual(sorted(_run(fused)), ref)
+
+    def test_flag_off_is_unaffected(self) -> None:
+        """Without the flag, the same pipeline runs the stages normally and matches."""
+        n = 10
+        ref = sorted((x + 1) * 2 for x in range(n))
+        ex = ProcessPoolExecutor(max_workers=2)
+        pipeline = (
+            PipelineBuilder()
+            .add_source(range(n))
+            .pipe(add_one, executor=ex, concurrency=2)
+            .pipe(times_two, executor=ex, concurrency=2)
+            .add_sink(n)
+            .build(num_threads=4, fuse_subprocess_stages=False)
+        )
+        self.assertEqual(sorted(_run(pipeline)), ref)
+
+
+class FuseInSubprocessTest(unittest.TestCase):
+    """Fusion composed with whole-pipeline subprocess execution."""
+
+    def test_fused_run_in_subprocess_matches(self) -> None:
+        """A fused config run via run_pipeline_in_subprocess yields the same result."""
+        n = 16
+        ref = sorted((x + 1) * 2 for x in range(n))
+        ex = ProcessPoolExecutor(max_workers=2)
+        config = (
+            PipelineBuilder()
+            .add_source(range(n))
+            .pipe(add_one, executor=ex, concurrency=2)
+            .pipe(times_two, executor=ex, concurrency=3)
+            .add_sink(n)
+            .get_config()
+        )
+        src = run_pipeline_in_subprocess(
+            config, num_threads=4, fuse_subprocess_stages=True
+        )
+        self.assertEqual(sorted(src), ref)
+
+    def test_fused_unpicklable_intermediate_in_subprocess(self) -> None:
+        """The fused handle survives the trip into the pipeline subprocess and the
+        unpicklable op->op handoff stays inside a worker."""
+        n = 12
+        ref = sorted((x + 1) * 2 for x in range(n))
+        ex = ProcessPoolExecutor(max_workers=2)
+        config = (
+            PipelineBuilder()
+            .add_source(range(n))
+            .pipe(wrap, executor=ex, concurrency=2)
+            .pipe(unwrap, executor=ex, concurrency=2)
+            .add_sink(n)
+            .get_config()
+        )
+        src = run_pipeline_in_subprocess(
+            config, num_threads=4, fuse_subprocess_stages=True
+        )
+        self.assertEqual(sorted(src), ref)


### PR DESCRIPTION
Add an opt-in `build(..., fuse_subprocess_stages=True)` (also accepted by `run_pipeline_in_subprocess`) that fuses runs of two or more *adjacent* `Pipe` stages sharing the same process-pool (or interpreter-pool) executor instance into a single stage that executes the run as one nested `Pipeline` inside a worker pool. The op->op handoff then stays inside one worker process: no inter-stage IPC, intermediate values need not be picklable, and each fused stage keeps its own `concurrency` and per-stage stats (the nested pipeline is built with `build_pipeline`, so the normal Task/Queue hooks fire inside the worker).

Pieces:

- `spdl/pipeline/_fuse.py`: `_find_fusable_runs`, a pure, side-effect-free pass that returns the maximal spans of `pipes` that can be combined. Only adjacent completion-ordered pool-pipes on the same executor instance fuse; a different executor, a thread/default/async stage, a path-variants stage, an input-ordered (`output_order="input"`) pool-pipe, an `aggregate`/`disaggregate` micro-stage, or a lone pool-pipe all break a run. Micro-stages are deliberately not absorbed, so their main-process batching semantics are unchanged. Also adds `_is_interpreter_pool` / `_is_isolating_pool`, mirroring `_is_process_pool`, so process pools and (Python 3.14+) interpreter pools are both recognized.
- `_subprocess_pipeline_pool.py`: a main-process-owned worker pool (the streaming counterpart of `_subprocess_worker_pool`) whose workers each run the fused run as a nested pipeline, draining items from a shared input queue and streaming results back. The submit side is a small picklable `_SubprocessPipelineHandle` carrying only the queues, so the same fused stage works whether its node runs in this process or is pickled into a pipeline subprocess. Worker failures are relayed as a picklable `RuntimeError` (carrying the worker-side traceback) and re-raised so the enclosing pipeline fails as usual. Wire messages use integer kinds, not sentinel objects, since a sentinel pickled onto a queue is a different object on the other side.
- `_components/_subprocess_pipe.py`: the main-side bridge stage that feeds items to the pool and forwards results, on a small dedicated thread pool so the blocking queue ops do not starve the enclosing pipeline's shared worker threads.
- `_fuse_subprocess_stages` rewrites a config by replacing each fusable run with one bridge stage (executors stripped so the stages run on the worker's own pool) and returns the spawned pools. Composes with `run_pipeline_in_subprocess`: the fused-stage pools are owned by the main process and the picklable handle rides into the pipeline subprocess with the config, so the per-stage round-trip is removed there too.
- `build_pipeline` / `PipelineBuilder.build` / `run_pipeline_in_subprocess` gain `fuse_subprocess_stages`; the spawned pools are owned by the resulting `Pipeline` (reaped on stop) or reaped via `weakref.finalize` on the returned iterable.

Documents the option in the parallelism guide and covers interpreter pools with a Python 3.14-only test.

Continuous-source support is added in the next commit.