### PR TITLE
[pipeline] copy the main process global RNG state into pipeline workers

### DIFF
--- a/src/spdl/pipeline/_build.py
+++ b/src/spdl/pipeline/_build.py
@@ -37,6 +37,7 @@ from spdl.pipeline._components import (
 from spdl.pipeline._executor_proxy import _make_config_executors_picklable
 from spdl.pipeline._fuse import _fuse_subprocess_stages
 from spdl.pipeline._iter_utils import iterate_in_subinterpreter, iterate_in_subprocess
+from spdl.pipeline._random_seed import _capture_rng_initializers
 from spdl.pipeline._subprocess_pipeline_pool import _shutdown_pipeline_pools
 from spdl.pipeline._subprocess_worker_pool import (
     _hoist_process_pools,
@@ -365,8 +366,20 @@ class _Wrapper(Generic[U]):
                 yield from pipeline
 
 
-def _get_initializer(kwargs: Any) -> Sequence[Callable[[], None]]:
-    initializer = [partial(_set_global_id, _get_global_id())]
+def _get_initializer(
+    kwargs: Any, *, shareable_rng_only: bool
+) -> Sequence[Callable[[], None]]:
+    initializer: list[Callable[[], None]] = [
+        partial(_set_global_id, _get_global_id()),
+    ]
+    # Copy the main process' current global RNG state into the worker so that
+    # RNG-dependent work inside the pipeline (e.g. augmentation in MTP mode)
+    # continues from the state the user set, regardless of the start method.
+    # Captured here in the main process; restored in the worker before iteration.
+    # For subinterpreters only the stdlib ``random`` state is copied: initializers
+    # cross the interpreter boundary as call arguments and so must be shareable,
+    # which the captured numpy/torch state objects are not.
+    initializer.extend(_capture_rng_initializers(shareable_only=shareable_rng_only))
     if "initializer" not in kwargs:
         return initializer
 
@@ -438,6 +451,55 @@ def run_pipeline_in_subprocess(
     GPU-transfer stages in the main process, an outer pipeline can wrap ``src``
     with ``add_source(src, continuous=True)`` (see the MTP pattern in the
     parallelism guide).
+
+    .. note::
+
+       **Random number generators.** The current global RNG state of the main
+       process is copied into the worker subprocess before iterating, so
+       RNG-dependent work inside the pipeline (e.g. data augmentation) continues
+       from exactly the state the main process was in — regardless of the
+       multiprocessing start method (``fork`` / ``spawn`` / ``forkserver``). No
+       opt-in is required.
+
+       In particular, if you seed the global RNGs in the main process before
+       creating the pipeline (``random.seed(k)``, ``numpy.random.seed(k)``,
+       ``torch.manual_seed(k)``), the worker inherits that seeding seamlessly, so
+       draws are reproducible across program runs just as they would be in-process.
+
+       This copies the **global** generators only:
+
+       - :py:mod:`random` (standard library),
+       - NumPy's **legacy** global RNG (:py:func:`numpy.random.rand`,
+         :py:func:`numpy.random.choice`, :py:func:`numpy.random.shuffle`, …), and
+       - PyTorch's CPU generator.
+
+       NumPy and PyTorch state is copied only when the program has already
+       imported them; SPDL never imports them on your behalf.
+
+       .. warning::
+
+          The following sources are **not** copied, because the library cannot
+          reach them:
+
+          - A :py:class:`numpy.random.Generator` created with
+            :py:func:`numpy.random.default_rng` (the modern NumPy API) is an
+            independent object, not part of the legacy global state. If your code
+            holds one, seed it explicitly. SPDL's own samplers already store an
+            explicit seed, so they are reproducible in every mode.
+          - PyTorch **CUDA** device RNG state (only the CPU generator is copied).
+          - Hash randomization (``PYTHONHASHSEED``), which affects ``set``
+            iteration order, is fixed at interpreter start — pin it in the launch
+            environment if it matters.
+          - Cryptographic / entropy sources (:py:func:`os.urandom`,
+            :py:mod:`secrets`, :py:func:`uuid.uuid4`) are intentionally left
+            untouched.
+
+          Note also that task *completion order* (``output_order="completion"``)
+          is independent of RNG state and can still differ between execution
+          modes.
+
+       .. versionchanged:: 0.6.0
+          The worker subprocess now inherits the main process' global RNG state.
 
     .. note::
 
@@ -559,7 +621,7 @@ def run_pipeline_in_subprocess(
     try:
         config = _make_config_executors_picklable(config)
 
-        initializer = _get_initializer(kwargs)
+        initializer = _get_initializer(kwargs, shareable_rng_only=False)
         iterable = iterate_in_subprocess(
             fn=partial(
                 _Wrapper,
@@ -638,13 +700,32 @@ def run_pipeline_in_subinterpreter(
     Yields:
         The results yielded from the pipeline.
 
+    .. note::
+
+       **Random number generators.** Only the stdlib :py:mod:`random` global
+       state is copied from the main interpreter into the subinterpreter; unlike
+       :py:func:`run_pipeline_in_subprocess`, the **NumPy** and **PyTorch** global
+       RNG state is **not**. Two interpreter limitations force this: the restore
+       initializers cross the boundary as call arguments and so must be shareable
+       across interpreters, which the captured NumPy / PyTorch state objects are
+       not; and NumPy and PyTorch cannot be imported in a subinterpreter at all,
+       so a pipeline running here cannot use them regardless. For any NumPy /
+       PyTorch randomness, seed it from within ``config`` — e.g. via an SPDL
+       sampler that stores an explicit seed
+       (:py:class:`~spdl.source.DistributedRandomSampler`) — rather than depending
+       on the main interpreter's global RNG state.
+
+       .. versionchanged:: 0.6.0
+          The subinterpreter now inherits the main interpreter's stdlib
+          :py:mod:`random` global state.
+
     .. seealso::
 
        - :py:func:`iterate_in_subinterpreter` implements the logic for manipulating an iterable
          in a subinterpreter.
        - :ref:`parallelism-performance` for the context in which this function was created.
     """
-    initializer = _get_initializer(kwargs)
+    initializer = _get_initializer(kwargs, shareable_rng_only=True)
     return iterate_in_subinterpreter(
         fn=partial(
             _Wrapper,

--- a/src/spdl/pipeline/_random_seed.py
+++ b/src/spdl/pipeline/_random_seed.py
@@ -1,0 +1,131 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""Copy the main process' global RNG state into a worker subprocess.
+
+When a pipeline runs in a worker subprocess (created by
+:py:func:`~spdl.pipeline.run_pipeline_in_subprocess`, including the threaded
+"MTP" arrangement), RNG-dependent work inside the pipeline (e.g. data
+augmentation that calls ``random`` / ``numpy`` / ``torch``) would otherwise
+behave differently than in single-process multi-threading:
+
+* With the ``fork`` start method the subprocess inherits a *copy* of the
+  parent's RNG state, but only of the forking thread's view at fork time.
+* With ``spawn`` / ``forkserver`` the subprocess seeds its RNGs from OS entropy,
+  unrelated to the parent.
+
+So if the user seeds the global RNGs in the main process (``random.seed(...)``,
+``numpy.random.seed(...)``, ``torch.manual_seed(...)``) and then runs the
+pipeline in a subprocess, that seeding would be lost or inconsistent.
+
+This module captures the global RNG state in the main process at build time and
+restores it in the subprocess before iteration, so the subprocess continues from
+exactly the state the main process was in -- seamlessly, regardless of the start
+method and with no user opt-in.
+
+Only RNG libraries the program has **already imported** are touched: the core
+``spdl.pipeline`` package is pure Python and must not import (or depend on)
+``numpy`` / ``torch``. State is captured per library, gated on
+:py:data:`sys.modules`, and a per-library restore initializer is shipped to the
+subprocess only when that library is in use. Unpickling a captured ``numpy`` /
+``torch`` state object re-imports the library in the subprocess, so it is
+guaranteed available when its restore initializer runs.
+
+SPDL's own samplers (:py:class:`~spdl.source.DistributedRandomSampler` and
+friends) build a private :py:class:`numpy.random.Generator` from their stored
+seed on each iteration, so they are independent of this global state and already
+produce identical sequences in every mode.
+
+This copies the **global** generators only. A :py:class:`numpy.random.Generator`
+from :py:func:`numpy.random.default_rng` is an independent object and is not
+affected; ``torch`` CUDA device RNG state is not copied (only the CPU
+generator); and hash randomization (``PYTHONHASHSEED``) / entropy sources
+(``os.urandom``, ``secrets``, ``uuid.uuid4``) are out of reach. The user-facing
+contract is documented on :py:func:`~spdl.pipeline.run_pipeline_in_subprocess`.
+
+When the worker is a **subinterpreter** rather than a subprocess (via
+:py:func:`~spdl.pipeline.run_pipeline_in_subinterpreter`), the restore
+initializers are passed as a call argument and so must be *shareable* across
+interpreters. Only the stdlib ``random`` state qualifies -- it is a plain tuple
+-- so capture is restricted to it via ``shareable_only``. The ``numpy`` / ``torch``
+state objects are not shareable, and those libraries cannot even be imported in a
+subinterpreter, so they are necessarily left out of that path.
+"""
+
+import random
+import sys
+from collections.abc import Callable
+from functools import partial
+from typing import Any
+
+__all__ = [
+    "_capture_rng_initializers",
+]
+
+
+def _imported(name: str) -> Any:
+    """Return the module ``name`` if the program already imported it, else ``None``.
+
+    Reads :py:data:`sys.modules` without importing, so a library the program
+    never loaded is left untouched (and no dependency is introduced).
+    """
+    return sys.modules.get(name)
+
+
+def _restore_random_state(state: object) -> None:
+    """Restore the stdlib :py:mod:`random` global state (runs in the subprocess)."""
+    random.setstate(state)  # pyre-ignore[6]: round-tripped from random.getstate()
+
+
+def _restore_numpy_state(state: object) -> None:
+    """Restore NumPy's legacy global RNG state (runs in the subprocess).
+
+    ``numpy`` is guaranteed importable here: unpickling ``state`` (which holds a
+    NumPy array) already imported it into :py:data:`sys.modules`.
+    """
+    _imported("numpy").random.set_state(state)
+
+
+def _restore_torch_state(state: object) -> None:
+    """Restore PyTorch's CPU RNG state (runs in the subprocess).
+
+    ``torch`` is guaranteed importable here: unpickling ``state`` (a tensor)
+    already imported it into :py:data:`sys.modules`.
+    """
+    _imported("torch").set_rng_state(state)
+
+
+def _capture_rng_initializers(
+    *, shareable_only: bool = False
+) -> list[Callable[[], None]]:
+    """Capture the current global RNG state of every already-imported RNG library.
+
+    Runs in the main process. Returns a list of zero-argument initializers, each
+    binding a captured state, that restore that exact state when run in the
+    worker. ``numpy`` and ``torch`` are included only when the program has already
+    imported them; stdlib ``random`` is always included.
+
+    When ``shareable_only`` is set, only the stdlib ``random`` initializer is
+    returned. Its captured state is a plain tuple of ints, which is shareable
+    across subinterpreters; the ``numpy`` / ``torch`` state objects (a NumPy array
+    and a tensor) are not, so they cannot ride along the subinterpreter call
+    boundary and are dropped.
+    """
+    initializers: list[Callable[[], None]] = [
+        partial(_restore_random_state, random.getstate()),
+    ]
+    if shareable_only:
+        return initializers
+
+    if (np := _imported("numpy")) is not None:
+        initializers.append(partial(_restore_numpy_state, np.random.get_state()))
+
+    if (torch := _imported("torch")) is not None:
+        initializers.append(partial(_restore_torch_state, torch.get_rng_state()))
+
+    return initializers

--- a/tests/dataloader/sampler_test.py
+++ b/tests/dataloader/sampler_test.py
@@ -7,10 +7,13 @@
 # pyre-strict
 
 import functools
+import multiprocessing as mp
+import pickle
+import random
 import unittest
 import warnings
 from collections import Counter
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
 from functools import partial
 from typing import TypeVar
 
@@ -508,3 +511,173 @@ class TestDistributedSamplerIterateInSubprocess(unittest.TestCase):
             self.assertEqual(hyp, ref)
             self.assertNotEqual(hyp, previous)
             previous = hyp
+
+
+# ---------------------------------------------------------------------------
+# Sampler contract: identical output is preserved across the subprocess
+# boundary, *regardless of how* the sampler implements its determinism.
+#
+# Today the cross-process equivalence happens to fall out of NumPy's seeded
+# ``Generator`` being a pure function of the stored seed -- but that is an
+# implementation detail. These tests pin the observable contract directly so
+# that an implementation change which breaks it (e.g. switching to a global RNG,
+# or capturing process-local / non-picklable state) is caught regardless of how
+# determinism is achieved.
+# ---------------------------------------------------------------------------
+_SAMPLER_N = 24
+_SAMPLER_SEED = 7
+_TIMEOUT = 60.0
+
+
+def _build_random_sampler() -> Iterable[int]:
+    """A plain (unshuffled) random sampler -- same sequence every epoch."""
+    return DistributedRandomSampler(
+        _SAMPLER_N, rank=0, world_size=1, seed=_SAMPLER_SEED
+    )
+
+
+def _build_weighted_sampler() -> Iterable[int]:
+    """A weighted random sampler (draws with replacement)."""
+    return DistributedRandomSampler(
+        _SAMPLER_N,
+        rank=0,
+        world_size=1,
+        weights=[1.0] * _SAMPLER_N,
+        num_draws=_SAMPLER_N,
+        seed=_SAMPLER_SEED,
+    )
+
+
+def _build_deterministic_sampler() -> Iterable[int]:
+    """A deterministic (round-robin) sampler -- no randomness at all."""
+    return DistributedDeterministicSampler(_SAMPLER_N, rank=0, world_size=1)
+
+
+def _build_shuffled_sampler() -> Iterable[int]:
+    """A random sampler that reshuffles itself each epoch via ``embed_shuffle``."""
+    return embed_shuffle(
+        DistributedRandomSampler(_SAMPLER_N, rank=0, world_size=1, seed=_SAMPLER_SEED)
+    )
+
+
+_BUILDERS: dict[str, Callable[[], Iterable[int]]] = {
+    "random": _build_random_sampler,
+    "weighted": _build_weighted_sampler,
+    "deterministic": _build_deterministic_sampler,
+    "shuffled": _build_shuffled_sampler,
+}
+
+
+def _collect_epochs(source: Iterable[int], num_epochs: int) -> list[list[int]]:
+    """Iterate ``source`` ``num_epochs`` times, returning one index list per epoch."""
+    return [list(source) for _ in range(num_epochs)]
+
+
+def _perturb_global_rngs() -> None:
+    """Advance the global RNGs to a state unrelated to any sampler seed.
+
+    A sampler whose output depends only on its own (seeded) state must be
+    completely unaffected by this. Only ``numpy`` (the legacy global RNG) and
+    stdlib ``random`` are perturbed -- those are the global generators a sampler
+    could plausibly start drawing from.
+    """
+    random.seed(0x0BADC0DE)
+    [random.random() for _ in range(64)]
+    # numpy's stub types ``seed`` as a sequence/array; pass a single-element seq.
+    np.random.seed([0x1234])
+    np.random.rand(64)
+
+
+def _available_start_methods() -> list[str]:
+    return [m for m in ("fork", "spawn") if m in mp.get_all_start_methods()]
+
+
+class TestDistributedSamplerSubprocessContract(unittest.TestCase):
+    @parameterized.expand([("random",), ("weighted",), ("deterministic",)])
+    def test_output_invariant_to_global_rng_state(self, builder_name: str) -> None:
+        """A sampler's sequence does not depend on ambient global RNG state.
+
+        Catches a regression where the sampler starts drawing from a global RNG
+        (``random`` / ``numpy``) -- which would also silently diverge across a
+        process boundary, since the global state differs there."""
+        builder = _BUILDERS[builder_name]
+        reference = list(builder())
+
+        # Perturbed global RNGs must not change a freshly built sampler's output.
+        _perturb_global_rngs()
+        self.assertEqual(list(builder()), reference, msg=f"fresh build {builder_name}")
+
+        # Nor perturbation between construction and iteration of the same object.
+        sampler = builder()
+        _perturb_global_rngs()
+        self.assertEqual(list(sampler), reference, msg=f"same object {builder_name}")
+
+    def test_shuffle_progression_invariant_to_global_rng_state(self) -> None:
+        """Per-epoch reshuffle (``embed_shuffle``) depends only on the epoch
+        counter, not on ambient global RNG state."""
+        num_epochs = 4
+        reference = _collect_epochs(_build_shuffled_sampler(), num_epochs)
+        # The reshuffle must reorder across epochs (otherwise the test is vacuous).
+        self.assertNotEqual(reference[0], reference[1])
+
+        src = _build_shuffled_sampler()
+        got = []
+        for _ in range(num_epochs):
+            _perturb_global_rngs()
+            got.append(list(src))
+        self.assertEqual(got, reference)
+
+    @parameterized.expand(
+        [
+            (builder_name, num_epochs)
+            for builder_name in ("random", "weighted", "deterministic", "shuffled")
+            for num_epochs in (1, 3)
+        ]
+    )
+    def test_output_survives_pickle_roundtrip(
+        self, builder_name: str, num_epochs: int
+    ) -> None:
+        """Pickling then unpickling a sampler -- exactly what ``spawn`` /
+        ``forkserver`` do to move it into a worker -- preserves its full
+        multi-epoch sequence. Catches reliance on process-local or non-picklable
+        state."""
+        builder = _BUILDERS[builder_name]
+        reference = _collect_epochs(builder(), num_epochs)
+
+        restored = pickle.loads(pickle.dumps(builder()))
+        got = _collect_epochs(restored, num_epochs)
+        self.assertEqual(
+            got, reference, msg=f"builder={builder_name} num_epochs={num_epochs}"
+        )
+
+    @parameterized.expand(
+        [
+            (builder_name, start_method, num_epochs)
+            for builder_name in ("random", "weighted", "deterministic", "shuffled")
+            for start_method in _available_start_methods()
+            for num_epochs in (1, 3)
+        ]
+    )
+    @_ignore_fork_warning
+    def test_sampler_matches_in_subprocess(
+        self, builder_name: str, start_method: str, num_epochs: int
+    ) -> None:
+        """Iterating a sampler in a subprocess yields the identical per-epoch
+        sequence as iterating it in-process, for both ``fork`` and ``spawn`` and
+        for single and multiple epochs."""
+        builder = _BUILDERS[builder_name]
+        reference = _collect_epochs(builder(), num_epochs)
+
+        src = iterate_in_subprocess(builder, mp_context=start_method, timeout=_TIMEOUT)
+        try:
+            got = _collect_epochs(src, num_epochs)
+        finally:
+            finalizer = getattr(src, "_finalizer", None)
+            if finalizer is not None:
+                finalizer()
+        self.assertEqual(
+            got,
+            reference,
+            msg=f"builder={builder_name} start_method={start_method} "
+            f"num_epochs={num_epochs}",
+        )

--- a/tests/pipeline/_subinterp_rng_ops.py
+++ b/tests/pipeline/_subinterp_rng_ops.py
@@ -1,0 +1,24 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""Pipeline ops for the subinterpreter RNG test.
+
+These live in their own **stdlib-only** module because a subinterpreter imports
+the op's defining module to resolve it. The main test module imports NumPy /
+PyTorch (directly and via ``spdl.source``), none of which can be imported in a
+subinterpreter, so the op cannot live there.
+"""
+
+import random
+
+__all__ = ["draw_random"]
+
+
+def draw_random(_: int) -> float:
+    """Draw one stdlib ``random`` value (stdlib only -- subinterpreter-safe)."""
+    return random.random()

--- a/tests/pipeline/rng_state_mtmpmtp_test.py
+++ b/tests/pipeline/rng_state_mtmpmtp_test.py
@@ -1,0 +1,414 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""Global-RNG / sampler consistency across MT, MP and MTP execution modes.
+
+A recurring source of train/eval discrepancies is that switching the data
+pipeline between multi-threading (MT) and sub-processing (MTP) changes the
+behavior of the *global* random number generators (``random``, ``numpy``,
+``torch``) used inside preprocessing functions:
+
+* **MT** runs preprocessing in main-process threads sharing one global RNG.
+* **MTP** runs the whole (threaded) pipeline in a single subprocess. Without
+  coordination, the subprocess either continues the parent's RNG stream
+  (``fork``) or seeds from OS entropy (``spawn``), so its draws are not
+  reproducible run-to-run.
+* **MP** moves the source/sampler into one subprocess and fans preprocessing out
+  to a pool of worker processes.
+
+These tests pin the behavior we actually want:
+
+* SPDL's distributed samplers produce the **same** index sequence in every mode,
+  including MP (the sampler lives in the single subprocess, never duplicated),
+  across single / multi iteration and continuous / non-continuous sources.
+* The global-RNG draws made in preprocessing are reproducible run-to-run in MT
+  and MTP.
+
+The random state of the **MP pool worker processes** is intentionally out of
+scope: those workers run only the preprocessing fan-out, and per-worker random
+state is left to the application.
+"""
+
+import multiprocessing as mp
+import random
+import sys
+import unittest
+import warnings
+from collections.abc import Callable, Iterable, Iterator
+from concurrent.futures import ProcessPoolExecutor
+from contextlib import contextmanager
+from functools import partial
+from typing import Any
+
+import numpy as np
+import torch
+from parameterized import parameterized
+from spdl.pipeline import (
+    build_pipeline,
+    iterate_in_subprocess,
+    run_pipeline_in_subprocess,
+)
+from spdl.pipeline._random_seed import _capture_rng_initializers
+from spdl.pipeline.defs import Pipe, PipelineConfig, SinkConfig, SourceConfig
+from spdl.source import DistributedRandomSampler
+from spdl.source.utils import embed_shuffle
+
+MT = "mt"
+MTP = "mtp"
+MP = "mp"
+
+_TIMEOUT = 60.0
+
+
+# ---------------------------------------------------------------------------
+# Top-level (picklable) pipeline ops and source factories.
+# ---------------------------------------------------------------------------
+def _identity(i: int) -> int:
+    return i
+
+
+def _augment(i: int) -> tuple[int, float, float, float]:
+    """Return the index alongside one draw from each global RNG.
+
+    Running this in the pipeline exercises exactly the global state the modes are
+    supposed to agree on.
+    """
+    return (
+        i,
+        float(np.random.rand()),
+        random.random(),
+        float(torch.rand(1).item()),
+    )
+
+
+def _rng_triples(epoch_items: Iterable[tuple[Any, ...]]) -> list[tuple[Any, ...]]:
+    """Drop the index, keep only the (numpy, random, torch) draw of each item."""
+    return [item[1:] for item in epoch_items]
+
+
+@contextmanager
+def _quiet_subprocess() -> Iterator[None]:
+    """Silence the expected fork-related warnings emitted when a subprocess (or a
+    hoisted ``ProcessPoolExecutor``) is started while pipeline threads are alive."""
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            message=(
+                r"This process \(pid=\d+\) is multi-threaded, use of "
+                r"fork\(\) may lead to deadlocks in the child"
+            ),
+            category=DeprecationWarning,
+        )
+        warnings.filterwarnings(
+            "ignore",
+            message=r"Hoisting a ProcessPoolExecutor.*",
+            category=RuntimeWarning,
+        )
+        yield
+
+
+def _config(
+    source: Iterable[Any],
+    op: Callable[..., Any],
+    *,
+    executor: ProcessPoolExecutor | None = None,
+    concurrency: int = 1,
+    continuous: bool = False,
+) -> PipelineConfig[Any]:
+    return PipelineConfig(
+        src=SourceConfig(source, continuous=continuous),
+        pipes=[Pipe(op, concurrency=concurrency, executor=executor)],
+        sink=SinkConfig(3),
+    )
+
+
+def _run(
+    mode: str,
+    *,
+    source: Iterable[Any],
+    op: Callable[..., Any],
+    workers: int,
+    continuous: bool,
+    num_epochs: int,
+    mp_context: str | None = None,
+) -> list[list[Any]]:
+    """Run ``op`` over ``source`` for ``num_epochs`` epochs in the given mode.
+
+    Returns one list of outputs per epoch.
+    """
+    if mode == MT:
+        out: list[list[Any]] = []
+        if continuous:
+            # A continuous pipeline is built once and re-iterated per epoch.
+            config = _config(source, op, concurrency=workers, continuous=True)
+            pipeline = build_pipeline(config, num_threads=max(workers, 1))
+            with pipeline.auto_stop(timeout=_TIMEOUT):
+                for _ in range(num_epochs):
+                    out.append(list(pipeline.get_iterator(timeout=_TIMEOUT)))
+        else:
+            # A non-continuous in-process pipeline is single-pass, so rebuild it
+            # per epoch (mirroring how the subprocess path rebuilds per iter()).
+            # The shared ``source`` object advances its own epoch state across
+            # rebuilds, exactly like the reference.
+            for _ in range(num_epochs):
+                config = _config(source, op, concurrency=workers, continuous=False)
+                pipeline = build_pipeline(config, num_threads=max(workers, 1))
+                with pipeline.auto_stop(timeout=_TIMEOUT):
+                    out.append(list(pipeline.get_iterator(timeout=_TIMEOUT)))
+        return out
+
+    if mode == MTP:
+        # Threaded pipeline, moved wholesale into one subprocess (no process pool).
+        config = _config(source, op, concurrency=workers, continuous=continuous)
+    elif mode == MP:
+        # Source/sampler in one subprocess; preprocessing fanned out to a pool of
+        # worker processes (hoisted into the main process).
+        config = _config(
+            source,
+            op,
+            executor=ProcessPoolExecutor(max_workers=workers),
+            concurrency=workers,
+            continuous=continuous,
+        )
+    else:
+        raise ValueError(f"Unknown mode: {mode}")
+
+    with _quiet_subprocess():
+        src = run_pipeline_in_subprocess(
+            config,
+            num_threads=max(workers, 1),
+            mp_context=mp_context,
+            timeout=_TIMEOUT,
+        )
+        try:
+            return [list(src) for _ in range(num_epochs)]
+        finally:
+            # Deterministically tear the worker subprocess (and any hoisted pools) down.
+            finalizer = getattr(src, "_finalizer", None)
+            if finalizer is not None:
+                finalizer()
+
+
+def _seed_main(seed: int) -> None:
+    random.seed(seed)
+    # numpy's stub types ``seed`` as a sequence/array; pass a single-element seq.
+    np.random.seed([seed])
+    torch.manual_seed(seed)
+
+
+def _available_start_methods() -> list[str]:
+    return [m for m in ("fork", "spawn") if m in mp.get_all_start_methods()]
+
+
+# ---------------------------------------------------------------------------
+# 1. The distributed sampler must produce the same sequence in every mode.
+# ---------------------------------------------------------------------------
+class TestSamplerConsistency(unittest.TestCase):
+    N = 24
+    SEED = 7
+
+    def _reference(self, *, reshuffle: bool, num_epochs: int) -> list[list[int]]:
+        sampler = DistributedRandomSampler(self.N, rank=0, world_size=1, seed=self.SEED)
+        src = embed_shuffle(sampler) if reshuffle else sampler
+        return [list(src) for _ in range(num_epochs)]
+
+    def _source(self, *, reshuffle: bool) -> Iterable[int]:
+        sampler = DistributedRandomSampler(self.N, rank=0, world_size=1, seed=self.SEED)
+        return embed_shuffle(sampler) if reshuffle else sampler
+
+    @parameterized.expand(
+        [
+            (continuous, reshuffle, num_epochs)
+            for continuous in (False, True)
+            for reshuffle, num_epochs in ((False, 1), (False, 3), (True, 3))
+        ]
+    )
+    def test_sampler_sequence_matches_across_modes(
+        self, continuous: bool, reshuffle: bool, num_epochs: int
+    ) -> None:
+        """Each mode yields the identical per-epoch index sequence (concurrency=1
+        preserves order, so we can compare sequences exactly)."""
+        reference = self._reference(reshuffle=reshuffle, num_epochs=num_epochs)
+
+        for mode in (MT, MTP, MP):
+            got = _run(
+                mode,
+                source=self._source(reshuffle=reshuffle),
+                op=_identity,
+                workers=1,
+                continuous=continuous,
+                num_epochs=num_epochs,
+            )
+            self.assertEqual(
+                got,
+                reference,
+                msg=f"mode={mode} continuous={continuous} reshuffle={reshuffle}",
+            )
+
+
+# ---------------------------------------------------------------------------
+# 2. Global-RNG draws must be reproducible run-to-run (MT and MTP).
+# ---------------------------------------------------------------------------
+class TestReproducibleAcrossRuns(unittest.TestCase):
+    N = 32
+    SEED = 2024
+
+    def _collect(
+        self, mode: str, *, start_method: str, continuous: bool
+    ) -> list[tuple[Any, ...]]:
+        _seed_main(self.SEED)
+        # workers=1 keeps a single deterministic stream, so the sequence of draws
+        # is well-defined regardless of task scheduling.
+        epochs = _run(
+            mode,
+            source=range(self.N),
+            op=_augment,
+            workers=1,
+            continuous=continuous,
+            num_epochs=1,
+            mp_context=start_method,
+        )
+        return _rng_triples(epochs[0])
+
+    @parameterized.expand(
+        [
+            (mode, start_method, continuous)
+            for mode in (MT, MTP)
+            for start_method in _available_start_methods()
+            for continuous in (False, True)
+        ]
+    )
+    def test_same_seed_same_draws(self, mode, start_method, continuous) -> None:
+        """Re-seeding the main process and re-running yields identical draws.
+
+        Pre-fix, MTP with ``spawn`` seeds from OS entropy, so the two runs differ;
+        with ``fork`` it continues the parent stream, so the value depends on
+        whatever the main process drew beforehand."""
+        if mode == MT and start_method != _available_start_methods()[0]:
+            # MT runs in-process; the subprocess start method is irrelevant.
+            self.skipTest("MT is start-method independent")
+
+        first = self._collect(mode, start_method=start_method, continuous=continuous)
+        second = self._collect(mode, start_method=start_method, continuous=continuous)
+        self.assertEqual(len(first), self.N)
+        self.assertEqual(
+            first,
+            second,
+            msg=f"mode={mode} start_method={start_method} continuous={continuous}",
+        )
+
+
+# ---------------------------------------------------------------------------
+# 3. The subprocess continues the main process' *exact current* RNG stream.
+#
+# This is the distinguishing property of copying the live state (vs. merely
+# re-deriving a stream from a seed): if the main process advances its global
+# RNGs before the pipeline is built, the subprocess must continue from that
+# advanced position, not from the original seed.
+# ---------------------------------------------------------------------------
+def _draw_global_triples(n: int) -> list[tuple[float, float, float]]:
+    """Draw ``n`` triples, one from each global RNG. Top-level + returns a list so
+    it is picklable and re-iterable across the subprocess boundary."""
+    return [
+        (random.random(), float(np.random.rand()), float(torch.rand(1).item()))
+        for _ in range(n)
+    ]
+
+
+class TestGlobalRngStateCopiedToSubprocess(unittest.TestCase):
+    N = 8
+
+    @parameterized.expand([(m,) for m in _available_start_methods()])
+    def test_subprocess_continues_advanced_main_stream(self, start_method: str) -> None:
+        """The subprocess resumes the main process' global RNG stream from its
+        current (already-advanced) position, identically for ``fork`` and
+        ``spawn`` -- proving the live state is copied, not just re-seeded."""
+        random.seed(20240101)
+        np.random.seed([20240101])
+        torch.manual_seed(20240101)
+        # Advance all three streams so the captured state is distinct from the
+        # seed's starting state.
+        _draw_global_triples(5)
+
+        # Snapshot the advanced state via the same mechanism the pipeline uses.
+        initializers = _capture_rng_initializers()
+
+        # In-process reference: restore the snapshot, then draw.
+        for init in initializers:
+            init()
+        reference = _draw_global_triples(self.N)
+
+        # Subprocess: restore the same snapshot there, then draw. Must match.
+        with _quiet_subprocess():
+            src = iterate_in_subprocess(
+                partial(_draw_global_triples, self.N),
+                initializer=initializers,
+                mp_context=start_method,
+                timeout=_TIMEOUT,
+            )
+            try:
+                got = list(src)
+            finally:
+                finalizer = getattr(src, "_finalizer", None)
+                if finalizer is not None:
+                    finalizer()
+
+        self.assertEqual(len(got), self.N)
+        self.assertEqual(got, reference, msg=f"start_method={start_method}")
+
+
+# ---------------------------------------------------------------------------
+# 4. The subinterpreter continues the main interpreter's *exact current* stdlib
+#    ``random`` stream.
+#
+# Subinterpreters cannot import numpy / torch and cannot receive their (non
+# -shareable) RNG state objects, so only the stdlib ``random`` state crosses the
+# boundary. This pins that the stdlib stream is copied (not re-seeded) and, just
+# as importantly, that wiring it through ``run_pipeline_in_subinterpreter`` does
+# not raise ``NotShareableError``.
+# ---------------------------------------------------------------------------
+@unittest.skipUnless(
+    sys.version_info >= (3, 14), "subinterpreters require Python 3.14+"
+)
+class TestStdlibRandomStateCopiedToSubinterpreter(unittest.TestCase):
+    N = 8
+
+    def test_subinterpreter_continues_advanced_random_stream(self) -> None:
+        """The subinterpreter resumes the main interpreter's stdlib ``random``
+        stream from its current (already-advanced) position -- proving the live
+        state is copied across the interpreter boundary, not re-seeded.
+
+        The op lives in a stdlib-only helper module: a subinterpreter imports the
+        op's defining module to resolve it, and this test module's top-level
+        ``import numpy`` / ``import torch`` cannot be imported there."""
+        from spdl.pipeline import run_pipeline_in_subinterpreter
+
+        from ._subinterp_rng_ops import draw_random
+
+        random.seed(20240101)
+        # Advance the stream so the captured state differs from the seed start.
+        [random.random() for _ in range(5)]
+
+        # In-process reference: snapshot the advanced state, then draw N values.
+        snapshot = random.getstate()
+        reference = [random.random() for _ in range(self.N)]
+
+        # The subinterpreter restores the same snapshot (shipped as a shareable
+        # initializer) and must produce the identical sequence.
+        random.setstate(snapshot)
+        config = _config(range(self.N), draw_random, concurrency=1)
+        src = run_pipeline_in_subinterpreter(config, num_threads=1, timeout=_TIMEOUT)
+        try:
+            got = list(src)
+        finally:
+            finalizer = getattr(src, "_finalizer", None)
+            if finalizer is not None:
+                finalizer()
+
+        self.assertEqual(len(got), self.N)
+        self.assertEqual(got, reference)


### PR DESCRIPTION
Switching a data pipeline between in-process multi-threading (MT) and worker-based execution (subprocess via `run_pipeline_in_subprocess`, or subinterpreter via `run_pipeline_in_subinterpreter`) silently changes the behavior of the *global* RNGs (`random`, `numpy`, `torch`) used inside preprocessing functions. With the `fork` start method the worker continues the parent stream; with `spawn`/`forkserver` it seeds from OS entropy. Either way draws differ from MT and are not reproducible run-to-run, a recurring source of train/eval discrepancies.

This captures the main process current global RNG state at build time and restores it in the worker before iteration, so RNG-dependent work (e.g. data augmentation) continues from exactly the state the main process was in, regardless of the start method and with no user opt-in. If the main process is seeded (`random.seed(k)`, `numpy.random.seed(k)`, `torch.manual_seed(k)`), the worker inherits that seeding seamlessly, so draws are reproducible across program runs just as they are in-process, the same contract as `torch.utils.data.DataLoader`.

`numpy` and `torch` state is captured only when the program has already imported them; the core `spdl.pipeline` package stays pure Python and never imports them on your behalf.

**Subinterpreter limitation.** For `run_pipeline_in_subinterpreter`, only the stdlib `random` state is copied. The restore initializers cross the interpreter boundary as call arguments and so must be *shareable* across interpreters: stdlib `random.getstate()` is a plain tuple and qualifies, but the captured `numpy` / `torch` state objects (a NumPy array and a tensor) are not. More fundamentally, `numpy` and `torch` cannot be imported in a subinterpreter at all (on 3.14, `import numpy` raises `ImportError`), so a pipeline running there cannot use them regardless. NumPy / PyTorch randomness in a subinterpreter must therefore be seeded from within `config`, e.g. via an SPDL sampler that stores an explicit seed.

This copies the **global** generators only. A `numpy.random.Generator` from `numpy.random.default_rng` is an independent object and is untouched; `torch` CUDA device RNG state is not copied (CPU generator only); and hash randomization (`PYTHONHASHSEED`) / entropy sources (`os.urandom`, `secrets`, `uuid.uuid4`) are out of reach. SPDL own samplers build a private `numpy.random.Generator` from their stored seed, so they already produce identical sequences in every mode.