### PR TITLE
[Pipeline] harden subprocess stage fusion error and warning paths

### DIFF
--- a/src/spdl/pipeline/_build.py
+++ b/src/spdl/pipeline/_build.py
@@ -150,8 +150,9 @@ def _build_pipeline(
         # Fuse consecutive same-pool stages so each run executes as one nested pipeline inside a
         # worker pool, eliminating the inter-stage IPC. The pools are owned by the returned
         # Pipeline and reaped when it stops.
+        # stacklevel=4: _fuse_subprocess_stages -> _build_pipeline -> build_pipeline -> user.
         pipeline_cfg, pools = _fuse_subprocess_stages(
-            pipeline_cfg, report_stats_interval=report_stats_interval
+            pipeline_cfg, report_stats_interval=report_stats_interval, stacklevel=4
         )
 
     desc = repr(pipeline_cfg)
@@ -277,7 +278,8 @@ def build_pipeline(
             stage keeps its own ``concurrency`` and per-stage stats. Only adjacent pool stages
             fuse: an ``aggregate``/``disaggregate`` between two pool stages is not fused (it
             keeps its main-process batching) and splits them into separate runs. Has no effect
-            on continuous-source pipelines. Default: ``False``.
+            on continuous-source pipelines (a :py:class:`RuntimeWarning` is emitted if fusable
+            stages are otherwise present). Default: ``False``.
 
             .. versionadded:: 0.6.0
                The ``fuse_subprocess_stages`` argument.
@@ -497,7 +499,8 @@ def run_pipeline_in_subprocess(
             ``ProcessPoolExecutor``; the pipeline subprocess drives them through a queue handle.
             This removes the per-stage round-trip between the pipeline subprocess and the pool
             workers (so intermediate values need not be picklable). Has no effect on
-            continuous-source pipelines. Default: ``False``.
+            continuous-source pipelines (a :py:class:`RuntimeWarning` is emitted if fusable
+            stages are otherwise present). Default: ``False``.
 
             .. versionadded:: 0.6.0
                The ``fuse_subprocess_stages`` argument.
@@ -540,10 +543,12 @@ def run_pipeline_in_subprocess(
     # subprocess with the config, where the bridge stage drives the main-owned workers.
     fuse_pools: list[Any] = []
     if fuse_subprocess_stages:
+        # stacklevel=3: _fuse_subprocess_stages -> run_pipeline_in_subprocess -> user.
         config, fuse_pools = _fuse_subprocess_stages(
             config,
             mp_context=kwargs.get("mp_context"),
             report_stats_interval=report_stats_interval,
+            stacklevel=3,
         )
 
     # Spawn workers for any stdlib ``ProcessPoolExecutor`` in the main process (as children of

--- a/src/spdl/pipeline/_components/_subprocess_pipe.py
+++ b/src/spdl/pipeline/_components/_subprocess_pipe.py
@@ -68,30 +68,71 @@ def _drain_one(q: Any) -> tuple[int, Any] | None:
 
 
 async def _feed(
-    input_queue: AsyncQueue, in_q: Any, num_workers: int, executor: Executor
+    input_queue: AsyncQueue,
+    in_q: Any,
+    num_workers: int,
+    executor: Executor,
+    abort: asyncio.Event,
 ) -> None:
     """Forward items from the stage's input queue to the worker pool, then end the session.
 
-    Sends exactly one ``_SESSION_END`` per worker: a worker stops pulling the instant it
-    receives one, so the per-worker count guarantees each worker ends exactly once even though
-    the input queue is shared.
+    Sends exactly one ``_SESSION_END`` per worker: a worker consumes exactly one such marker to
+    end its current session, so the per-worker count ends every worker exactly once even though
+    the input queue is shared. ``abort`` is set by :py:func:`_collect` on a worker error; once
+    set, forwarding stops early and only the per-worker ``_SESSION_END`` markers are sent, so
+    the workers wind down their current sessions instead of churning through the rest of the
+    stream.
+
+    The next-item ``get`` is raced against ``abort`` rather than awaited directly: on the error
+    path the feeder is often parked here waiting on a slow/idle upstream, and ``abort`` must still
+    interrupt it so the ``_SESSION_END`` markers go out. Otherwise the workers would block on
+    ``in_q`` waiting for a marker that never arrives and :py:func:`_collect` would never see every
+    ``_DONE`` — a hang bounded only by the collector's stall timeout. The pending item is dropped
+    because the pipeline is already failing.
     """
     loop = asyncio.get_running_loop()
-    while True:
-        item = await input_queue.get()
-        if is_eof(item):
-            break
-        await loop.run_in_executor(executor, _put, in_q, (_ITEM, item))
+    abort_wait = create_task(abort.wait())
+    try:
+        while not abort.is_set():
+            get_task = create_task(input_queue.get())
+            try:
+                await asyncio.wait(
+                    {get_task, abort_wait}, return_when=asyncio.FIRST_COMPLETED
+                )
+                if not get_task.done():
+                    break  # abort fired while parked on get; stop feeding
+                item = get_task.result()
+            finally:
+                get_task.cancel()
+            if is_eof(item):
+                break
+            await loop.run_in_executor(executor, _put, in_q, (_ITEM, item))
+    finally:
+        abort_wait.cancel()
     for _ in range(num_workers):
         await loop.run_in_executor(executor, _put, in_q, (_SESSION_END, None))
 
 
 async def _collect(
-    out_q: Any, num_workers: int, output_queue: AsyncQueue, executor: Executor
+    out_q: Any,
+    num_workers: int,
+    output_queue: AsyncQueue,
+    executor: Executor,
+    abort: asyncio.Event,
 ) -> None:
-    """Forward worker results to the stage's output queue until every worker is done."""
+    """Forward worker results to the stage's output queue until every worker is done.
+
+    On a worker ``_ERROR``, the first error is kept and ``abort`` is set (so the feeder stops
+    sending new items), but draining continues until every worker has reported ``_DONE`` before
+    the error is re-raised. Raising immediately would leave the still-running workers blocked on
+    the bounded result queue with stale messages behind them, leaving the pool unusable without
+    a full teardown. Results that arrive after the first error are discarded — the enclosing
+    pipeline is already failing, and forwarding them could block on a no-longer-drained output
+    queue.
+    """
     loop = asyncio.get_running_loop()
     done = 0
+    error: BaseException | None = None
     while done < num_workers:
         res = await loop.run_in_executor(executor, _drain_one, out_q)
         if res is None:
@@ -100,9 +141,13 @@ async def _collect(
         if kind == _DONE:
             done += 1
         elif kind == _ERROR:
-            raise payload
-        elif kind == _RESULT:
+            if error is None:
+                error = payload
+                abort.set()
+        elif kind == _RESULT and error is None:
             await output_queue.put(payload)
+    if error is not None:
+        raise error
 
 
 async def _subprocess_pipeline(
@@ -124,9 +169,13 @@ async def _subprocess_pipeline(
     executor = ThreadPoolExecutor(
         max_workers=2, thread_name_prefix="spdl_fused_bridge_"
     )
+    # Set by the collector on a worker error so the feeder stops forwarding new items promptly.
+    abort = asyncio.Event()
     async with _queue_stage_hook(output_queue):
-        feeder = create_task(_feed(input_queue, in_q, num_workers, executor))
-        collector = create_task(_collect(out_q, num_workers, output_queue, executor))
+        feeder = create_task(_feed(input_queue, in_q, num_workers, executor, abort))
+        collector = create_task(
+            _collect(out_q, num_workers, output_queue, executor, abort)
+        )
         try:
             await asyncio.gather(feeder, collector)
         except BaseException:

--- a/src/spdl/pipeline/_fuse.py
+++ b/src/spdl/pipeline/_fuse.py
@@ -259,14 +259,14 @@ def _pool_params(executor: Executor) -> tuple[int, Any, tuple[Any, ...]]:
     return max_workers, user_initializer, user_initargs
 
 
-def _warn_fork_with_threads(ctx: Any) -> None:
+def _warn_fork_with_threads(ctx: Any, stacklevel: int) -> None:
     if ctx.get_start_method() == "fork" and threading.active_count() > 1:
         warnings.warn(
             "Fusing subprocess pipeline stages with the 'fork' start method from a "
             "multi-threaded process can deadlock. Pass mp_context='spawn' or 'forkserver', "
             "or build the pipeline before other threads start.",
             RuntimeWarning,
-            stacklevel=3,
+            stacklevel=stacklevel,
         )
 
 
@@ -308,6 +308,7 @@ def _fuse_subprocess_stages(
     *,
     mp_context: str | None = None,
     report_stats_interval: float = -1,
+    stacklevel: int = 3,
 ) -> tuple[PipelineConfig[Any], list[_SubprocessPipelinePool]]:
     """Replace fusable runs of pool-pipe stages with single subprocess-pipeline stages.
 
@@ -317,7 +318,9 @@ def _fuse_subprocess_stages(
     not mutated.
 
     Fusion is skipped for continuous-source pipelines (epoch-end markers would be mishandled by
-    the fused source); such configs are returned unchanged.
+    the fused source); such configs are returned unchanged. When fusion was actually applicable
+    (the config has fusable runs) but is skipped for this reason, a :py:class:`RuntimeWarning`
+    is emitted so the caller's explicit ``fuse_subprocess_stages=True`` does not silently no-op.
 
     Args:
         config: The pipeline configuration to rewrite.
@@ -325,18 +328,29 @@ def _fuse_subprocess_stages(
             :py:func:`multiprocessing.get_context`.
         report_stats_interval: Forwarded to the nested ``build_pipeline`` so per-stage stats are
             reported from inside the workers.
+        stacklevel: ``warnings.warn`` stack level for a warning emitted directly by this
+            function, set by the caller so the warning points at the user's call site. The
+            fork-with-threads warning is one frame deeper and uses ``stacklevel + 1``.
 
     Returns:
         A tuple ``(new_config, pools)``. ``pools`` is empty when no fusion applies.
     """
-    if _has_continuous_source(config):
-        return config, []
     runs = _find_fusable_runs(config.pipes)
     if not runs:
         return config, []
 
+    if _has_continuous_source(config):
+        warnings.warn(
+            "fuse_subprocess_stages=True has no effect on continuous-source pipelines; the "
+            "fusable stages were left unfused (the fused source cannot handle epoch-end "
+            "markers).",
+            RuntimeWarning,
+            stacklevel=stacklevel,
+        )
+        return config, []
+
     ctx = mp.get_context(mp_context)
-    _warn_fork_with_threads(ctx)
+    _warn_fork_with_threads(ctx, stacklevel + 1)
 
     pools: list[_SubprocessPipelinePool] = []
     by_start = {r.start: r for r in runs}

--- a/src/spdl/pipeline/_subprocess_pipeline_pool.py
+++ b/src/spdl/pipeline/_subprocess_pipeline_pool.py
@@ -84,31 +84,56 @@ def _pipeline_worker_loop(
     from spdl.pipeline._build import build_pipeline
 
     if initializer is not None:
-        initializer(*initargs)
+        try:
+            initializer(*initargs)
+        except Exception as err:
+            # A failed initializer leaves this worker unable to run any session. Relay the error
+            # (followed by a ``_DONE`` so the bridge collector's per-worker accounting stays
+            # balanced) instead of exiting silently — a silent exit would hang the collector
+            # waiting for messages this dead worker can never send. ``KeyboardInterrupt`` /
+            # ``SystemExit`` deliberately propagate so the worker actually exits.
+            out_q.put((_ERROR, _to_picklable_error(err, traceback.format_exc())))
+            out_q.put((_DONE, None))
+            return
 
     exiting = False
+    session_ended = False
 
     def _drain() -> Any:
-        nonlocal exiting
+        nonlocal exiting, session_ended
         while True:
             kind, payload = in_q.get()
             if kind == _ITEM:
                 yield payload
             elif kind == _SESSION_END:
+                session_ended = True
                 return
             else:  # _POOL_SHUTDOWN
                 exiting = True
                 return
 
     while not exiting:
+        session_ended = False
         cfg = replace(sub_config, src=SourceConfig(_drain()))
         try:
             pipeline = build_pipeline(cfg, **build_kwargs)
             with pipeline.auto_stop():
                 for out in pipeline:
                     out_q.put((_RESULT, out))
-        except BaseException as err:  # noqa: B036 - relayed to the submitter below
+        except Exception as err:  # relayed to the submitter below
             out_q.put((_ERROR, _to_picklable_error(err, traceback.format_exc())))
+            # A pipeline failure abandons the source generator mid-session, so this session's
+            # remaining input (up to its ``_SESSION_END``) is still queued. Consume it here so
+            # the session emits exactly one ``_DONE`` and stays aligned with the one-per-worker
+            # ``_SESSION_END`` accounting on the feeder side — otherwise a retry session would
+            # consume that marker and emit a second, stray ``_DONE``. ``KeyboardInterrupt`` /
+            # ``SystemExit`` are not caught, so they tear the worker down as expected.
+            while not session_ended and not exiting:
+                kind, _ = in_q.get()
+                if kind == _SESSION_END:
+                    session_ended = True
+                elif kind == _POOL_SHUTDOWN:
+                    exiting = True
         out_q.put((_DONE, None))
 
 

--- a/tests/pipeline/subprocess_pipeline_fuse_test.py
+++ b/tests/pipeline/subprocess_pipeline_fuse_test.py
@@ -6,17 +6,31 @@
 
 # pyre-strict
 
+import asyncio
+import queue as _queue
 import sys
 import unittest
 from collections.abc import AsyncIterator, Iterator
-from concurrent.futures import ProcessPoolExecutor
+from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor
 from typing import Any
 
-from spdl.pipeline import Pipeline, PipelineBuilder, run_pipeline_in_subprocess
+from spdl.pipeline import (
+    AsyncQueue,
+    Pipeline,
+    PipelineBuilder,
+    PipelineFailure,
+    run_pipeline_in_subprocess,
+)
+from spdl.pipeline._components import _subprocess_pipe
+from spdl.pipeline._components._common import StageInfo
 
 
 def add_one(x: int) -> int:
     return x + 1
+
+
+def _raise_initializer() -> None:
+    raise RuntimeError("initializer boom")
 
 
 def times_two(x: int) -> int:
@@ -166,6 +180,39 @@ class SubprocessPipelineFuseTest(unittest.TestCase):
         )
         self.assertEqual(sorted(_run(fused)), ref)
 
+    def test_initializer_failure_surfaces_not_hangs(self) -> None:
+        """A worker initializer that raises surfaces as a failure instead of hanging.
+
+        A real failure surfaces as :py:class:`PipelineFailure`; a hung pipeline would instead
+        raise :py:class:`TimeoutError` from the finite ``get_iterator`` timeout, so asserting on
+        ``PipelineFailure`` proves the failed initializer is reported rather than wedging the
+        collector forever.
+        """
+        ex = ProcessPoolExecutor(max_workers=2, initializer=_raise_initializer)
+        fused = (
+            PipelineBuilder()
+            .add_source(range(2))
+            .pipe(add_one, executor=ex, concurrency=2)
+            .pipe(times_two, executor=ex, concurrency=2)
+            .add_sink(4)
+            .build(num_threads=4, fuse_subprocess_stages=True)
+        )
+        with self.assertRaises(PipelineFailure):
+            _run(fused, timeout=30.0)
+
+    def test_continuous_source_fusion_warns(self) -> None:
+        """fuse_subprocess_stages=True on a continuous source warns, not a silent no-op."""
+        ex = ProcessPoolExecutor(max_workers=2)
+        builder = (
+            PipelineBuilder()
+            .add_source(range(4), continuous=True)
+            .pipe(add_one, executor=ex, concurrency=2)
+            .pipe(times_two, executor=ex, concurrency=2)
+            .add_sink(4)
+        )
+        with self.assertWarnsRegex(RuntimeWarning, "continuous-source"):
+            builder.build(num_threads=4, fuse_subprocess_stages=True)
+
     def test_flag_off_is_unaffected(self) -> None:
         """Without the flag, the same pipeline runs the stages normally and matches."""
         n = 10
@@ -221,3 +268,36 @@ class FuseInSubprocessTest(unittest.TestCase):
             config, num_threads=4, fuse_subprocess_stages=True
         )
         self.assertEqual(sorted(src), ref)
+
+
+class FeedAbortTest(unittest.TestCase):
+    """The bridge feeder must wind down promptly when the collector signals abort."""
+
+    def test_feed_ends_session_when_aborted_while_idle(self) -> None:
+        """A feeder parked on an empty input queue still emits the per-worker _SESSION_END.
+
+        On a worker error the collector sets ``abort`` while the feeder is typically blocked
+        waiting on a slow/idle upstream. The feeder must wake and send one ``_SESSION_END`` per
+        worker so the collector can drain every ``_DONE`` instead of hanging until its stall
+        timeout. Driving ``_feed`` directly keeps the abort-while-idle race deterministic.
+        """
+        num_workers = 3
+
+        async def _scenario() -> list[Any]:
+            in_q: _queue.Queue[Any] = _queue.Queue()
+            input_queue = AsyncQueue(
+                StageInfo(pipeline_id=0, stage_id="0", stage_name="input")
+            )  # stays empty -> get() blocks
+            abort = asyncio.Event()
+            with ThreadPoolExecutor(max_workers=2) as ex:
+                task = asyncio.ensure_future(
+                    _subprocess_pipe._feed(input_queue, in_q, num_workers, ex, abort)
+                )
+                await asyncio.sleep(0.1)  # let the feeder park on input_queue.get()
+                self.assertFalse(task.done(), "feeder should be parked on empty queue")
+                abort.set()
+                await asyncio.wait_for(task, timeout=5.0)
+            return [in_q.get_nowait() for _ in range(in_q.qsize())]
+
+        msgs = asyncio.run(_scenario())
+        self.assertEqual(msgs, [(_subprocess_pipe._SESSION_END, None)] * num_workers)


### PR DESCRIPTION
Address review feedback on the subprocess pipe-stage fusion feature, covering the worker/bridge protocol, the fusion entry points, and the bridge collector.

- Initializer failures no longer hang the pipeline. If a user-provided executor `initializer` raises inside a fused worker, the worker now relays the error (and a `_DONE`) over the result queue instead of exiting silently, so the bridge collector fails the pipeline rather than blocking forever waiting for messages a dead worker can never send.

- Worker error handling catches `Exception` instead of `BaseException`, so `KeyboardInterrupt`/`SystemExit` propagate and actually tear the worker down rather than being relayed as a `RuntimeError`.

- On a sub-pipeline failure, the worker now drains the rest of its current session before emitting exactly one `_DONE`, keeping it aligned with the per-worker `_SESSION_END` accounting (a retry session would otherwise consume that marker and emit a stray `_DONE`).

- The bridge collector keeps the first worker error and signals the feeder to stop forwarding new items, but continues draining until every worker reports `_DONE` before re-raising. Raising immediately left surviving workers blocked on the bounded result queue with stale messages behind them, leaving the pool unusable without a full teardown. Results arriving after the first error are discarded.

- `fuse_subprocess_stages=True` on a continuous-source pipeline now emits a `RuntimeWarning` when fusable stages are present, instead of silently no-opping.

- The fork-with-threads `RuntimeWarning` now uses a `stacklevel` threaded from the public entry points (`build_pipeline`, `run_pipeline_in_subprocess`) so it points at the user call site rather than at internal fusion code.

Adds regression tests for the initializer-failure path and the continuous-source warning.