### PR TITLE
[Pipeline] Support continuous sources in fused subprocess execution

### DIFF
--- a/docs/source/getting_started/parallelism.rst
+++ b/docs/source/getting_started/parallelism.rst
@@ -362,11 +362,17 @@ pool is owned by the main process and the run executes in those workers — so
 the per-stage round-trip between the pipeline subprocess and the pool is
 removed as well.
 
+Fusion also works with a **continuous source**
+(:py:meth:`~spdl.pipeline.PipelineBuilder.add_source(..., continuous=True)
+<spdl.pipeline.PipelineBuilder.add_source>`). The worker sub-pipelines run in
+continuous mode and stay warm across epochs, and epoch boundaries are
+propagated across the pool: each fused stage emits one epoch boundary per epoch
+just like an unfused pipeline.
+
 .. note::
 
    Fusion preserves results but produces them in completion order across the
-   pool workers. Stages built with ``output_order="input"`` are not fused, and
-   fusion has no effect on continuous-source pipelines.
+   pool workers. Stages built with ``output_order="input"`` are not fused.
 
 Multi-threading in subprocess
 -----------------------------

--- a/src/spdl/pipeline/_build.py
+++ b/src/spdl/pipeline/_build.py
@@ -277,9 +277,9 @@ def build_pipeline(
             between each stage (so intermediate values need not be picklable), while each fused
             stage keeps its own ``concurrency`` and per-stage stats. Only adjacent pool stages
             fuse: an ``aggregate``/``disaggregate`` between two pool stages is not fused (it
-            keeps its main-process batching) and splits them into separate runs. Has no effect
-            on continuous-source pipelines (a :py:class:`RuntimeWarning` is emitted if fusable
-            stages are otherwise present). Default: ``False``.
+            keeps its main-process batching) and splits them into separate runs. Continuous
+            sources are supported (the fused worker sub-pipelines stay warm across epochs and
+            epoch boundaries are propagated across the pool). Default: ``False``.
 
             .. versionadded:: 0.6.0
                The ``fuse_subprocess_stages`` argument.
@@ -498,9 +498,8 @@ def run_pipeline_in_subprocess(
             processes are spawned in (and owned by) the main process, exactly like a hoisted
             ``ProcessPoolExecutor``; the pipeline subprocess drives them through a queue handle.
             This removes the per-stage round-trip between the pipeline subprocess and the pool
-            workers (so intermediate values need not be picklable). Has no effect on
-            continuous-source pipelines (a :py:class:`RuntimeWarning` is emitted if fusable
-            stages are otherwise present). Default: ``False``.
+            workers (so intermediate values need not be picklable). Continuous sources are
+            supported. Default: ``False``.
 
             .. versionadded:: 0.6.0
                The ``fuse_subprocess_stages`` argument.

--- a/src/spdl/pipeline/_components/__init__.py
+++ b/src/spdl/pipeline/_components/__init__.py
@@ -23,6 +23,8 @@ from ._queue import (
 )
 from ._subprocess_pipe import (
     _DONE,
+    _EPOCH,
+    _EPOCH_DONE,
     _ERROR,
     _ITEM,
     _POOL_SHUTDOWN,
@@ -34,6 +36,8 @@ from ._subprocess_pipe import (
 __all__ = [
     "_build_pipeline_coro",
     "_DONE",
+    "_EPOCH",
+    "_EPOCH_DONE",
     "_ERROR",
     "_ITEM",
     "_POOL_SHUTDOWN",

--- a/src/spdl/pipeline/_components/_subprocess_pipe.py
+++ b/src/spdl/pipeline/_components/_subprocess_pipe.py
@@ -12,23 +12,35 @@ A fused run of pipe stages (see :py:mod:`spdl.pipeline._fuse`) is replaced by a 
 whose coroutine, defined here, streams items to a worker pool that runs the run as a nested
 :py:class:`~spdl.pipeline.Pipeline`, and streams the results back. The pool itself lives in
 :py:mod:`spdl.pipeline._subprocess_pipeline_pool`; this stage only talks to it through the
-shared queues carried by a handle.
+queues carried by a handle.
+
+There are two modes, selected by ``handle.continuous``:
+
+- **Non-continuous:** items are fed onto one shared queue that the workers steal from, and the
+  stage finishes when every worker reports ``_DONE``.
+- **Continuous:** the source emits epoch boundaries (``_EPOCH_END``). Each worker has its own
+  input queue so a boundary can be broadcast to all of them, and the collector applies the same
+  cross-stream barrier as :py:func:`spdl.pipeline._components._pipe._default_merge` — it emits one
+  ``_EPOCH_END`` downstream only once every worker has reached the boundary. The feeder gates the
+  next epoch's items behind that barrier so epochs stay correctly ordered across the pool.
 
 The wire protocol uses small integer message kinds (not sentinel objects): a sentinel pickled
 onto a multiprocessing queue is a different object on the other side, so identity comparison
-would not survive the trip.
+would not survive the trip. ``_EPOCH_END`` itself never crosses — it is translated to the
+``_EPOCH`` tag on the way in and re-emitted locally on the way out.
 """
 
 from __future__ import annotations
 
 import asyncio
 import queue as _queue
+import time
 from concurrent.futures import Executor, ThreadPoolExecutor
 from typing import Any
 
 from spdl.pipeline._common._misc import create_task
 
-from ._common import is_eof
+from ._common import _EPOCH_END, is_eof, is_epoch_end
 from ._queue import _queue_stage_hook, AsyncQueue
 
 __all__ = [
@@ -36,24 +48,35 @@ __all__ = [
     "_ITEM",
     "_SESSION_END",
     "_POOL_SHUTDOWN",
+    "_EPOCH",
     "_RESULT",
     "_ERROR",
     "_DONE",
+    "_EPOCH_DONE",
 ]
 
 # Input-queue message kinds (this stage -> worker).
 _ITEM = 0  # (_ITEM, value): one item for the sub-pipeline source
 _SESSION_END = 1  # (_SESSION_END, None): end of one input stream; finish the session
 _POOL_SHUTDOWN = 2  # (_POOL_SHUTDOWN, None): tear the worker down entirely
+_EPOCH = 3  # (_EPOCH, None): end of the current epoch (continuous mode); keep the worker alive
 
 # Output-queue message kinds (worker -> this stage).
 _RESULT = 0  # (_RESULT, value): one produced item
 _ERROR = 1  # (_ERROR, exc): the sub-pipeline failed
-_DONE = 2  # (_DONE, None): a worker finished the current session
+_DONE = 2  # (_DONE, None): a worker finished (session end, or exiting)
+_EPOCH_DONE = (
+    3  # (_EPOCH_DONE, None): a worker reached an epoch boundary (continuous mode)
+)
 
 # How long a blocking get may wait before yielding control, so the awaiting coroutine can
 # observe cancellation between polls instead of parking a thread on an indefinite get.
 _GET_TIMEOUT: float = 0.5
+
+# Fixed bound (15 min) on how long the collector waits for any worker message before assuming a
+# worker died abruptly and raising, instead of hanging forever. Comfortably above any per-stage
+# latency in a data loader. Not user-configurable for now.
+_WORKER_STALL_TIMEOUT: float = 900.0
 
 
 def _put(q: Any, msg: tuple[int, Any]) -> None:
@@ -67,14 +90,37 @@ def _drain_one(q: Any) -> tuple[int, Any] | None:
         return None
 
 
+def _check_stall(last_progress: float) -> None:
+    """Raise if no worker message has arrived within ``_WORKER_STALL_TIMEOUT`` seconds.
+
+    A worker that dies abruptly (segfault, OOM-kill, external ``SIGKILL``) bypasses the worker
+    loop's ``except`` and emits neither ``_ERROR`` nor ``_DONE``, so the collector would otherwise
+    spin on empty reads forever and hang the enclosing pipeline. This bounds that wait. Any worker
+    message (result, epoch boundary, done, error) counts as progress and resets the clock, so the
+    bound only needs to exceed the slowest expected gap between messages.
+    """
+    if time.monotonic() - last_progress > _WORKER_STALL_TIMEOUT:
+        raise TimeoutError(
+            f"Fused subprocess stage received no worker message for "
+            f"{_WORKER_STALL_TIMEOUT:.0f}s; a worker process may have died abruptly "
+            "(e.g. segfault or OOM-kill)."
+        )
+
+
+########################################################################################
+# Non-continuous: shared work-stealing input queue, finish when all workers report _DONE.
+########################################################################################
+
+
 async def _feed(
     input_queue: AsyncQueue,
     in_q: Any,
     num_workers: int,
     executor: Executor,
     abort: asyncio.Event,
+    feeder_idle: asyncio.Event,
 ) -> None:
-    """Forward items from the stage's input queue to the worker pool, then end the session.
+    """Forward items to the shared worker queue, then end the session.
 
     Sends exactly one ``_SESSION_END`` per worker: a worker consumes exactly one such marker to
     end its current session, so the per-worker count ends every worker exactly once even though
@@ -95,6 +141,7 @@ async def _feed(
     try:
         while not abort.is_set():
             get_task = create_task(input_queue.get())
+            feeder_idle.set()
             try:
                 await asyncio.wait(
                     {get_task, abort_wait}, return_when=asyncio.FIRST_COMPLETED
@@ -104,6 +151,7 @@ async def _feed(
                 item = get_task.result()
             finally:
                 get_task.cancel()
+                feeder_idle.clear()
             if is_eof(item):
                 break
             await loop.run_in_executor(executor, _put, in_q, (_ITEM, item))
@@ -119,6 +167,7 @@ async def _collect(
     output_queue: AsyncQueue,
     executor: Executor,
     abort: asyncio.Event,
+    feeder_idle: asyncio.Event,
 ) -> None:
     """Forward worker results to the stage's output queue until every worker is done.
 
@@ -129,14 +178,24 @@ async def _collect(
     a full teardown. Results that arrive after the first error are discarded — the enclosing
     pipeline is already failing, and forwarding them could block on a no-longer-drained output
     queue.
+
+    The stall guard is suppressed while ``feeder_idle`` is set: an idle feeder means nothing is
+    dispatched and no worker message is due, so a quiet ``out_q`` is input starvation, not a
+    dead worker.
     """
     loop = asyncio.get_running_loop()
     done = 0
     error: BaseException | None = None
+    last_progress = time.monotonic()
     while done < num_workers:
         res = await loop.run_in_executor(executor, _drain_one, out_q)
         if res is None:
+            if feeder_idle.is_set():
+                last_progress = time.monotonic()  # input-starved, not a stalled worker
+            else:
+                _check_stall(last_progress)
             continue  # timeout — loop so cancellation can be observed
+        last_progress = time.monotonic()
         kind, payload = res
         if kind == _DONE:
             done += 1
@@ -148,6 +207,109 @@ async def _collect(
             await output_queue.put(payload)
     if error is not None:
         raise error
+
+
+########################################################################################
+# Continuous: per-worker input queues, epoch broadcast + barrier across the pool.
+########################################################################################
+
+
+async def _feed_continuous(
+    input_queue: AsyncQueue,
+    in_qs: list[Any],
+    executor: Executor,
+    epoch_barrier: asyncio.Event,
+    feeder_idle: asyncio.Event,
+) -> None:
+    """Round-robin items to per-worker queues; broadcast and barrier each epoch boundary.
+
+    On an epoch boundary the next epoch's items must not be fed until every worker has drained
+    the current epoch (otherwise results from two epochs would interleave). The feeder therefore
+    broadcasts ``_EPOCH`` to all workers and waits on ``epoch_barrier``, which the collector sets
+    once it has emitted the epoch's single ``_EPOCH_END`` downstream.
+
+    A single shared ``epoch_barrier`` is sufficient (rather than one per epoch) only because the
+    feeder cannot advance past a boundary until the collector releases it: the feeder and
+    collector strictly alternate one epoch at a time, so the ``clear()``/``set()`` never race.
+    """
+    loop = asyncio.get_running_loop()
+
+    async def _broadcast(msg: tuple[int, Any]) -> None:
+        # Concurrent so a full/slow worker queue does not block the broadcast to the others.
+        await asyncio.gather(
+            *(loop.run_in_executor(executor, _put, q, msg) for q in in_qs)
+        )
+
+    i = 0
+    n = len(in_qs)
+    while True:
+        feeder_idle.set()
+        item = await input_queue.get()
+        feeder_idle.clear()
+        if is_eof(item):
+            await _broadcast((_POOL_SHUTDOWN, None))
+            break
+        if is_epoch_end(item):
+            epoch_barrier.clear()
+            await _broadcast((_EPOCH, None))
+            await epoch_barrier.wait()
+            continue
+        await loop.run_in_executor(executor, _put, in_qs[i % n], (_ITEM, item))
+        i += 1
+
+
+async def _collect_continuous(
+    out_q: Any,
+    num_workers: int,
+    output_queue: AsyncQueue,
+    executor: Executor,
+    epoch_barrier: asyncio.Event,
+    feeder_idle: asyncio.Event,
+) -> None:
+    """Forward results; emit one ``_EPOCH_END`` per epoch once all workers reach the boundary.
+
+    Mirrors the fan-in barrier in
+    :py:func:`spdl.pipeline._components._pipe._default_merge`: count ``_EPOCH_DONE`` across the
+    workers and, when all ``num_workers`` have reported, emit a single ``_EPOCH_END`` and release
+    the feeder. Finishes when every worker reports ``_DONE`` (graceful shutdown); on normal
+    pipeline stop this coroutine is cancelled instead.
+
+    The stall guard is suppressed while ``feeder_idle`` is set (e.g. between epochs, waiting on a
+    slow upstream for the next epoch's first item), where a quiet ``out_q`` is expected rather
+    than a sign of a dead worker.
+    """
+    loop = asyncio.get_running_loop()
+    workers_at_boundary = 0
+    done = 0
+    last_progress = time.monotonic()
+    while done < num_workers:
+        res = await loop.run_in_executor(executor, _drain_one, out_q)
+        if res is None:
+            if feeder_idle.is_set():
+                last_progress = time.monotonic()  # input-starved, not a stalled worker
+            else:
+                _check_stall(last_progress)
+            continue
+        last_progress = time.monotonic()
+        kind, payload = res
+        if kind == _RESULT:
+            await output_queue.put(payload)
+        elif kind == _EPOCH_DONE:
+            workers_at_boundary += 1
+            if workers_at_boundary >= num_workers:
+                workers_at_boundary = 0
+                await output_queue.put(_EPOCH_END)
+                epoch_barrier.set()
+        elif kind == _ERROR:
+            # Raise immediately rather than draining to every ``_DONE`` like :py:func:`_collect`.
+            # A continuous worker only emits ``_ERROR`` on a fatal sub-pipeline failure and then
+            # exits, so there is no warm pool left to preserve — the failure tears the whole
+            # pipeline (and pool) down. Draining-to-``_DONE`` would also deadlock here: the other
+            # workers stay warm waiting for the next epoch and never send ``_DONE`` without a
+            # shutdown. Surviving workers are unblocked by the pool teardown that follows.
+            raise payload
+        elif kind == _DONE:
+            done += 1
 
 
 async def _subprocess_pipeline(
@@ -164,18 +326,44 @@ async def _subprocess_pipeline(
     not occupy the enclosing pipeline's shared worker threads (which would starve its other
     stages).
     """
-    in_q, out_q, num_workers = handle.in_q, handle.out_q, handle.max_workers
-    # Two threads: one parked on the feeder put, one on the collector get.
+    in_qs, out_q = handle.in_qs, handle.out_q
+    num_workers = handle.max_workers
+    # One thread parked per concurrent blocking op: a put per input queue plus the collector get.
+    max_threads = (len(in_qs) if handle.continuous else 1) + 1
     executor = ThreadPoolExecutor(
-        max_workers=2, thread_name_prefix="spdl_fused_bridge_"
+        max_workers=max_threads, thread_name_prefix="spdl_fused_bridge_"
     )
-    # Set by the collector on a worker error so the feeder stops forwarding new items promptly.
-    abort = asyncio.Event()
+    # Set by the feeder whenever it is parked waiting on the upstream queue. The collector reads
+    # it to tell input starvation (no work dispatched, no worker message expected) apart from an
+    # unresponsive worker, so its stall guard does not fire spuriously on a slow/idle source.
+    feeder_idle = asyncio.Event()
     async with _queue_stage_hook(output_queue):
-        feeder = create_task(_feed(input_queue, in_q, num_workers, executor, abort))
-        collector = create_task(
-            _collect(out_q, num_workers, output_queue, executor, abort)
-        )
+        if handle.continuous:
+            epoch_barrier = asyncio.Event()
+            feeder = create_task(
+                _feed_continuous(
+                    input_queue, in_qs, executor, epoch_barrier, feeder_idle
+                )
+            )
+            collector = create_task(
+                _collect_continuous(
+                    out_q,
+                    num_workers,
+                    output_queue,
+                    executor,
+                    epoch_barrier,
+                    feeder_idle,
+                )
+            )
+        else:
+            # Set by the collector on a worker error so the feeder stops forwarding new items.
+            abort = asyncio.Event()
+            feeder = create_task(
+                _feed(input_queue, in_qs[0], num_workers, executor, abort, feeder_idle)
+            )
+            collector = create_task(
+                _collect(out_q, num_workers, output_queue, executor, abort, feeder_idle)
+            )
         try:
             await asyncio.gather(feeder, collector)
         except BaseException:

--- a/src/spdl/pipeline/_fuse.py
+++ b/src/spdl/pipeline/_fuse.py
@@ -275,6 +275,7 @@ def _build_fused_stage(
     executor: Executor,
     ctx: Any,
     report_stats_interval: float,
+    continuous: bool,
 ) -> tuple[_SubprocessPipelineConfig, _SubprocessPipelinePool]:
     """Build the worker pool and replacement stage for one fusable run."""
     stripped = [_strip_executor(s) for s in stages]
@@ -297,7 +298,13 @@ def _build_fused_stage(
         _worker_initializer, _get_global_id(), user_initializer, user_initargs
     )
     pool = _SubprocessPipelinePool(
-        ctx, max_workers, sub_config, build_kwargs, initializer, ()
+        ctx,
+        max_workers,
+        sub_config,
+        build_kwargs,
+        initializer,
+        (),
+        continuous=continuous,
     )
     name = "subprocess_pipeline(" + "+".join(_stage_name(s) for s in stages) + ")"
     return _SubprocessPipelineConfig(name=name, handle=pool.make_handle()), pool
@@ -317,10 +324,9 @@ def _fuse_subprocess_stages(
     spawned pools are returned so the caller can reap them at teardown. The input ``config`` is
     not mutated.
 
-    Fusion is skipped for continuous-source pipelines (epoch-end markers would be mishandled by
-    the fused source); such configs are returned unchanged. When fusion was actually applicable
-    (the config has fusable runs) but is skipped for this reason, a :py:class:`RuntimeWarning`
-    is emitted so the caller's explicit ``fuse_subprocess_stages=True`` does not silently no-op.
+    For a continuous-source pipeline, the fused workers run continuous sub-pipelines and the
+    bridge stage propagates epoch boundaries across the pool (see
+    :py:mod:`spdl.pipeline._components._subprocess_pipe`).
 
     Args:
         config: The pipeline configuration to rewrite.
@@ -328,9 +334,9 @@ def _fuse_subprocess_stages(
             :py:func:`multiprocessing.get_context`.
         report_stats_interval: Forwarded to the nested ``build_pipeline`` so per-stage stats are
             reported from inside the workers.
-        stacklevel: ``warnings.warn`` stack level for a warning emitted directly by this
-            function, set by the caller so the warning points at the user's call site. The
-            fork-with-threads warning is one frame deeper and uses ``stacklevel + 1``.
+        stacklevel: ``warnings.warn`` stack level measured at this function, set by the
+            caller so warnings point at the user's call site. The fork-with-threads warning
+            is one frame deeper and uses ``stacklevel + 1``.
 
     Returns:
         A tuple ``(new_config, pools)``. ``pools`` is empty when no fusion applies.
@@ -339,16 +345,7 @@ def _fuse_subprocess_stages(
     if not runs:
         return config, []
 
-    if _has_continuous_source(config):
-        warnings.warn(
-            "fuse_subprocess_stages=True has no effect on continuous-source pipelines; the "
-            "fusable stages were left unfused (the fused source cannot handle epoch-end "
-            "markers).",
-            RuntimeWarning,
-            stacklevel=stacklevel,
-        )
-        return config, []
-
+    continuous = _has_continuous_source(config)
     ctx = mp.get_context(mp_context)
     _warn_fork_with_threads(ctx, stacklevel + 1)
 
@@ -357,16 +354,29 @@ def _fuse_subprocess_stages(
     pipes = list(config.pipes)
     new_pipes: list[object] = []
     i = 0
-    while i < len(pipes):
-        run = by_start.get(i)
-        if run is None:
-            new_pipes.append(pipes[i])
-            i += 1
-            continue
-        fused, pool = _build_fused_stage(
-            pipes[run.start : run.stop], run.executor, ctx, report_stats_interval
-        )
-        pools.append(pool)
-        new_pipes.append(fused)
-        i = run.stop
+    try:
+        while i < len(pipes):
+            run = by_start.get(i)
+            if run is None:
+                new_pipes.append(pipes[i])
+                i += 1
+                continue
+            fused, pool = _build_fused_stage(
+                pipes[run.start : run.stop],
+                run.executor,
+                ctx,
+                report_stats_interval,
+                continuous,
+            )
+            pools.append(pool)
+            new_pipes.append(fused)
+            i = run.stop
+    except BaseException:
+        # Each pool spawns its workers eagerly, so a failure partway through this loop (e.g. a
+        # later pool fails to spawn) would otherwise leak the workers already started by the
+        # pools built so far. Reap them before propagating, since the caller never receives the
+        # ``pools`` list to reap them itself.
+        for pool in pools:
+            pool.shutdown()
+        raise
     return replace(config, pipes=new_pipes), pools  # pyre-ignore[6]

--- a/src/spdl/pipeline/_subprocess_pipeline_pool.py
+++ b/src/spdl/pipeline/_subprocess_pipeline_pool.py
@@ -9,17 +9,25 @@
 """Main-process-owned worker pools that run a fused sub-pipeline inside each worker.
 
 This is the streaming counterpart of :py:mod:`spdl.pipeline._subprocess_worker_pool`. Where that
-module runs one submitted ``fn(*args)`` per task, here each worker process runs a long-lived
-nested :py:class:`~spdl.pipeline.Pipeline` (built from the fused stages by
-:py:func:`~spdl.pipeline._build.build_pipeline`). Items stream in over a shared input queue and
-results stream back over a shared output queue, so the op→op handoff between fused stages stays
-inside one worker process — no inter-stage IPC, and intermediate values need not be picklable.
+module runs one submitted ``fn(*args)`` per task, here each worker process runs a nested
+:py:class:`~spdl.pipeline.Pipeline` (built from the fused stages by
+:py:func:`~spdl.pipeline._build.build_pipeline`). Items stream in over a queue and results stream
+back over a shared queue, so the op→op handoff between fused stages stays inside one worker
+process — no inter-stage IPC, and intermediate values need not be picklable.
+
+Two layouts, chosen by ``continuous``:
+
+- **Non-continuous:** all workers steal from one shared input queue; each worker runs one session
+  (until ``_SESSION_END``) and reports ``_DONE``.
+- **Continuous:** each worker has its own input queue (so the bridge can broadcast epoch
+  boundaries) and runs a long-lived *continuous* sub-pipeline, emitting ``_EPOCH_DONE`` at each
+  boundary and staying warm across epochs.
 
 Like :py:class:`spdl.pipeline._subprocess_worker_pool._WorkerPool`, the worker processes are
 owned by the main process (spawned here, reaped in :py:meth:`_SubprocessPipelinePool.shutdown`).
 The submit side is a small picklable :py:class:`_SubprocessPipelineHandle` carrying only the
-shared queues, so the fused stage can drive the pool whether its node runs in the main process
-(a normal ``build``) or in a pipeline subprocess (``run_pipeline_in_subprocess``).
+queues, so the fused stage can drive the pool whether its node runs in the main process (a normal
+``build``) or in a pipeline subprocess (``run_pipeline_in_subprocess``).
 
 Messages are tagged with small integer kinds rather than sentinel objects: a sentinel pickled
 onto a queue is a *different* object on the other side, so identity (``is``) comparison would
@@ -30,12 +38,14 @@ from __future__ import annotations
 
 import queue as _queue
 import traceback
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Iterator, Sequence
 from dataclasses import replace
 from typing import Any
 
 from spdl.pipeline._components import (
     _DONE,
+    _EPOCH,
+    _EPOCH_DONE,
     _ERROR,
     _ITEM,
     _POOL_SHUTDOWN,
@@ -49,6 +59,11 @@ __all__ = [
     "_SubprocessPipelinePool",
     "_shutdown_pipeline_pools",
 ]
+
+
+# Poll interval for a worker's blocking queue read, so a drain parked on an empty queue wakes to
+# observe shutdown instead of blocking forever after the pool has been torn down.
+_DRAIN_POLL_TIMEOUT: float = 0.5
 
 
 def _to_picklable_error(err: BaseException, tb: str) -> RuntimeError:
@@ -65,41 +80,53 @@ def _to_picklable_error(err: BaseException, tb: str) -> RuntimeError:
     )
 
 
-def _pipeline_worker_loop(
+class _DrainSource:
+    """Re-iterable source that drains one epoch of items from a worker's input queue.
+
+    Used as a *continuous* source: :py:func:`spdl.pipeline._components._source._source_continuous`
+    calls ``iter()`` once per epoch, so ``__iter__`` must return a fresh generator each time
+    (a one-shot generator object would only ever run one epoch). Each pass yields ``_ITEM``
+    payloads until an ``_EPOCH`` (epoch boundary) or ``_POOL_SHUTDOWN`` (teardown) message.
+
+    ``exiting`` latches once ``_POOL_SHUTDOWN`` is seen; the worker loop reads it to stop after
+    the current epoch. The blocking read uses a timeout so the drain thread wakes periodically
+    to observe shutdown rather than parking forever on an empty queue during teardown.
+    """
+
+    def __init__(self, in_q: Any) -> None:
+        self._in_q = in_q
+        self.exiting = False
+
+    def __iter__(self) -> Iterator[Any]:
+        while True:
+            try:
+                kind, payload = self._in_q.get(timeout=_DRAIN_POLL_TIMEOUT)
+            except _queue.Empty:
+                if self.exiting:
+                    return
+                continue
+            if kind == _ITEM:
+                yield payload
+            elif kind == _EPOCH:
+                return
+            else:  # _POOL_SHUTDOWN
+                self.exiting = True
+                return
+
+
+def _run_sessions(
     in_q: Any,
     out_q: Any,
     sub_config: PipelineConfig[Any],
     build_kwargs: dict[str, Any],
-    initializer: Callable[..., object] | None,
-    initargs: tuple[Any, ...],
 ) -> None:
-    """Worker body: repeatedly build and run the fused sub-pipeline over one input stream.
-
-    Each session drains ``in_q`` into the sub-pipeline's source until a ``_SESSION_END`` (next
-    session) or ``_POOL_SHUTDOWN`` (exit) message, streams the results onto ``out_q``, then
-    emits ``_DONE``. The pipeline is rebuilt per session so its single-use source iterator is
-    fresh, which keeps the pool reusable across epochs without an explicit control channel.
-    """
-    # Imported lazily: ``build_pipeline``'s module (transitively) imports this one.
+    """Non-continuous worker body: one rebuilt sub-pipeline per input stream."""
     from spdl.pipeline._build import build_pipeline
-
-    if initializer is not None:
-        try:
-            initializer(*initargs)
-        except Exception as err:
-            # A failed initializer leaves this worker unable to run any session. Relay the error
-            # (followed by a ``_DONE`` so the bridge collector's per-worker accounting stays
-            # balanced) instead of exiting silently — a silent exit would hang the collector
-            # waiting for messages this dead worker can never send. ``KeyboardInterrupt`` /
-            # ``SystemExit`` deliberately propagate so the worker actually exits.
-            out_q.put((_ERROR, _to_picklable_error(err, traceback.format_exc())))
-            out_q.put((_DONE, None))
-            return
 
     exiting = False
     session_ended = False
 
-    def _drain() -> Any:
+    def _drain() -> Iterator[Any]:
         nonlocal exiting, session_ended
         while True:
             kind, payload = in_q.get()
@@ -137,20 +164,92 @@ def _pipeline_worker_loop(
         out_q.put((_DONE, None))
 
 
+def _run_continuous(
+    in_q: Any,
+    out_q: Any,
+    sub_config: PipelineConfig[Any],
+    build_kwargs: dict[str, Any],
+) -> None:
+    """Continuous worker body: one warm sub-pipeline, one ``_EPOCH_DONE`` per epoch.
+
+    The sub-pipeline is built once with a continuous source draining ``in_q``; each
+    ``for out in pipeline`` pass yields exactly one epoch's results (the continuous pipeline
+    turns each ``_EPOCH_END`` into an iterator stop), after which the worker reports
+    ``_EPOCH_DONE`` and loops for the next epoch — keeping the pipeline's prefetch buffers warm.
+
+    Unlike :py:func:`_run_sessions`, a fatal sub-pipeline error is terminal here: the worker
+    relays ``_ERROR`` + ``_DONE`` and exits rather than rebuilding for a retry. A continuous
+    pipeline has no session boundary to recover at, and the bridge collector fails the whole
+    pipeline (and tears the pool down) on the first ``_ERROR`` anyway, so there is no warm pool
+    worth preserving.
+    """
+    from spdl.pipeline._build import build_pipeline
+
+    source = _DrainSource(in_q)
+    cfg = replace(sub_config, src=SourceConfig(source, continuous=True))
+    try:
+        pipeline = build_pipeline(cfg, **build_kwargs)
+        with pipeline.auto_stop():
+            while not source.exiting:
+                for out in pipeline:
+                    out_q.put((_RESULT, out))
+                if source.exiting:
+                    break
+                out_q.put((_EPOCH_DONE, None))
+    except Exception as err:
+        # Catch ``Exception`` (not ``BaseException``) so ``KeyboardInterrupt`` / ``SystemExit``
+        # propagate and actually tear the worker down, rather than being relayed as a
+        # ``RuntimeError``. Matches :py:func:`_run_sessions` and the worker-loop initializer path.
+        out_q.put((_ERROR, _to_picklable_error(err, traceback.format_exc())))
+    out_q.put((_DONE, None))
+
+
+def _pipeline_worker_loop(
+    in_q: Any,
+    out_q: Any,
+    sub_config: PipelineConfig[Any],
+    build_kwargs: dict[str, Any],
+    continuous: bool,
+    initializer: Callable[..., object] | None,
+    initargs: tuple[Any, ...],
+) -> None:
+    """Worker entry point: run the initializer, then dispatch to the matching body."""
+    if initializer is not None:
+        try:
+            initializer(*initargs)
+        except Exception as err:
+            # A failed initializer leaves this worker unable to run any session. Relay the error
+            # (followed by a ``_DONE`` so the bridge collector's per-worker accounting stays
+            # balanced) instead of exiting silently — a silent exit would hang the collector
+            # waiting for messages this dead worker can never send. ``KeyboardInterrupt`` /
+            # ``SystemExit`` deliberately propagate so the worker actually exits.
+            out_q.put((_ERROR, _to_picklable_error(err, traceback.format_exc())))
+            out_q.put((_DONE, None))
+            return
+    if continuous:
+        _run_continuous(in_q, out_q, sub_config, build_kwargs)
+    else:
+        _run_sessions(in_q, out_q, sub_config, build_kwargs)
+
+
 class _SubprocessPipelineHandle:
     """Picklable submit side of a :py:class:`_SubprocessPipelinePool`.
 
-    Holds only the shared queues and worker count, so it is cheap to carry inside a
+    Holds only the queues, worker count, and mode, so it is cheap to carry inside a
     :py:class:`~spdl.pipeline.defs.PipelineConfig` — including across the pickle boundary into a
     pipeline subprocess (the queues travel as ``Process`` spawn arguments, the only context in
-    which an ``mp.Queue`` may be pickled). The worker processes themselves are owned by the main
-    process, so this handle holds no process references.
+    which an ``mp.Queue`` may be pickled). ``in_qs`` is the shared input queue (length 1) in
+    non-continuous mode, or one queue per worker in continuous mode. The worker processes
+    themselves are owned by the main process, so this handle holds no process references.
     """
 
-    def __init__(self, in_q: Any, out_q: Any, max_workers: int) -> None:
-        self.in_q = in_q
+    def __init__(
+        self, in_qs: list[Any], out_q: Any, max_workers: int, continuous: bool
+    ) -> None:
+        self.in_qs = in_qs
         self.out_q = out_q
         self.max_workers = max_workers
+        self.continuous = continuous
 
 
 class _SubprocessPipelinePool:
@@ -164,27 +263,40 @@ class _SubprocessPipelinePool:
         build_kwargs: dict[str, Any],
         initializer: Callable[..., object] | None,
         initargs: tuple[Any, ...],
+        continuous: bool = False,
     ) -> None:
         # Bound the queues so a slow consumer/producer applies backpressure rather than
         # buffering without limit. Sized to keep every worker fed, plus in-flight slack.
         size = max(4, max_workers * 2)
-        self._in_q: Any = ctx.Queue(maxsize=size)
+        self._continuous = continuous
         self._out_q: Any = ctx.Queue(maxsize=size)
+        if continuous:
+            # One queue per worker so the bridge can broadcast epoch boundaries cleanly.
+            self._in_qs: list[Any] = [
+                ctx.Queue(maxsize=size) for _ in range(max_workers)
+            ]
+            worker_in_qs = self._in_qs
+        else:
+            # One shared queue the workers steal from.
+            shared = ctx.Queue(maxsize=size)
+            self._in_qs = [shared]
+            worker_in_qs = [shared] * max_workers
         self._max_workers = max_workers
         self._procs: list[Any] = [
             ctx.Process(
                 target=_pipeline_worker_loop,
                 args=(
-                    self._in_q,
+                    worker_in_qs[i],
                     self._out_q,
                     sub_config,
                     build_kwargs,
+                    continuous,
                     initializer,
                     initargs,
                 ),
                 daemon=True,
             )
-            for _ in range(max_workers)
+            for i in range(max_workers)
         ]
         started: list[Any] = []
         try:
@@ -198,7 +310,7 @@ class _SubprocessPipelinePool:
             # down and close the queues before propagating, so the failure does not leak
             # processes or pipe fds. Mirrors ``_WorkerPool.__init__``.
             self._terminate(started)
-            for q in (self._in_q, self._out_q):
+            for q in (*self._in_qs, self._out_q):
                 q.close()
                 q.join_thread()
             raise
@@ -217,18 +329,24 @@ class _SubprocessPipelinePool:
 
     def make_handle(self) -> _SubprocessPipelineHandle:
         """Create the picklable submit-side handle that rides in the pipeline config."""
-        return _SubprocessPipelineHandle(self._in_q, self._out_q, self._max_workers)
+        return _SubprocessPipelineHandle(
+            self._in_qs, self._out_q, self._max_workers, self._continuous
+        )
 
-    def shutdown(self) -> None:
-        """Tell every worker to exit, then reap the processes (join → terminate → kill)."""
-        for _ in self._procs:
+    def _broadcast_shutdown(self) -> None:
+        # Continuous: one shutdown per worker queue. Non-continuous: N onto the shared queue,
+        # where each worker consumes exactly one (it stops pulling the instant it gets one).
+        targets = (
+            self._in_qs if self._continuous else [self._in_qs[0]] * self._max_workers
+        )
+        for q in targets:
             try:
-                # Non-blocking: ``_in_q`` is bounded and on the error path workers may have
+                # Non-blocking: the queues are bounded and on the error path workers may have
                 # stalled on a full ``_out_q`` (the bridge stage stops draining after relaying
                 # an ``_ERROR``) and stopped consuming, so a blocking ``put`` would wedge here
                 # forever and never reach the terminate/kill escalation below. A dropped
                 # sentinel is fine — the worker that misses it will be terminated.
-                self._in_q.put_nowait((_POOL_SHUTDOWN, None))
+                q.put_nowait((_POOL_SHUTDOWN, None))
             except _queue.Full:
                 # Expected miss when the queue is saturated; the missing worker is terminated
                 # by the escalation below.
@@ -237,10 +355,14 @@ class _SubprocessPipelinePool:
                 # Any other failure for one worker should not block the others; fall through
                 # to the join/terminate/kill escalation.
                 continue
+
+    def shutdown(self) -> None:
+        """Tell every worker to exit, then reap the processes (join → terminate → kill)."""
+        self._broadcast_shutdown()
         self._terminate(self._procs)
         # Close this process's queue handles so the feeder threads created on first ``put``
         # exit; otherwise a process that creates many pipelines leaks threads and pipe fds.
-        for q in (self._in_q, self._out_q):
+        for q in (*self._in_qs, self._out_q):
             q.close()
             q.join_thread()
 

--- a/tests/pipeline/subprocess_pipeline_fuse_test.py
+++ b/tests/pipeline/subprocess_pipeline_fuse_test.py
@@ -9,6 +9,7 @@
 import asyncio
 import queue as _queue
 import sys
+import time
 import unittest
 from collections.abc import AsyncIterator, Iterator
 from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor
@@ -35,6 +36,10 @@ def _raise_initializer() -> None:
 
 def times_two(x: int) -> int:
     return x * 2
+
+
+def boom(x: int) -> int:
+    raise ValueError("boom")
 
 
 class _Unpicklable:
@@ -200,19 +205,6 @@ class SubprocessPipelineFuseTest(unittest.TestCase):
         with self.assertRaises(PipelineFailure):
             _run(fused, timeout=30.0)
 
-    def test_continuous_source_fusion_warns(self) -> None:
-        """fuse_subprocess_stages=True on a continuous source warns, not a silent no-op."""
-        ex = ProcessPoolExecutor(max_workers=2)
-        builder = (
-            PipelineBuilder()
-            .add_source(range(4), continuous=True)
-            .pipe(add_one, executor=ex, concurrency=2)
-            .pipe(times_two, executor=ex, concurrency=2)
-            .add_sink(4)
-        )
-        with self.assertWarnsRegex(RuntimeWarning, "continuous-source"):
-            builder.build(num_threads=4, fuse_subprocess_stages=True)
-
     def test_flag_off_is_unaffected(self) -> None:
         """Without the flag, the same pipeline runs the stages normally and matches."""
         n = 10
@@ -227,6 +219,159 @@ class SubprocessPipelineFuseTest(unittest.TestCase):
             .build(num_threads=4, fuse_subprocess_stages=False)
         )
         self.assertEqual(sorted(_run(pipeline)), ref)
+
+
+class ContinuousFuseTest(unittest.TestCase):
+    """Fusion with a continuous (multi-epoch) source."""
+
+    def test_multi_epoch_correct(self) -> None:
+        """A continuous fused pipeline yields the correct set each epoch."""
+        n = 12
+        ref = sorted((x + 1) * 2 for x in range(n))
+        ex = ProcessPoolExecutor(max_workers=2)
+        pipeline = (
+            PipelineBuilder()
+            .add_source(range(n), continuous=True)
+            .pipe(add_one, executor=ex, concurrency=2)
+            .pipe(times_two, executor=ex, concurrency=3)
+            .add_sink(n)
+            .build(num_threads=4, fuse_subprocess_stages=True)
+        )
+        with pipeline.auto_stop():
+            for _ in range(3):  # three epochs from the same warm worker pool
+                epoch = sorted(pipeline.get_iterator(timeout=60))
+                self.assertEqual(epoch, ref)
+
+    def test_unpicklable_intermediate_multi_epoch(self) -> None:
+        """The unpicklable op->op handoff keeps working across epochs."""
+        n = 10
+        ref = sorted((x + 1) * 2 for x in range(n))
+        ex = ProcessPoolExecutor(max_workers=2)
+        pipeline = (
+            PipelineBuilder()
+            .add_source(range(n), continuous=True)
+            .pipe(wrap, executor=ex, concurrency=2)
+            .pipe(unwrap, executor=ex, concurrency=2)
+            .add_sink(n)
+            .build(num_threads=4, fuse_subprocess_stages=True)
+        )
+        with pipeline.auto_stop():
+            for _ in range(2):
+                self.assertEqual(sorted(pipeline.get_iterator(timeout=60)), ref)
+
+    def test_aggregate_not_absorbed_multi_epoch(self) -> None:
+        """A non-absorbed aggregate keeps single-flush-per-epoch semantics across epochs.
+
+        Because the aggregate runs in the main process (not per worker), each epoch produces
+        full-size batches plus one combined partial, and every item is accounted for.
+        """
+        n = 12
+        ex = ProcessPoolExecutor(max_workers=2)
+        pipeline = (
+            PipelineBuilder()
+            .add_source(range(n), continuous=True)
+            .pipe(add_one, executor=ex, concurrency=2)
+            .aggregate(3)
+            .pipe(len, executor=ex, concurrency=2)
+            .add_sink(n)
+            .build(num_threads=4, fuse_subprocess_stages=True)
+        )
+        with pipeline.auto_stop():
+            for _ in range(2):  # each epoch's batches cover exactly n items
+                out = list(pipeline.get_iterator(timeout=60))
+                self.assertEqual(sum(out), n)
+
+    def test_fewer_items_than_workers(self) -> None:
+        """An epoch with fewer items than workers still completes (some workers run empty)."""
+        n = 2
+        ref = sorted((x + 1) * 2 for x in range(n))
+        ex = ProcessPoolExecutor(max_workers=4)
+        pipeline = (
+            PipelineBuilder()
+            .add_source(range(n), continuous=True)
+            .pipe(add_one, executor=ex, concurrency=2)
+            .pipe(times_two, executor=ex, concurrency=2)
+            .add_sink(n)
+            .build(num_threads=4, fuse_subprocess_stages=True)
+        )
+        with pipeline.auto_stop():
+            for _ in range(2):
+                self.assertEqual(sorted(pipeline.get_iterator(timeout=60)), ref)
+
+    def test_generator_op_multi_epoch(self) -> None:
+        """A fused generator op keeps its 1->N fan-out correct across epochs."""
+        n = 8
+        ref = list(range(1, 2 * n + 1))
+        ex = ProcessPoolExecutor(max_workers=2)
+        pipeline = (
+            PipelineBuilder()
+            .add_source(range(n), continuous=True)
+            .pipe(dup, executor=ex, concurrency=2)
+            .pipe(add_one, executor=ex, concurrency=2)
+            .add_sink(n)
+            .build(num_threads=4, fuse_subprocess_stages=True)
+        )
+        with pipeline.auto_stop():
+            for _ in range(3):
+                self.assertEqual(sorted(pipeline.get_iterator(timeout=60)), ref)
+
+    def test_async_generator_op_multi_epoch(self) -> None:
+        """A main-process async-generator op fans out downstream of a fused run each epoch."""
+        n = 8
+        ref = list(range(2, 2 * n + 2))
+        ex = ProcessPoolExecutor(max_workers=2)
+        pipeline = (
+            PipelineBuilder()
+            .add_source(range(n), continuous=True)
+            .pipe(add_one, executor=ex, concurrency=2)
+            .pipe(times_two, executor=ex, concurrency=2)
+            .pipe(adup)
+            .add_sink(n)
+            .build(num_threads=4, fuse_subprocess_stages=True)
+        )
+        with pipeline.auto_stop():
+            for _ in range(3):
+                self.assertEqual(sorted(pipeline.get_iterator(timeout=60)), ref)
+
+    def test_continuous_op_failure_does_not_deadlock(self) -> None:
+        """Op failures (dropped per SPDL default) still let each epoch's barrier complete.
+
+        ``boom`` raises on every item, so the fused workers produce no results; the test checks
+        the continuous epoch barrier still completes each epoch (workers report the boundary
+        with zero results) instead of deadlocking, matching unfused drop-on-failure behavior.
+        """
+        n = 8
+        ex = ProcessPoolExecutor(max_workers=2)
+        pipeline = (
+            PipelineBuilder()
+            .add_source(range(n), continuous=True)
+            .pipe(add_one, executor=ex, concurrency=2)
+            .pipe(boom, executor=ex, concurrency=2)
+            .add_sink(n)
+            .build(num_threads=4, fuse_subprocess_stages=True)
+        )
+        with pipeline.auto_stop():
+            for _ in range(2):
+                self.assertEqual(list(pipeline.get_iterator(timeout=60)), [])
+
+    def test_continuous_in_subprocess(self) -> None:
+        """Continuous fusion composes with run_pipeline_in_subprocess across epochs."""
+        n = 12
+        ref = sorted((x + 1) * 2 for x in range(n))
+        ex = ProcessPoolExecutor(max_workers=2)
+        config = (
+            PipelineBuilder()
+            .add_source(range(n), continuous=True)
+            .pipe(add_one, executor=ex, concurrency=2)
+            .pipe(times_two, executor=ex, concurrency=2)
+            .add_sink(n)
+            .get_config()
+        )
+        src = run_pipeline_in_subprocess(
+            config, num_threads=4, fuse_subprocess_stages=True
+        )
+        for _ in range(3):  # one epoch per iteration
+            self.assertEqual(sorted(src), ref)
 
 
 class FuseInSubprocessTest(unittest.TestCase):
@@ -289,9 +434,12 @@ class FeedAbortTest(unittest.TestCase):
                 StageInfo(pipeline_id=0, stage_id="0", stage_name="input")
             )  # stays empty -> get() blocks
             abort = asyncio.Event()
+            feeder_idle = asyncio.Event()
             with ThreadPoolExecutor(max_workers=2) as ex:
                 task = asyncio.ensure_future(
-                    _subprocess_pipe._feed(input_queue, in_q, num_workers, ex, abort)
+                    _subprocess_pipe._feed(
+                        input_queue, in_q, num_workers, ex, abort, feeder_idle
+                    )
                 )
                 await asyncio.sleep(0.1)  # let the feeder park on input_queue.get()
                 self.assertFalse(task.done(), "feeder should be parked on empty queue")
@@ -301,3 +449,64 @@ class FeedAbortTest(unittest.TestCase):
 
         msgs = asyncio.run(_scenario())
         self.assertEqual(msgs, [(_subprocess_pipe._SESSION_END, None)] * num_workers)
+
+
+class StallGuardTest(unittest.TestCase):
+    """The collector's stall guard against an abruptly-dead worker."""
+
+    def test_check_stall_raises_past_timeout(self) -> None:
+        """``_check_stall`` raises once no message has arrived for longer than the bound."""
+        orig = _subprocess_pipe._WORKER_STALL_TIMEOUT
+        _subprocess_pipe._WORKER_STALL_TIMEOUT = 0.0
+        try:
+            with self.assertRaises(TimeoutError):
+                _subprocess_pipe._check_stall(time.monotonic() - 1.0)
+        finally:
+            _subprocess_pipe._WORKER_STALL_TIMEOUT = orig
+
+    def test_check_stall_quiet_within_timeout(self) -> None:
+        """``_check_stall`` does not raise while progress is within the bound."""
+        orig = _subprocess_pipe._WORKER_STALL_TIMEOUT
+        _subprocess_pipe._WORKER_STALL_TIMEOUT = 60.0
+        try:
+            _subprocess_pipe._check_stall(time.monotonic())  # should not raise
+        finally:
+            _subprocess_pipe._WORKER_STALL_TIMEOUT = orig
+
+    def test_collect_suppresses_stall_while_feeder_idle(self) -> None:
+        """An idle feeder suppresses the collector's stall guard during input starvation.
+
+        With the timeout pinned to zero, any stall check on an empty queue would trip instantly;
+        the collector must instead keep draining while ``feeder_idle`` is set (nothing dispatched,
+        no worker message due) and still finish once the worker reports ``_DONE``.
+        """
+        orig = _subprocess_pipe._WORKER_STALL_TIMEOUT
+        _subprocess_pipe._WORKER_STALL_TIMEOUT = 0.0
+
+        async def _scenario() -> None:
+            out_q: _queue.Queue[Any] = _queue.Queue()
+            output_queue = AsyncQueue(
+                StageInfo(pipeline_id=0, stage_id="0", stage_name="output")
+            )
+            abort = asyncio.Event()
+            feeder_idle = asyncio.Event()
+            feeder_idle.set()  # feeder parked on an idle upstream -> no message expected
+            with ThreadPoolExecutor(max_workers=2) as ex:
+                task = asyncio.ensure_future(
+                    _subprocess_pipe._collect(
+                        out_q, 1, output_queue, ex, abort, feeder_idle
+                    )
+                )
+                await asyncio.sleep(
+                    0.6
+                )  # several empty poll cycles; must not trip the guard
+                self.assertFalse(
+                    task.done(), "idle feeder must suppress the stall guard"
+                )
+                out_q.put((_subprocess_pipe._DONE, None))
+                await asyncio.wait_for(task, timeout=5.0)
+
+        try:
+            asyncio.run(_scenario())
+        finally:
+            _subprocess_pipe._WORKER_STALL_TIMEOUT = orig


### PR DESCRIPTION
Extend subprocess-stage fusion to continuous-source pipelines, so multi-epoch training keeps the fused worker sub-pipelines and their prefetch buffers warm across epochs.

The work composes existing mechanisms: `_source_continuous` injects an `_EPOCH_END` marker between epochs, a continuous `Pipeline` delimits one epoch per iterator pass, and `_default_merge` already implements the cross-stream epoch barrier this needs.

Changes:

- The bridge stage (`_components/_subprocess_pipe.py`) gains a continuous path. The feeder round-robins items to per-worker input queues and, at each epoch boundary, broadcasts an `_EPOCH` control message to every worker (concurrently, so a slow worker queue does not stall the broadcast) and waits on a barrier before feeding the next epoch, so epochs do not interleave across workers. The collector counts `_EPOCH_DONE` across the workers and emits exactly one `_EPOCH_END` downstream per epoch, then releases the feeder. Epoch boundaries are carried as integer tags, not sentinel objects, so nothing relies on sentinel identity surviving a pickle round-trip.
- Each worker (`_subprocess_pipeline_pool.py`) runs a long-lived continuous sub-pipeline whose source is a re-iterable `_DrainSource` draining that worker's own queue; one `for out in pipeline` pass yields one epoch, after which the worker reports `_EPOCH_DONE` and loops, staying warm. The drain reads with a timeout so the worker tears down promptly on shutdown instead of parking on a blocking read. The pool uses per-worker input queues in continuous mode (for clean broadcast) and the existing shared work-stealing queue otherwise; the picklable handle carries the layout and mode.
- `_fuse_subprocess_stages` no longer skips continuous configs; it threads the continuous flag (from `_has_continuous_source`) into the pool.

Aggregate/disaggregate micro-stages are not fused (they bound a run and stay in the main process), so their batching semantics are identical to an unfused pipeline in both modes.

The bridge collector also guards against an abruptly-dead worker (a segfault or OOM-kill emits neither an error nor a completion marker): if no worker message arrives within a fixed stall timeout (15 min), it raises instead of spinning forever. Any worker message resets the timer.