### PR TITLE
[pipeline] seed subprocess global RNGs deterministically

### DIFF
--- a/src/spdl/pipeline/_build.py
+++ b/src/spdl/pipeline/_build.py
@@ -37,6 +37,7 @@ from spdl.pipeline._components import (
 from spdl.pipeline._executor_proxy import _make_config_executors_picklable
 from spdl.pipeline._fuse import _fuse_subprocess_stages
 from spdl.pipeline._iter_utils import iterate_in_subinterpreter, iterate_in_subprocess
+from spdl.pipeline._random_seed import _draw_base_seed, _seed_global_rngs
 from spdl.pipeline._subprocess_pipeline_pool import _shutdown_pipeline_pools
 from spdl.pipeline._subprocess_worker_pool import (
     _hoist_process_pools,
@@ -366,7 +367,13 @@ class _Wrapper(Generic[U]):
 
 
 def _get_initializer(kwargs: Any) -> Sequence[Callable[[], None]]:
-    initializer = [partial(_set_global_id, _get_global_id())]
+    # Seed the subprocess' global RNGs deterministically so that random draws made
+    # inside the subprocess (e.g. multi-threaded preprocessing in MTP mode) are
+    # reproducible and do not depend on the start method.
+    initializer = [
+        partial(_set_global_id, _get_global_id()),
+        partial(_seed_global_rngs, _draw_base_seed()),
+    ]
     if "initializer" not in kwargs:
         return initializer
 
@@ -438,6 +445,56 @@ def run_pipeline_in_subprocess(
     GPU-transfer stages in the main process, an outer pipeline can wrap ``src``
     with ``add_source(src, continuous=True)`` (see the MTP pattern in the
     parallelism guide).
+
+    .. note::
+
+       **Random number generators.** The worker subprocess seeds its global RNGs
+       deterministically before iterating, so random draws made inside the
+       pipeline (e.g. data augmentation) are reproducible run-to-run and do not
+       depend on the multiprocessing start method (``fork`` / ``spawn`` /
+       ``forkserver``). No opt-in is required.
+
+       The base seed is captured in the main process from the standard library
+       :py:mod:`random` module. Seeding it (``random.seed(k)``) therefore makes
+       the subprocess draws reproducible across program runs as well — the same
+       contract as :py:class:`torch.utils.data.DataLoader`. Leaving it unseeded
+       keeps draws reproducible *within* a run but varying *across* runs.
+
+       This covers the **global** RNGs only:
+
+       - :py:mod:`random` (standard library),
+       - NumPy's **legacy** global RNG (:py:func:`numpy.random.rand`,
+         :py:func:`numpy.random.choice`, :py:func:`numpy.random.shuffle`, …), and
+       - PyTorch (:py:func:`torch.manual_seed`, which also seeds all CUDA
+         devices).
+
+       NumPy and PyTorch are reseeded only when the program has already imported
+       them; SPDL never imports them on your behalf.
+
+       .. warning::
+
+          The following sources are **not** covered, because the library cannot
+          reach them:
+
+          - A :py:class:`numpy.random.Generator` created with
+            :py:func:`numpy.random.default_rng` (the modern NumPy API) is an
+            independent object that ``numpy.random.seed`` does not touch. If your
+            code holds an unseeded ``default_rng()``, seed it explicitly or derive
+            it from the (now seeded) global RNG. SPDL's own samplers already store
+            an explicit seed, so they are reproducible in every mode.
+          - Hash randomization (``PYTHONHASHSEED``), which affects ``set``
+            iteration order, is fixed at interpreter start and cannot be reseeded
+            at runtime — pin it in the launch environment if it matters.
+          - Cryptographic / entropy sources (:py:func:`os.urandom`,
+            :py:mod:`secrets`, :py:func:`uuid.uuid4`) are intentionally left
+            untouched.
+
+          Note also that task *completion order* (``output_order="completion"``)
+          is independent of RNG state and can still differ between execution
+          modes.
+
+       .. versionadded:: 0.6.0
+          The worker subprocess now seeds its global RNGs deterministically.
 
     .. note::
 

--- a/src/spdl/pipeline/_random_seed.py
+++ b/src/spdl/pipeline/_random_seed.py
@@ -1,0 +1,111 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""Deterministic seeding of global RNGs for subprocess-based execution.
+
+When a pipeline runs in a worker subprocess (created by
+:py:func:`~spdl.pipeline.run_pipeline_in_subprocess`, including the threaded
+"MTP" arrangement), the global RNGs of ``random`` / ``numpy`` / ``torch`` would
+otherwise diverge from single-process multi-threading execution:
+
+* With the ``fork`` start method the subprocess inherits a *copy* of the parent's
+  RNG state, so its draws happen to continue the parent's stream.
+* With ``spawn`` / ``forkserver`` the subprocess seeds its RNGs from OS entropy,
+  so results are not reproducible across program runs.
+
+To make execution consistent without any user opt-in, the subprocess boundary
+seeds the global RNGs deterministically from a base seed captured in the main
+process. A given base seed always yields the same streams (reproducible). The
+base seed is drawn from the main process' stdlib ``random`` module, so seeding
+the main process (e.g. ``random.seed(k)``) makes the subprocess draws
+reproducible across program runs as well -- the same contract as
+:py:class:`torch.utils.data.DataLoader`.
+
+``numpy`` and ``torch`` are reseeded only when they are **already imported** by
+the running program: the core ``spdl.pipeline`` package is pure Python and must
+not import (let alone depend on) them, and reseeding a library the user never
+loaded would be pointless. SPDL's own samplers
+(:py:class:`~spdl.source.DistributedRandomSampler` and friends) build a private
+:py:class:`numpy.random.Generator` from their stored seed on each iteration, so
+they are unaffected and already produce identical sequences in every mode.
+
+This deliberately covers only the **global** RNGs. In particular,
+``numpy.random.seed`` reseeds NumPy's *legacy* global ``RandomState`` (the one
+behind ``numpy.random.rand`` etc.) but has no effect on a
+``numpy.random.Generator`` returned by ``numpy.random.default_rng()`` — those are
+independent objects the library does not own, so user code holding an unseeded
+one must seed it itself. Likewise, hash randomization (``PYTHONHASHSEED``) and
+entropy sources (``os.urandom``, ``secrets``, ``uuid.uuid4``) are out of reach.
+The user-facing contract is documented on
+:py:func:`~spdl.pipeline.run_pipeline_in_subprocess`.
+"""
+
+import logging
+import random
+import sys
+from types import ModuleType
+
+__all__ = [
+    "_draw_base_seed",
+    "_seed_global_rngs",
+]
+
+_LG: logging.Logger = logging.getLogger(__name__)
+
+_MASK64: int = (1 << 64) - 1
+# FNV-1a 64-bit constants.
+_FNV_OFFSET: int = 0xCBF29CE484222325
+_FNV_PRIME: int = 0x100000001B3
+
+
+def _mix(*values: int) -> int:
+    """Combine integers into a 64-bit seed (order-sensitive, well-dispersed, numpy-free)."""
+    h = _FNV_OFFSET
+    for value in values:
+        v = value & _MASK64
+        for _ in range(8):
+            h ^= v & 0xFF
+            h = (h * _FNV_PRIME) & _MASK64
+            v >>= 8
+    return h
+
+
+def _imported(name: str) -> ModuleType | None:
+    """Return the module ``name`` only if user code already imported it, else ``None``.
+
+    Reads ``sys.modules`` without importing, so a library the program never
+    loaded is left untouched (and no hard dependency is introduced).
+    """
+    return sys.modules.get(name)
+
+
+def _draw_base_seed() -> int:
+    """Draw a 64-bit base seed from the main process' stdlib ``random`` global.
+
+    Reproducible across program runs only if the main process seeds ``random``
+    (e.g. ``random.seed(k)``); otherwise it varies per run, exactly like the base
+    seed of :py:class:`torch.utils.data.DataLoader`.
+    """
+    return random.getrandbits(64)
+
+
+def _seed_global_rngs(base_seed: int) -> None:
+    """Deterministically seed the global RNGs of ``random`` and any imported RNG library.
+
+    ``random`` is always seeded. ``numpy`` and ``torch`` are seeded only when they
+    are already present in :py:data:`sys.modules` (i.e. the program imported them);
+    they are never imported by this function.
+    """
+    random.seed(_mix(base_seed, 0))
+
+    if (np := _imported("numpy")) is not None:
+        # ``numpy.random.seed`` accepts a 32-bit value.
+        np.random.seed(_mix(base_seed, 1) & 0xFFFFFFFF)
+
+    if (torch := _imported("torch")) is not None:
+        torch.manual_seed(_mix(base_seed, 2))

--- a/tests/pipeline/rng_state_mtmpmtp_test.py
+++ b/tests/pipeline/rng_state_mtmpmtp_test.py
@@ -1,0 +1,297 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-unsafe
+
+"""Global-RNG / sampler consistency across MT, MP and MTP execution modes.
+
+A recurring source of train/eval discrepancies is that switching the data
+pipeline between multi-threading (MT) and sub-processing (MTP) changes the
+behavior of the *global* random number generators (``random``, ``numpy``,
+``torch``) used inside preprocessing functions:
+
+* **MT** runs preprocessing in main-process threads sharing one global RNG.
+* **MTP** runs the whole (threaded) pipeline in a single subprocess. Without
+  coordination, the subprocess either continues the parent's RNG stream
+  (``fork``) or seeds from OS entropy (``spawn``), so its draws are not
+  reproducible run-to-run.
+* **MP** moves the source/sampler into one subprocess and fans preprocessing out
+  to a pool of worker processes.
+
+These tests pin the behavior we actually want:
+
+* SPDL's distributed samplers produce the **same** index sequence in every mode,
+  including MP (the sampler lives in the single subprocess, never duplicated),
+  across single / multi iteration and continuous / non-continuous sources.
+* The global-RNG draws made in preprocessing are reproducible run-to-run in MT
+  and MTP.
+
+The random state of the **MP pool worker processes** is intentionally out of
+scope: those workers run only the preprocessing fan-out, and per-worker random
+state is left to the application.
+"""
+
+import multiprocessing as mp
+import random
+import unittest
+import warnings
+from collections.abc import Callable, Iterable
+from concurrent.futures import ProcessPoolExecutor
+from contextlib import contextmanager
+
+import numpy as np
+import torch
+from parameterized import parameterized
+from spdl.pipeline import build_pipeline, run_pipeline_in_subprocess
+from spdl.pipeline.defs import Pipe, PipelineConfig, SinkConfig, SourceConfig
+from spdl.source import DistributedRandomSampler
+from spdl.source.utils import embed_shuffle
+
+MT = "mt"
+MTP = "mtp"
+MP = "mp"
+
+_TIMEOUT = 60.0
+
+
+# ---------------------------------------------------------------------------
+# Top-level (picklable) pipeline ops and source factories.
+# ---------------------------------------------------------------------------
+def _identity(i: int) -> int:
+    return i
+
+
+def _augment(i: int) -> tuple:
+    """Return the index alongside one draw from each global RNG.
+
+    Running this in the pipeline exercises exactly the global state the modes are
+    supposed to agree on.
+    """
+    return (
+        i,
+        float(np.random.rand()),
+        random.random(),
+        float(torch.rand(1).item()),
+    )
+
+
+def _rng_triples(epoch_items: Iterable[tuple]) -> list[tuple]:
+    """Drop the index, keep only the (numpy, random, torch) draw of each item."""
+    return [item[1:] for item in epoch_items]
+
+
+@contextmanager
+def _quiet_subprocess():
+    """Silence the expected fork-related warnings emitted when a subprocess (or a
+    hoisted ``ProcessPoolExecutor``) is started while pipeline threads are alive."""
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            message=(
+                r"This process \(pid=\d+\) is multi-threaded, use of "
+                r"fork\(\) may lead to deadlocks in the child"
+            ),
+            category=DeprecationWarning,
+        )
+        warnings.filterwarnings(
+            "ignore",
+            message=r"Hoisting a ProcessPoolExecutor.*",
+            category=RuntimeWarning,
+        )
+        yield
+
+
+def _config(
+    source: Iterable,
+    op: Callable,
+    *,
+    executor: ProcessPoolExecutor | None = None,
+    concurrency: int = 1,
+    continuous: bool = False,
+) -> PipelineConfig:
+    return PipelineConfig(
+        src=SourceConfig(source, continuous=continuous),
+        pipes=[Pipe(op, concurrency=concurrency, executor=executor)],
+        sink=SinkConfig(3),
+    )
+
+
+def _run(
+    mode: str,
+    *,
+    source: Iterable,
+    op: Callable,
+    workers: int,
+    continuous: bool,
+    num_epochs: int,
+    mp_context: str | None = None,
+) -> list[list]:
+    """Run ``op`` over ``source`` for ``num_epochs`` epochs in the given mode.
+
+    Returns one list of outputs per epoch.
+    """
+    if mode == MT:
+        out: list[list] = []
+        if continuous:
+            # A continuous pipeline is built once and re-iterated per epoch.
+            config = _config(source, op, concurrency=workers, continuous=True)
+            pipeline = build_pipeline(config, num_threads=max(workers, 1))
+            with pipeline.auto_stop(timeout=_TIMEOUT):
+                for _ in range(num_epochs):
+                    out.append(list(pipeline.get_iterator(timeout=_TIMEOUT)))
+        else:
+            # A non-continuous in-process pipeline is single-pass, so rebuild it
+            # per epoch (mirroring how the subprocess path rebuilds per iter()).
+            # The shared ``source`` object advances its own epoch state across
+            # rebuilds, exactly like the reference.
+            for _ in range(num_epochs):
+                config = _config(source, op, concurrency=workers, continuous=False)
+                pipeline = build_pipeline(config, num_threads=max(workers, 1))
+                with pipeline.auto_stop(timeout=_TIMEOUT):
+                    out.append(list(pipeline.get_iterator(timeout=_TIMEOUT)))
+        return out
+
+    if mode == MTP:
+        # Threaded pipeline, moved wholesale into one subprocess (no process pool).
+        config = _config(source, op, concurrency=workers, continuous=continuous)
+    elif mode == MP:
+        # Source/sampler in one subprocess; preprocessing fanned out to a pool of
+        # worker processes (hoisted into the main process).
+        config = _config(
+            source,
+            op,
+            executor=ProcessPoolExecutor(max_workers=workers),
+            concurrency=workers,
+            continuous=continuous,
+        )
+    else:
+        raise ValueError(f"Unknown mode: {mode}")
+
+    with _quiet_subprocess():
+        src = run_pipeline_in_subprocess(
+            config,
+            num_threads=max(workers, 1),
+            mp_context=mp_context,
+            timeout=_TIMEOUT,
+        )
+        try:
+            return [list(src) for _ in range(num_epochs)]
+        finally:
+            # Deterministically tear the worker subprocess (and any hoisted pools) down.
+            finalizer = getattr(src, "_finalizer", None)
+            if finalizer is not None:
+                finalizer()
+
+
+def _seed_main(seed: int) -> None:
+    random.seed(seed)
+    # numpy's stub types ``seed`` as a sequence/array; pass a single-element seq.
+    np.random.seed([seed])
+    torch.manual_seed(seed)
+
+
+def _available_start_methods() -> list[str]:
+    return [m for m in ("fork", "spawn") if m in mp.get_all_start_methods()]
+
+
+# ---------------------------------------------------------------------------
+# 1. The distributed sampler must produce the same sequence in every mode.
+# ---------------------------------------------------------------------------
+class TestSamplerConsistency(unittest.TestCase):
+    N = 24
+    SEED = 7
+
+    def _reference(self, *, reshuffle: bool, num_epochs: int) -> list[list[int]]:
+        sampler = DistributedRandomSampler(self.N, rank=0, world_size=1, seed=self.SEED)
+        src = embed_shuffle(sampler) if reshuffle else sampler
+        return [list(src) for _ in range(num_epochs)]
+
+    def _source(self, *, reshuffle: bool):
+        sampler = DistributedRandomSampler(self.N, rank=0, world_size=1, seed=self.SEED)
+        return embed_shuffle(sampler) if reshuffle else sampler
+
+    @parameterized.expand(
+        [
+            (continuous, reshuffle, num_epochs)
+            for continuous in (False, True)
+            for reshuffle, num_epochs in ((False, 1), (False, 3), (True, 3))
+        ]
+    )
+    def test_sampler_sequence_matches_across_modes(
+        self, continuous, reshuffle, num_epochs
+    ) -> None:
+        """Each mode yields the identical per-epoch index sequence (concurrency=1
+        preserves order, so we can compare sequences exactly)."""
+        reference = self._reference(reshuffle=reshuffle, num_epochs=num_epochs)
+
+        for mode in (MT, MTP, MP):
+            got = _run(
+                mode,
+                source=self._source(reshuffle=reshuffle),
+                op=_identity,
+                workers=1,
+                continuous=continuous,
+                num_epochs=num_epochs,
+            )
+            self.assertEqual(
+                got,
+                reference,
+                msg=f"mode={mode} continuous={continuous} reshuffle={reshuffle}",
+            )
+
+
+# ---------------------------------------------------------------------------
+# 2. Global-RNG draws must be reproducible run-to-run (MT and MTP).
+# ---------------------------------------------------------------------------
+class TestReproducibleAcrossRuns(unittest.TestCase):
+    N = 32
+    SEED = 2024
+
+    def _collect(self, mode, *, start_method, continuous) -> list[tuple]:
+        _seed_main(self.SEED)
+        # workers=1 keeps a single deterministic stream, so the sequence of draws
+        # is well-defined regardless of task scheduling.
+        epochs = _run(
+            mode,
+            source=range(self.N),
+            op=_augment,
+            workers=1,
+            continuous=continuous,
+            num_epochs=1,
+            mp_context=start_method,
+        )
+        return _rng_triples(epochs[0])
+
+    @parameterized.expand(
+        [
+            (mode, start_method, continuous)
+            for mode in (MT, MTP)
+            for start_method in _available_start_methods()
+            for continuous in (False, True)
+        ]
+    )
+    def test_same_seed_same_draws(self, mode, start_method, continuous) -> None:
+        """Re-seeding the main process and re-running yields identical draws.
+
+        Pre-fix, MTP with ``spawn`` seeds from OS entropy, so the two runs differ;
+        with ``fork`` it continues the parent stream, so the value depends on
+        whatever the main process drew beforehand."""
+        if mode == MT and start_method != _available_start_methods()[0]:
+            # MT runs in-process; the subprocess start method is irrelevant.
+            self.skipTest("MT is start-method independent")
+
+        first = self._collect(mode, start_method=start_method, continuous=continuous)
+        second = self._collect(mode, start_method=start_method, continuous=continuous)
+        self.assertEqual(len(first), self.N)
+        self.assertEqual(
+            first,
+            second,
+            msg=f"mode={mode} start_method={start_method} continuous={continuous}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Switching a data pipeline between in-process multi-threading (MT) and sub-process execution (MTP, via `run_pipeline_in_subprocess`) silently changes the behavior of the *global* RNGs (`random`, `numpy`, `torch`) used inside preprocessing functions. With the `fork` start method the subprocess continues the parent's RNG stream; with `spawn`/`forkserver` it seeds from OS entropy. Either way the draws are not reproducible run-to-run and differ from MT, which is a recurring source of train/eval discrepancies.

This adds `spdl/pipeline/_random_seed.py` and seeds the worker subprocess's global RNGs deterministically in `run_pipeline_in_subprocess` (no user opt-in). The base seed is captured in the main process from the stdlib `random` module, so the subprocess draws are reproducible and, if the main process is seeded (e.g. `random.seed(k)`), reproducible across program runs as well — the same contract as `torch.utils.data.DataLoader`.

`numpy` and `torch` are reseeded only when they are already present in `sys.modules`: the core `spdl.pipeline` package stays pure Python and never imports them, so no new dependency is introduced. SPDL's own samplers build a private `numpy.random.Generator` from their stored seed each iteration and are unaffected — they already produce identical sequences in every mode.

The random state of MP pool-worker processes is intentionally left out of scope; those workers only run the preprocessing fan-out and their per-worker random state is left to the application.