### PR TITLE
[pipeline] make pipeline tests robust to CPU oversubscription

### DIFF
--- a/tests/pipeline/aggregate_test.py
+++ b/tests/pipeline/aggregate_test.py
@@ -281,7 +281,7 @@ class AggregatePipeEndToEndTest(unittest.TestCase):
         )
 
         with pipeline.auto_stop():
-            results = list(pipeline.get_iterator(timeout=10))
+            results = list(pipeline.get_iterator(timeout=30))
             self.assertEqual(results, [[0, 1, 2], [3, 4, 5], [6, 7, 8], [9]])
 
     def test_aggregate_custom_op_bulk_drain(self) -> None:
@@ -322,5 +322,5 @@ class AggregatePipeEndToEndTest(unittest.TestCase):
         )
 
         with pipeline.auto_stop():
-            results = list(pipeline.get_iterator(timeout=10))
+            results = list(pipeline.get_iterator(timeout=30))
             self.assertEqual(results, ["abbcccdddd", "effgggh"])

--- a/tests/pipeline/background_task_test.py
+++ b/tests/pipeline/background_task_test.py
@@ -108,7 +108,7 @@ class BackgroundTaskTest(unittest.TestCase):
         )
 
         with pipeline.auto_stop():
-            items = list(pipeline.get_iterator(timeout=3))
+            items = list(pipeline.get_iterator(timeout=30))
 
         self.assertEqual(sorted(items), [0, 1, 2, 3, 4])
         self.assertTrue(task_instance.started, "Background task should have started")
@@ -123,7 +123,7 @@ class BackgroundTaskTest(unittest.TestCase):
         )
 
         with pipeline.auto_stop():
-            items = list(pipeline.get_iterator(timeout=3))
+            items = list(pipeline.get_iterator(timeout=30))
 
         self.assertEqual(sorted(items), [0, 1, 2, 3, 4])
 
@@ -139,7 +139,7 @@ class BackgroundTaskTest(unittest.TestCase):
         )
 
         with pipeline.auto_stop():
-            items = list(pipeline.get_iterator(timeout=3))
+            items = list(pipeline.get_iterator(timeout=30))
 
         self.assertEqual(sorted(items), [0, 1, 2, 3, 4])
         self.assertGreater(task_0.count, 0, "First background task should have run")
@@ -150,7 +150,7 @@ class BackgroundTaskTest(unittest.TestCase):
         pipeline = build_pipeline(_simple_cfg(), num_threads=1)
 
         with pipeline.auto_stop():
-            items = list(pipeline.get_iterator(timeout=3))
+            items = list(pipeline.get_iterator(timeout=30))
 
         self.assertEqual(sorted(items), [0, 1, 2, 3, 4])
 
@@ -159,7 +159,7 @@ class BackgroundTaskTest(unittest.TestCase):
         pipeline = build_pipeline(_simple_cfg(), num_threads=1, background_tasks=[])
 
         with pipeline.auto_stop():
-            items = list(pipeline.get_iterator(timeout=3))
+            items = list(pipeline.get_iterator(timeout=30))
 
         self.assertEqual(sorted(items), [0, 1, 2, 3, 4])
 
@@ -174,7 +174,7 @@ class BackgroundTaskTest(unittest.TestCase):
         )
 
         with pipeline.auto_stop():
-            items = list(pipeline.get_iterator(timeout=10))
+            items = list(pipeline.get_iterator(timeout=30))
 
         self.assertEqual(sorted(items), [0, 1, 2])
         self.assertTrue(
@@ -192,7 +192,7 @@ class BackgroundTaskTest(unittest.TestCase):
         )
 
         with pipeline.auto_stop():
-            items = list(pipeline.get_iterator(timeout=3))
+            items = list(pipeline.get_iterator(timeout=30))
 
         self.assertEqual(sorted(items), [0, 1, 2, 3, 4])
         self.assertTrue(good_task.started, "Good background task should have run")
@@ -217,7 +217,7 @@ class BackgroundTaskTest(unittest.TestCase):
         )
 
         with pipeline.auto_stop():
-            items = list(pipeline.get_iterator(timeout=3))
+            items = list(pipeline.get_iterator(timeout=30))
 
         self.assertEqual(sorted(items), [0, 1, 2, 3, 4])
         self.assertTrue(MyTask.ran, "Task class used as factory should have run")
@@ -252,7 +252,7 @@ class DefaultBackgroundTasksTest(unittest.TestCase):
         pipeline = build_pipeline(_simple_cfg(), num_threads=1)
 
         with pipeline.auto_stop():
-            items = list(pipeline.get_iterator(timeout=3))
+            items = list(pipeline.get_iterator(timeout=30))
 
         self.assertEqual(sorted(items), [0, 1, 2, 3, 4])
         self.assertTrue(
@@ -271,7 +271,7 @@ class DefaultBackgroundTasksTest(unittest.TestCase):
         )
 
         with pipeline.auto_stop():
-            items = list(pipeline.get_iterator(timeout=3))
+            items = list(pipeline.get_iterator(timeout=30))
 
         self.assertEqual(sorted(items), [0, 1, 2, 3, 4])
         self.assertTrue(default_task.started, "Default background task should have run")

--- a/tests/pipeline/continuous_pipeline_test.py
+++ b/tests/pipeline/continuous_pipeline_test.py
@@ -90,7 +90,7 @@ class TestContinuousPipelineBasic(unittest.TestCase):
 
         with pipeline.auto_stop():
             for epoch in range(3):
-                result = list(pipeline.get_iterator(timeout=5))
+                result = list(pipeline.get_iterator(timeout=30))
                 self.assertEqual(result, [0, 1, 2, 3, 4], f"epoch {epoch}")
 
     def test_continuous_single_epoch(self) -> None:
@@ -103,7 +103,7 @@ class TestContinuousPipelineBasic(unittest.TestCase):
         )
 
         with pipeline.auto_stop():
-            result = list(pipeline.get_iterator(timeout=5))
+            result = list(pipeline.get_iterator(timeout=30))
             self.assertEqual(result, [0, 1, 2])
 
     def test_continuous_empty_epoch(self) -> None:
@@ -117,7 +117,7 @@ class TestContinuousPipelineBasic(unittest.TestCase):
 
         with pipeline.auto_stop():
             for epoch in range(3):
-                result = list(pipeline.get_iterator(timeout=5))
+                result = list(pipeline.get_iterator(timeout=30))
                 self.assertEqual(result, [], f"epoch {epoch}")
 
     def test_continuous_single_item_epoch(self) -> None:
@@ -131,7 +131,7 @@ class TestContinuousPipelineBasic(unittest.TestCase):
 
         with pipeline.auto_stop():
             for epoch in range(3):
-                result = list(pipeline.get_iterator(timeout=5))
+                result = list(pipeline.get_iterator(timeout=30))
                 self.assertEqual(result, [0], f"epoch {epoch}")
 
 
@@ -152,7 +152,7 @@ class TestContinuousPipelinePipe(unittest.TestCase):
 
         with pipeline.auto_stop():
             for epoch in range(3):
-                result = sorted(pipeline.get_iterator(timeout=5))
+                result = sorted(pipeline.get_iterator(timeout=30))
                 self.assertEqual(result, [0, 2, 4, 6, 8], f"epoch {epoch}")
 
     def test_continuous_pipe_chain(self) -> None:
@@ -175,7 +175,7 @@ class TestContinuousPipelinePipe(unittest.TestCase):
 
         with pipeline.auto_stop():
             for epoch in range(3):
-                result = list(pipeline.get_iterator(timeout=5))
+                result = list(pipeline.get_iterator(timeout=30))
                 self.assertEqual(result, [2, 4, 6], f"epoch {epoch}")
 
 
@@ -192,7 +192,7 @@ class TestContinuousPipelineAggregate(unittest.TestCase):
 
         with pipeline.auto_stop():
             for epoch in range(3):
-                result = list(pipeline.get_iterator(timeout=5))
+                result = list(pipeline.get_iterator(timeout=30))
                 self.assertEqual(result, [[0, 1, 2], [3, 4, 5]], f"epoch {epoch}")
 
     def test_continuous_aggregate_partial_batch_flushed(self) -> None:
@@ -207,7 +207,7 @@ class TestContinuousPipelineAggregate(unittest.TestCase):
 
         with pipeline.auto_stop():
             for epoch in range(3):
-                result = list(pipeline.get_iterator(timeout=5))
+                result = list(pipeline.get_iterator(timeout=30))
                 # 5 items, batch_size=3: full batch [0,1,2] + partial batch [3,4]
                 self.assertEqual(result, [[0, 1, 2], [3, 4]], f"epoch {epoch}")
 
@@ -223,7 +223,7 @@ class TestContinuousPipelineAggregate(unittest.TestCase):
 
         with pipeline.auto_stop():
             for epoch in range(3):
-                result = list(pipeline.get_iterator(timeout=5))
+                result = list(pipeline.get_iterator(timeout=30))
                 # 5 items, batch_size=3, drop_last: only [0,1,2], partial [3,4] dropped
                 self.assertEqual(result, [[0, 1, 2]], f"epoch {epoch}")
 
@@ -239,7 +239,7 @@ class TestContinuousPipelineShutdown(unittest.TestCase):
         )
 
         with pipeline.auto_stop():
-            it = pipeline.get_iterator(timeout=5)
+            it = pipeline.get_iterator(timeout=30)
             # Consume only a few items
             self.assertEqual(next(it), 0)
             self.assertEqual(next(it), 1)
@@ -255,7 +255,7 @@ class TestContinuousPipelineShutdown(unittest.TestCase):
         )
 
         with pipeline.auto_stop():
-            result = list(pipeline.get_iterator(timeout=5))
+            result = list(pipeline.get_iterator(timeout=30))
             self.assertEqual(result, [0, 1, 2])
             # auto_stop exits here after one epoch — must not hang
 
@@ -269,9 +269,9 @@ class TestContinuousPipelineShutdown(unittest.TestCase):
         )
 
         with pipeline.auto_stop():
-            r1 = list(pipeline.get_iterator(timeout=5))
-            r2 = list(pipeline.get_iterator(timeout=5))
-            r3 = list(pipeline.get_iterator(timeout=5))
+            r1 = list(pipeline.get_iterator(timeout=30))
+            r2 = list(pipeline.get_iterator(timeout=30))
+            r3 = list(pipeline.get_iterator(timeout=30))
             self.assertEqual(r1, [0, 1, 2])
             self.assertEqual(r2, [0, 1, 2])
             self.assertEqual(r3, [0, 1, 2])
@@ -288,7 +288,7 @@ class TestContinuousPipelineShutdown(unittest.TestCase):
                 )
 
                 with pipeline.auto_stop():
-                    it = pipeline.get_iterator(timeout=5)
+                    it = pipeline.get_iterator(timeout=30)
                     self.assertEqual(list(it), [0, 1, 2])
                     # Reusing the same iterator does not start a new epoch.
                     self.assertEqual(list(it), [])
@@ -308,7 +308,7 @@ class TestContinuousPipelineShutdown(unittest.TestCase):
         )
 
         with pipeline.auto_stop():
-            r1 = sorted(pipeline.get_iterator(timeout=5))
+            r1 = sorted(pipeline.get_iterator(timeout=30))
             self.assertEqual(r1, [0, 2, 4, 6, 8])
             # auto_stop exits — pipeline has items buffered for next epoch
             # stop() must drain and shut down cleanly
@@ -333,7 +333,7 @@ class TestContinuousPipelineShutdown(unittest.TestCase):
         )
 
         with pipeline.auto_stop():
-            r1 = list(pipeline.get_iterator(timeout=5))
+            r1 = list(pipeline.get_iterator(timeout=30))
             self.assertEqual(r1, [0, 1, 2, 3, 4])
             # auto_stop exits — must not hang on subprocess IPC
 
@@ -402,7 +402,7 @@ class TestContinuousPipelineShutdown(unittest.TestCase):
 
         with pipeline.auto_stop():
             for epoch in range(3):
-                result = list(pipeline.get_iterator(timeout=5))
+                result = list(pipeline.get_iterator(timeout=30))
                 self.assertEqual(result, [0, 1, 2, 3, 4], f"epoch {epoch}")
 
     @_ignore_fork_warning
@@ -428,7 +428,7 @@ class TestContinuousPipelineShutdown(unittest.TestCase):
         )
 
         with pipeline.auto_stop():
-            it = pipeline.get_iterator(timeout=5)
+            it = pipeline.get_iterator(timeout=30)
             self.assertEqual(next(it), 0)
             self.assertEqual(next(it), 1)
             # auto_stop exits mid-epoch — must not hang
@@ -461,11 +461,11 @@ class TestContinuousPipelineShutdown(unittest.TestCase):
         )
 
         pipeline.start()
-        finalizer = weakref.finalize(pipeline, lambda p: p.stop(timeout=10), pipeline)
+        finalizer = weakref.finalize(pipeline, lambda p: p.stop(timeout=30), pipeline)
 
         # Iterate 2 epochs
         for epoch in range(2):
-            result = list(pipeline.get_iterator(timeout=5))
+            result = list(pipeline.get_iterator(timeout=30))
             self.assertEqual(result, [0, 1, 2, 3, 4], f"epoch {epoch}")
 
         t0 = time.monotonic()
@@ -494,7 +494,7 @@ class TestContinuousPipelinePathVariants(unittest.TestCase):
 
         with pipeline.auto_stop():
             for epoch in range(3):
-                result = sorted(pipeline.get_iterator(timeout=5))
+                result = sorted(pipeline.get_iterator(timeout=30))
                 self.assertEqual(result, [0, 4, 8, 101, 103, 105], f"epoch {epoch}")
 
     def test_continuous_path_variants_empty_epoch(self) -> None:
@@ -515,7 +515,7 @@ class TestContinuousPipelinePathVariants(unittest.TestCase):
 
         with pipeline.auto_stop():
             for epoch in range(3):
-                result = list(pipeline.get_iterator(timeout=5))
+                result = list(pipeline.get_iterator(timeout=30))
                 self.assertEqual(result, [], f"epoch {epoch}")
 
     def test_continuous_nested_path_variants_multi_epoch(self) -> None:
@@ -546,7 +546,7 @@ class TestContinuousPipelinePathVariants(unittest.TestCase):
 
         with pipeline.auto_stop():
             for epoch in range(3):
-                result = sorted(pipeline.get_iterator(timeout=5))
+                result = sorted(pipeline.get_iterator(timeout=30))
                 # evens 0,4 -> 0,4; evens 2,6 -> 20,60; odds 1,3,5,7 -> 101..107
                 self.assertEqual(
                     result, [0, 4, 20, 60, 101, 103, 105, 107], f"epoch {epoch}"
@@ -570,7 +570,7 @@ class TestContinuousPipelinePathVariants(unittest.TestCase):
 
         with pipeline.auto_stop():
             for epoch in range(3):
-                result = list(pipeline.get_iterator(timeout=5))
+                result = list(pipeline.get_iterator(timeout=30))
                 # evens -> [0, 2] full batch + [4] partial flushed at epoch end;
                 # odds -> 101, 103, 105. Cross-path order is nondeterministic.
                 self.assertCountEqual(
@@ -604,7 +604,7 @@ class TestContinuousPipelinePathVariants(unittest.TestCase):
         with pipeline.auto_stop():
             for epoch in range(4):
                 base = epoch * 100
-                result = sorted(pipeline.get_iterator(timeout=10))
+                result = sorted(pipeline.get_iterator(timeout=30))
                 # Each epoch must contain exactly its own disjoint block. A
                 # next-epoch fast-path item leaking in would show as a value
                 # >= base + 100; the fan-in barrier parks the fast path at the
@@ -636,7 +636,7 @@ class TestContinuousPipelineErrors(unittest.TestCase):
 
         with self.assertRaises(PipelineFailure):
             with pipeline.auto_stop():
-                list(pipeline.get_iterator(timeout=5))
+                list(pipeline.get_iterator(timeout=30))
 
     def test_continuous_pipe_failure(self) -> None:
         """Pipe function raising propagates error."""
@@ -656,7 +656,7 @@ class TestContinuousPipelineErrors(unittest.TestCase):
 
         with self.assertRaises(PipelineFailure):
             with pipeline.auto_stop():
-                list(pipeline.get_iterator(timeout=5))
+                list(pipeline.get_iterator(timeout=30))
 
 
 class TestContinuousPipelineValidation(unittest.TestCase):

--- a/tests/pipeline/failure_rate_test.py
+++ b/tests/pipeline/failure_rate_test.py
@@ -136,7 +136,7 @@ class PipelineFailureRateTest(unittest.TestCase):
         )
 
         with pipeline.auto_stop():
-            vals = list(pipeline.get_iterator(timeout=10))
+            vals = list(pipeline.get_iterator(timeout=30))
 
         # Should get all non-multiples of 10
         expected = [x for x in range(100) if x % 10 != 0]
@@ -173,7 +173,7 @@ class PipelineFailureRateTest(unittest.TestCase):
         )
 
         with pipeline.auto_stop():
-            vals = list(pipeline.get_iterator(timeout=10))
+            vals = list(pipeline.get_iterator(timeout=30))
 
         # Should get values 0-89 (90 successful items)
         self.assertEqual(list(range(90)), vals)
@@ -209,7 +209,7 @@ class PipelineFailureRateTest(unittest.TestCase):
         vals = []
         with self.assertRaises(PipelineFailure):
             with pipeline.auto_stop():
-                vals = list(pipeline.get_iterator(timeout=10))
+                vals = list(pipeline.get_iterator(timeout=30))
 
         # Should get values 0-89 (90 successful items)
         self.assertEqual(list(range(90)), vals)
@@ -244,7 +244,7 @@ class PipelineFailureRateTest(unittest.TestCase):
         )
 
         with pipeline.auto_stop():
-            vals = list(pipeline.get_iterator(timeout=10))
+            vals = list(pipeline.get_iterator(timeout=30))
 
         # Should get all non-multiples of 5: 1,2,3,4,6,7,8,9,11,12,13,14,16,17,18,19
         expected = [x for x in range(20) if x % 5 != 0]
@@ -286,7 +286,7 @@ class PipelineFailureRateTest(unittest.TestCase):
         vals = []
         with self.assertRaises(PipelineFailure):
             with pipeline.auto_stop():
-                vals = list(pipeline.get_iterator(timeout=10))
+                vals = list(pipeline.get_iterator(timeout=30))
 
         # Should get all non-multiples of 7
         expected = [x for x in range(100) if x % 7 != 0]
@@ -332,7 +332,7 @@ class PipelineFailureRateTest(unittest.TestCase):
         # Fails on 0,12,24,36,48,60,72,84,96 = 9 failures out of 50 = 18%
         # With 22% threshold, should succeed
         with pipeline.auto_stop():
-            vals = list(pipeline.get_iterator(timeout=10))
+            vals = list(pipeline.get_iterator(timeout=30))
 
         # Even numbers not divisible by 12: 2,4,6,8,10,14,16,...
         expected = [x for x in range(100) if x % 2 == 0 and x % 12 != 0]
@@ -367,7 +367,7 @@ class PipelineFailureRateTest(unittest.TestCase):
         )
 
         with pipeline.auto_stop():
-            vals = list(pipeline.get_iterator(timeout=10))
+            vals = list(pipeline.get_iterator(timeout=30))
 
         # Should get all non-multiples of 10
         expected = [x for x in range(100) if x % 10 != 0]
@@ -385,7 +385,7 @@ class PipelineFailureRateTest(unittest.TestCase):
         vals = []
         with self.assertRaises(PipelineFailure):
             with pipeline.auto_stop():
-                vals = list(pipeline.get_iterator(timeout=10))
+                vals = list(pipeline.get_iterator(timeout=30))
 
         # Pipeline stops early after 5 failures; vals is a subset of expected
         all_expected = {x for x in range(100) if x % 10 != 0}
@@ -417,7 +417,7 @@ class PipelineFailureRateTest(unittest.TestCase):
         vals = []
         with self.assertRaises(PipelineFailure):
             with pipeline.auto_stop():
-                vals = list(pipeline.get_iterator(timeout=10))
+                vals = list(pipeline.get_iterator(timeout=30))
 
         # Should get all non-multiples of 7
         expected = [x for x in range(100) if x % 7 != 0]
@@ -459,7 +459,7 @@ class PipelineFailureRateTest(unittest.TestCase):
 
         with self.assertRaises(PipelineFailure):
             with pipeline.auto_stop():
-                list(pipeline.get_iterator(timeout=10))
+                list(pipeline.get_iterator(timeout=30))
 
     @parameterized.expand(
         [
@@ -486,7 +486,7 @@ class PipelineFailureRateTest(unittest.TestCase):
         )
 
         with pipeline.auto_stop():
-            vals = list(pipeline.get_iterator(timeout=10))
+            vals = list(pipeline.get_iterator(timeout=30))
 
         # Should get all values doubled
         self.assertEqual([x * 2 for x in range(100)], vals)
@@ -524,7 +524,7 @@ class PipelineFailureRateTest(unittest.TestCase):
 
         # Should succeed despite 40% > 30% because probation not complete
         with pipeline.auto_stop():
-            vals = list(pipeline.get_iterator(timeout=10))
+            vals = list(pipeline.get_iterator(timeout=30))
 
         # Should get all non-multiples of 3: 1, 2, 4, 5, 7, 8
         expected = [x for x in range(10) if x % 3 != 0]
@@ -620,7 +620,7 @@ class PipelineFailureRateTest(unittest.TestCase):
 
         # Should complete without PipelineFailure (100% failures allowed)
         with pipeline.auto_stop():
-            vals = list(pipeline.get_iterator(timeout=10))
+            vals = list(pipeline.get_iterator(timeout=30))
 
         # No items should pass through since all fail
         self.assertEqual([], vals)
@@ -685,7 +685,7 @@ class PipelineFailureRateTest(unittest.TestCase):
                 .build(num_threads=1, max_failures=fraction)
             )
             with pipeline.auto_stop():
-                vals = list(pipeline.get_iterator(timeout=10))
+                vals = list(pipeline.get_iterator(timeout=30))
             self.assertEqual(list(range(10)), vals)
 
     @parameterized.expand(
@@ -738,7 +738,7 @@ class PipelineFailureRateTest(unittest.TestCase):
         )
 
         with pipeline.auto_stop():
-            vals = list(pipeline.get_iterator(timeout=10))
+            vals = list(pipeline.get_iterator(timeout=30))
 
         # All values should pass through
         self.assertEqual(list(range(100)), vals)
@@ -766,7 +766,7 @@ class PipelineFailureRateTest(unittest.TestCase):
         )
 
         with pipeline.auto_stop():
-            vals = list(pipeline.get_iterator(timeout=10))
+            vals = list(pipeline.get_iterator(timeout=30))
 
         # Should get all non-multiples of 5: 1, 2, 3, 4, 6, 7, 8, 9
         expected = [x for x in range(10) if x % 5 != 0]
@@ -797,7 +797,7 @@ class PipelineFailureRateTest(unittest.TestCase):
         vals = []
         with self.assertRaises(PipelineFailure):
             with pipeline.auto_stop():
-                vals = list(pipeline.get_iterator(timeout=10))
+                vals = list(pipeline.get_iterator(timeout=30))
 
         # Should get all non-multiples of 5
         expected = [x for x in range(100) if x % 5 != 0]

--- a/tests/pipeline/merge_config_test.py
+++ b/tests/pipeline/merge_config_test.py
@@ -48,7 +48,7 @@ class MergeConfigTest(unittest.TestCase):
         pipeline = build_pipeline(main_pipeline_config, num_threads=2)
 
         with pipeline.auto_stop():
-            results = list(pipeline.get_iterator(timeout=3))
+            results = list(pipeline.get_iterator(timeout=30))
 
         self.assertEqual(len(results), 6)
         self.assertCountEqual(results, [1, 2, 3, 4, 5, 6])
@@ -79,7 +79,7 @@ class MergeConfigTest(unittest.TestCase):
         pipeline = build_pipeline(main_pipeline_config, num_threads=2)
 
         with pipeline.auto_stop():
-            results = list(pipeline.get_iterator(timeout=3))
+            results = list(pipeline.get_iterator(timeout=30))
 
         self.assertEqual(len(results), 6)
         # Pipeline 1: [1, 2, 3] -> [2, 4, 6] (doubled)
@@ -115,7 +115,7 @@ class MergeConfigTest(unittest.TestCase):
         pipeline = build_pipeline(main_pipeline_config, num_threads=3)
 
         with pipeline.auto_stop():
-            results = list(pipeline.get_iterator(timeout=3))
+            results = list(pipeline.get_iterator(timeout=30))
 
         self.assertEqual(len(results), 6)
         self.assertCountEqual(results, [1, 2, 10, 20, 100, 200])
@@ -145,7 +145,7 @@ class MergeConfigTest(unittest.TestCase):
         pipeline = build_pipeline(main_pipeline_config, num_threads=2)
 
         with pipeline.auto_stop():
-            results = list(pipeline.get_iterator(timeout=3))
+            results = list(pipeline.get_iterator(timeout=30))
 
         self.assertEqual(len(results), 6)
         self.assertCountEqual(results, [5, 10, 15, 20, 25, 30])
@@ -180,7 +180,7 @@ class MergeConfigTest(unittest.TestCase):
         pipeline = build_pipeline(main_pipeline_config, num_threads=2)
 
         with pipeline.auto_stop():
-            results = list(pipeline.get_iterator(timeout=5))
+            results = list(pipeline.get_iterator(timeout=30))
 
         self.assertEqual(len(results), 6)
         self.assertCountEqual(results, [2, 4, 6, 8, 10, 12])
@@ -208,7 +208,7 @@ class MergeConfigTest(unittest.TestCase):
         pipeline = build_pipeline(main_pipeline_config, num_threads=2)
 
         with pipeline.auto_stop():
-            results = list(pipeline.get_iterator(timeout=3))
+            results = list(pipeline.get_iterator(timeout=30))
 
         self.assertEqual(len(results), 6)
         self.assertCountEqual(results, [1, 2, 3, "a", "b", "c"])
@@ -236,7 +236,7 @@ class MergeConfigTest(unittest.TestCase):
         pipeline = build_pipeline(main_pipeline_config, num_threads=2)
 
         with pipeline.auto_stop():
-            results = list(pipeline.get_iterator(timeout=3))
+            results = list(pipeline.get_iterator(timeout=30))
 
         self.assertEqual(len(results), 3)
         self.assertCountEqual(results, [1, 2, 3])
@@ -276,7 +276,7 @@ class MergeConfigTest(unittest.TestCase):
         pipeline = build_pipeline(main_pipeline_config, num_threads=2)
 
         with pipeline.auto_stop():
-            results = list(pipeline.get_iterator(timeout=3))
+            results = list(pipeline.get_iterator(timeout=30))
 
         self.assertEqual(len(results), 8)
         self.assertCountEqual(results, [1, 2, 3, 4, 10, 20, 30, 40])
@@ -306,7 +306,7 @@ class MergeConfigTest(unittest.TestCase):
         pipeline = build_pipeline(main_pipeline_config, num_threads=4)
 
         with pipeline.auto_stop():
-            results = list(pipeline.get_iterator(timeout=3))
+            results = list(pipeline.get_iterator(timeout=30))
 
         self.assertEqual(len(results), 20)
         expected = list(range(100, 110)) + list(range(150, 160))
@@ -347,7 +347,7 @@ class MergeConfigTest(unittest.TestCase):
         pipeline = build_pipeline(main_pipeline_config, num_threads=2)
 
         with pipeline.auto_stop():
-            results = list(pipeline.get_iterator(timeout=3))
+            results = list(pipeline.get_iterator(timeout=30))
 
         self.assertEqual(len(results), 5)
 
@@ -415,7 +415,7 @@ class MergeConfigTest(unittest.TestCase):
         pipeline = build_pipeline(main_pipeline_config, num_threads=2)
 
         with pipeline.auto_stop():
-            results = list(pipeline.get_iterator(timeout=3))
+            results = list(pipeline.get_iterator(timeout=30))
 
         # Verify we got all items with prefixes
         self.assertEqual(len(results), 6)
@@ -466,7 +466,7 @@ class MergeConfigTest(unittest.TestCase):
         pipeline = build_pipeline(main_pipeline_config, num_threads=2)
 
         with pipeline.auto_stop():
-            results = list(pipeline.get_iterator(timeout=3))
+            results = list(pipeline.get_iterator(timeout=30))
 
         self.assertEqual(results, [1, 4, 2, 5, 3, 6])
 

--- a/tests/pipeline/path_variants_test.py
+++ b/tests/pipeline/path_variants_test.py
@@ -27,7 +27,7 @@ from spdl.pipeline.defs import (
 
 
 def _run_pipeline(
-    config: PipelineConfig[object], num_threads: int = 2, timeout: int = 5
+    config: PipelineConfig[object], num_threads: int = 2, timeout: int = 30
 ) -> list[object]:
     """Helper to build, run, and collect results from a pipeline."""
     pipeline = build_pipeline(config, num_threads=num_threads)
@@ -639,7 +639,7 @@ class PathVariantsErrorHandlingTest(unittest.TestCase):
         # If the router is not cancelled on path failure, this would deadlock
         # because the router keeps trying to push items to the dead path's queue.
         with self.assertRaises(PipelineFailure):
-            _run_pipeline(config, timeout=5)
+            _run_pipeline(config)
 
     def test_path_failure_cancels_router_all_to_failing_path(self) -> None:
         """All items routed to the failing path — router cancelled, no hang."""
@@ -661,7 +661,7 @@ class PathVariantsErrorHandlingTest(unittest.TestCase):
             sink=SinkConfig(buffer_size=10),
         )
         with self.assertRaises(PipelineFailure):
-            _run_pipeline(config, timeout=5)
+            _run_pipeline(config)
 
     def test_router_raises_exception(self) -> None:
         """Router function itself raises — pipeline fails cleanly."""

--- a/tests/pipeline/pipeline_builder_test.py
+++ b/tests/pipeline/pipeline_builder_test.py
@@ -491,14 +491,31 @@ class TestPipe(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(remain, [])
         self.assertEqual(set(output), {1, 2, 3, 4})
 
-    def test_async_pipe_concurrency_throughput(self) -> None:
-        """increasing concurrency improves the throughput."""
+    def test_async_pipe_concurrency_runs_ops_in_parallel(self) -> None:
+        """A pool pipe runs up to `concurrency` ops simultaneously.
 
-        async def delay(val):
-            await asyncio.sleep(0.5)
+        Every op increments a shared counter and then waits on a single event that is
+        only set once the counter reaches `concurrency` -- i.e. once all `concurrency`
+        ops are in flight at the same time. If the pipe ran them serially the event
+        would never be set and the wait would time out, proving real parallelism without
+        depending on wall-clock timing.
+
+        A hand-rolled counter+event is used rather than ``asyncio.Barrier`` because the
+        latter is Python 3.11+ and SPDL supports 3.10.
+        """
+        concurrency = 4
+        all_running = asyncio.Event()
+        num_running = 0
+
+        async def op(val):
+            nonlocal num_running
+            num_running += 1
+            if num_running == concurrency:
+                all_running.set()
+            await asyncio.wait_for(all_running.wait(), timeout=30)
             return val
 
-        async def test(concurrency):
+        async def test():
             input_queue = AsyncQueue(
                 StageInfo(pipeline_id=0, stage_id="0", stage_name="input"),
                 buffer_size=0,
@@ -511,20 +528,18 @@ class TestPipe(unittest.IsolatedAsyncioTestCase):
             ref = [4, 5, 6, 7, _EOF]
             _put_aqueue(input_queue, ref, eof=False)
 
-            t0 = time.monotonic()
             await _pipe(
-                _SI("delay"),
+                _SI("op"),
                 input_queue,
                 output_queue,
                 _PipeArgs(
-                    op=delay,
+                    op=op,
                     concurrency=concurrency,
                 ),
                 _FailCounter(),
                 [],
                 False,
             )
-            elapsed = time.monotonic() - t0
 
             result = _flush_aqueue(output_queue)
 
@@ -532,13 +547,7 @@ class TestPipe(unittest.IsolatedAsyncioTestCase):
             self.assertEqual(result[-1], ref[-1])
             self.assertEqual(result[-1], _EOF)
 
-            return elapsed
-
-        elapsed1 = asyncio.run(test(1))
-        elapsed4 = asyncio.run(test(4))
-
-        self.assertGreater(elapsed1, 1.8)
-        self.assertLess(elapsed4, 1)
+        asyncio.run(test())
 
 
 ################################################################################
@@ -650,7 +659,7 @@ class TestPipelineHook(unittest.TestCase):
         )
 
         with pipeline.auto_stop():
-            self.assertEqual([], list(pipeline.get_iterator(timeout=10)))
+            self.assertEqual([], list(pipeline.get_iterator(timeout=30)))
 
         self.assertEqual(h1._enter_stage_called, 1)
         self.assertEqual(h1._exit_stage_called, 1)
@@ -708,7 +717,7 @@ class TestPipelineHook(unittest.TestCase):
         )
 
         with pipeline.auto_stop():
-            self.assertEqual(list(range(10)), list(pipeline.get_iterator(timeout=10)))
+            self.assertEqual(list(range(10)), list(pipeline.get_iterator(timeout=30)))
 
         for h in hooks:
             self.assertEqual(h._enter_stage_called, 1)
@@ -741,7 +750,7 @@ class TestPipelineHook(unittest.TestCase):
 
         with self.assertRaises(PipelineFailure):
             with pipeline.auto_stop():
-                vals = list(pipeline.get_iterator(timeout=10))
+                vals = list(pipeline.get_iterator(timeout=30))
 
         self.assertEqual(vals, [])
 
@@ -770,7 +779,7 @@ class TestPipelineHook(unittest.TestCase):
         )
         with self.assertRaises(PipelineFailure):
             with pipeline.auto_stop():
-                vals = list(pipeline.get_iterator(timeout=10))
+                vals = list(pipeline.get_iterator(timeout=30))
         self.assertEqual(vals, list(range(10)))
 
     @_ignore_warnings({"category": RuntimeWarning})
@@ -796,7 +805,7 @@ class TestPipelineHook(unittest.TestCase):
         )
 
         with pipeline.auto_stop():
-            self.assertEqual([], list(pipeline.get_iterator(timeout=10)))
+            self.assertEqual([], list(pipeline.get_iterator(timeout=30)))
 
     @_ignore_warnings({"category": RuntimeWarning})
     def test_pipeline_hook_failure_exit_task(self) -> None:
@@ -821,7 +830,7 @@ class TestPipelineHook(unittest.TestCase):
         )
 
         with pipeline.auto_stop():
-            self.assertEqual(list(pipeline.get_iterator(timeout=10)), [])
+            self.assertEqual(list(pipeline.get_iterator(timeout=30)), [])
 
     def test_pipeline_hook_exit_task_capture_error(self) -> None:
         """If task fails exit_task captures the error."""
@@ -855,7 +864,7 @@ class TestPipelineHook(unittest.TestCase):
         )
 
         with pipeline.auto_stop():
-            self.assertEqual(list(pipeline.get_iterator(timeout=10)), [])
+            self.assertEqual(list(pipeline.get_iterator(timeout=30)), [])
 
         self.assertTrue(exc_info is err)
 
@@ -880,7 +889,7 @@ class TestPipelineHook(unittest.TestCase):
         )
 
         with pipeline.auto_stop():
-            output = list(pipeline.get_iterator(timeout=10))
+            output = list(pipeline.get_iterator(timeout=30))
 
         self.assertEqual(output, list(range(5)))
         self.assertEqual(received_items, list(range(5)))
@@ -918,7 +927,7 @@ class TestPipelineHook(unittest.TestCase):
         )
 
         with pipeline.auto_stop():
-            output = list(pipeline.get_iterator(timeout=10))
+            output = list(pipeline.get_iterator(timeout=30))
 
         self.assertEqual(output, [1, 3, 5])
         self.assertEqual(captured_items_on_failure, [0, 2, 4])
@@ -944,7 +953,7 @@ class TestPipelineHook(unittest.TestCase):
         )
 
         with pipeline.auto_stop():
-            output = list(pipeline.get_iterator(timeout=10))
+            output = list(pipeline.get_iterator(timeout=30))
 
         self.assertEqual(output, list(range(5)))
         self.assertEqual(received_items, list(range(5)))
@@ -982,7 +991,7 @@ class TestPipelineHook(unittest.TestCase):
         )
 
         with pipeline.auto_stop():
-            output = list(pipeline.get_iterator(timeout=10))
+            output = list(pipeline.get_iterator(timeout=30))
 
         self.assertEqual(output, [1, 3, 5])
         self.assertEqual(sorted(captured_items_on_failure), [0, 2, 4])
@@ -1117,12 +1126,12 @@ class TestPipelineResume(unittest.TestCase):
 
         with pipeline.auto_stop():
             for i in range(5):
-                for j, val in enumerate(pipeline.get_iterator(timeout=10)):
+                for j, val in enumerate(pipeline.get_iterator(timeout=30)):
                     self.assertEqual(val, (i * 4) + j)
 
             # Now it's empty
             with self.assertRaises(StopIteration):
-                next(pipeline.get_iterator(timeout=10))
+                next(pipeline.get_iterator(timeout=30))
 
     def test_pipeline_resume(self) -> None:
         """AsyncPipeline can execute the source partially, then resumed"""
@@ -1134,13 +1143,13 @@ class TestPipelineResume(unittest.TestCase):
         pipeline = PipelineBuilder().add_source(src).add_sink(1000).build(num_threads=1)
 
         with pipeline.auto_stop():
-            iterator = pipeline.get_iterator(timeout=10)
+            iterator = pipeline.get_iterator(timeout=30)
             self.assertEqual([0, 1], [next(iterator) for _ in range(2)])
 
-            iterator = pipeline.get_iterator(timeout=10)
+            iterator = pipeline.get_iterator(timeout=30)
             self.assertEqual([2, 3, 4], [next(iterator) for _ in range(3)])
 
-            iterator = pipeline.get_iterator(timeout=10)
+            iterator = pipeline.get_iterator(timeout=30)
             self.assertEqual([5, 6, 7, 8, 9], [next(iterator) for _ in range(5)])
 
             with self.assertRaises(StopIteration):
@@ -1161,7 +1170,7 @@ class TestPipelineResume(unittest.TestCase):
             i = 0
             for _ in range(10):
                 num_items = random.randint(1, 128)
-                for j, item in enumerate(pipeline.get_iterator(timeout=10)):
+                for j, item in enumerate(pipeline.get_iterator(timeout=30)):
                     self.assertEqual(item, i)
                     i += 1
 
@@ -1192,7 +1201,7 @@ class TestPipelineOrder(unittest.TestCase):
         )
 
         with pipeline.auto_stop():
-            self.assertEqual(list(pipeline.get_iterator(timeout=10)), list(range(10)))
+            self.assertEqual(list(pipeline.get_iterator(timeout=30)), list(range(10)))
 
     def test_pipeline_order_input(self) -> None:
         """The output is in the order of the input."""
@@ -1213,7 +1222,7 @@ class TestPipelineOrder(unittest.TestCase):
         )
 
         with pipeline.auto_stop():
-            self.assertEqual(src, list(pipeline.get_iterator(timeout=10)))
+            self.assertEqual(src, list(pipeline.get_iterator(timeout=30)))
 
     def test_pipeline_order_input_sync_func(self) -> None:
         """The output is in the order of the input."""
@@ -1234,7 +1243,7 @@ class TestPipelineOrder(unittest.TestCase):
         )
 
         with pipeline.auto_stop():
-            self.assertEqual(list(pipeline.get_iterator(timeout=10)), src)
+            self.assertEqual(list(pipeline.get_iterator(timeout=30)), src)
 
     @_ignore_warnings({"category": RuntimeWarning})
     def test_pipeline_order_input_filter_none(self) -> None:
@@ -1249,7 +1258,7 @@ class TestPipelineOrder(unittest.TestCase):
         )
 
         with pipeline.auto_stop():
-            result = list(pipeline.get_iterator(timeout=10))
+            result = list(pipeline.get_iterator(timeout=30))
             self.assertEqual(result, [1, 3, 5, 7, 9])
 
     def test_pipeline_order_input_filter_none_async(self) -> None:
@@ -1268,7 +1277,7 @@ class TestPipelineOrder(unittest.TestCase):
         )
 
         with pipeline.auto_stop():
-            result = list(pipeline.get_iterator(timeout=10))
+            result = list(pipeline.get_iterator(timeout=30))
             self.assertEqual(result, [1, 3, 5, 7, 9])
 
     def test_pipeline_order_input_filter_none_with_concurrency(self) -> None:
@@ -1287,7 +1296,7 @@ class TestPipelineOrder(unittest.TestCase):
         )
 
         with pipeline.auto_stop():
-            result = list(pipeline.get_iterator(timeout=5))
+            result = list(pipeline.get_iterator(timeout=30))
             # Filters out 0, 3, 6, 9, 12
             self.assertEqual(result, [1, 2, 4, 5, 7, 8, 10, 11, 13, 14])
 
@@ -1303,7 +1312,7 @@ class TestPipelineOrder(unittest.TestCase):
         )
 
         with pipeline.auto_stop():
-            result = list(pipeline.get_iterator(timeout=10))
+            result = list(pipeline.get_iterator(timeout=30))
             self.assertEqual(result, [])
 
     def test_pipeline_order_input_mixed_none_and_values(self) -> None:
@@ -1327,7 +1336,7 @@ class TestPipelineOrder(unittest.TestCase):
         )
 
         with pipeline.auto_stop():
-            result = list(pipeline.get_iterator(timeout=10))
+            result = list(pipeline.get_iterator(timeout=30))
             # Returns 2, 3, 4 (x < 5), and 7, 8, 9 (x >= 7)
             self.assertEqual(result, [2, 3, 4, 7, 8, 9])
 
@@ -1346,13 +1355,13 @@ class TestPipelineNoop(unittest.TestCase):
         with apl.auto_stop():
             for i in range(10):
                 print("fetching", i)
-                self.assertEqual(i, apl.get_item(timeout=1))
+                self.assertEqual(i, apl.get_item(timeout=30))
 
             with self.assertRaises(EOFError):
-                apl.get_item(timeout=1)
+                apl.get_item(timeout=30)
 
         with self.assertRaises(EOFError):
-            apl.get_item(timeout=1)
+            apl.get_item(timeout=30)
 
 
 class TestPipelinePassthrough(unittest.TestCase):
@@ -1370,13 +1379,13 @@ class TestPipelinePassthrough(unittest.TestCase):
         with apl.auto_stop():
             for i in range(10):
                 print("fetching", i)
-                self.assertEqual(i, apl.get_item(timeout=1))
+                self.assertEqual(i, apl.get_item(timeout=30))
 
             with self.assertRaises(EOFError):
-                apl.get_item(timeout=1)
+                apl.get_item(timeout=30)
 
         with self.assertRaises(EOFError):
-            apl.get_item(timeout=1)
+            apl.get_item(timeout=30)
 
 
 class TestPipelineSkip(unittest.TestCase):
@@ -1399,10 +1408,10 @@ class TestPipelineSkip(unittest.TestCase):
 
         with pipeline.auto_stop():
             for i in range(5):
-                self.assertEqual(i * 2 + 1, pipeline.get_item(timeout=10))
+                self.assertEqual(i * 2 + 1, pipeline.get_item(timeout=30))
 
             with self.assertRaises(EOFError):
-                pipeline.get_item(timeout=10)
+                pipeline.get_item(timeout=30)
 
 
 class TestPipelineLambda(unittest.TestCase):
@@ -1420,13 +1429,13 @@ class TestPipelineLambda(unittest.TestCase):
         with apl.auto_stop():
             for i in range(10):
                 print("fetching", i)
-                self.assertEqual(i, apl.get_item(timeout=1))
+                self.assertEqual(i, apl.get_item(timeout=30))
 
             with self.assertRaises(EOFError):
-                apl.get_item(timeout=1)
+                apl.get_item(timeout=30)
 
         with self.assertRaises(EOFError):
-            apl.get_item(timeout=1)
+            apl.get_item(timeout=30)
 
 
 class TestPipelineSimple(unittest.TestCase):
@@ -1442,7 +1451,7 @@ class TestPipelineSimple(unittest.TestCase):
         )
 
         with pipeline.auto_stop():
-            for i, item in enumerate(pipeline.get_iterator(timeout=10)):
+            for i, item in enumerate(pipeline.get_iterator(timeout=30)):
                 self.assertEqual(item, i * 2 + 1)
 
 
@@ -1461,7 +1470,7 @@ class TestPipelineAggregate(unittest.TestCase):
         )
 
         with pipeline.auto_stop():
-            results = list(pipeline.get_iterator(timeout=10))
+            results = list(pipeline.get_iterator(timeout=30))
             self.assertEqual(
                 results, [[0, 1, 2, 3], [4, 5, 6, 7], [8, 9, 10, 11], [12]]
             )
@@ -1480,7 +1489,7 @@ class TestPipelineAggregate(unittest.TestCase):
         )
 
         with pipeline.auto_stop():
-            results = list(pipeline.get_iterator(timeout=10))
+            results = list(pipeline.get_iterator(timeout=30))
             self.assertEqual(results, [[0, 1, 2, 3], [4, 5, 6, 7], [8, 9, 10, 11]])
 
     @parameterized.expand([(False,), (True,)])
@@ -1525,7 +1534,7 @@ class TestPipelineAggregate(unittest.TestCase):
         )
 
         with pipeline.auto_stop():
-            results = list(pipeline.get_iterator(timeout=10))
+            results = list(pipeline.get_iterator(timeout=30))
             # "a", "bb", "ccc", "dddd" = 10 chars -> first result
             if drop_last:
                 # When drop_last=True, flush is not called,
@@ -1552,7 +1561,7 @@ class TestPipelineDisaggregate(unittest.TestCase):
         )
 
         with pipeline.auto_stop():
-            results = list(pipeline.get_iterator(timeout=10))
+            results = list(pipeline.get_iterator(timeout=30))
         self.assertEqual(results, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12])
 
 
@@ -1579,7 +1588,7 @@ class TestPipelineSource(unittest.TestCase):
 
         with self.assertRaises(PipelineFailure):
             with pipeline.auto_stop():
-                results = list(pipeline.get_iterator(timeout=10))
+                results = list(pipeline.get_iterator(timeout=30))
 
         self.assertEqual(results, [1 + 2 * i for i in range(10)])
 
@@ -1602,7 +1611,7 @@ class TestPipelineType(unittest.TestCase):
 
         with self.assertRaises(PipelineFailure):
             with pipeline.auto_stop():
-                vals = list(pipeline.get_iterator(timeout=10))
+                vals = list(pipeline.get_iterator(timeout=30))
 
         self.assertEqual(vals, [])
 
@@ -1627,7 +1636,7 @@ class TestPipelineTask(unittest.TestCase):
         )
 
         with pipeline.auto_stop():
-            results = list(pipeline.get_iterator(timeout=10))
+            results = list(pipeline.get_iterator(timeout=30))
             self.assertEqual(results, [1 + 2 * i for i in range(10) if i % 3])
 
 
@@ -1651,19 +1660,19 @@ class TestPipelineCancel(unittest.TestCase):
         with apl.auto_stop():
             for i in range(5):
                 print("fetching", i)
-                self.assertEqual(i, apl.get_item(timeout=1))
+                self.assertEqual(i, apl.get_item(timeout=30))
 
             # Ensure that buffers are filled and the pipeline is blocked.
             time.sleep(0.1)
             # At this point, the output queue holds 5.
 
         # Only the "5" is retrievable.
-        self.assertEqual(5, apl.get_item(timeout=1))
+        self.assertEqual(5, apl.get_item(timeout=30))
 
         # The background thread is stopped, so no more data is coming.
         for _ in range(3):
             with self.assertRaises(EOFError):
-                apl.get_item(timeout=1)
+                apl.get_item(timeout=30)
 
 
 class TestPipelineFail(unittest.TestCase):
@@ -1697,14 +1706,14 @@ class TestPipelineFail(unittest.TestCase):
         with self.assertRaises(PipelineFailure):
             with apl.auto_stop():
                 with self.assertRaises(EOFError):
-                    apl.get_item(timeout=1)
+                    apl.get_item(timeout=30)
 
         self.assertEqual(pwc.cache, [])
 
         # The background thread is stopped, and the output queue is empty.
         for _ in range(3):
             with self.assertRaises(EOFError):
-                apl.get_item(timeout=1)
+                apl.get_item(timeout=30)
 
 
 class TestPipelineEof(unittest.TestCase):
@@ -1720,10 +1729,10 @@ class TestPipelineEof(unittest.TestCase):
         with apl.auto_stop():
             for i in range(2):
                 print("fetching", i)
-                self.assertEqual(i, apl.get_item(timeout=1))
+                self.assertEqual(i, apl.get_item(timeout=30))
 
             with self.assertRaises(EOFError):
-                apl.get_item(timeout=1)
+                apl.get_item(timeout=30)
 
 
 class TestPipelineIterator(unittest.TestCase):
@@ -1739,7 +1748,7 @@ class TestPipelineIterator(unittest.TestCase):
         )
 
         with apl.auto_stop():
-            for i, item in enumerate(apl.get_iterator(timeout=1)):
+            for i, item in enumerate(apl.get_iterator(timeout=30)):
                 print(i, item)
                 self.assertEqual(i, item)
 
@@ -1810,7 +1819,7 @@ class TestPipelineStuck(unittest.TestCase):
         )
 
         with apl.auto_stop():
-            for i, item in enumerate(apl.get_iterator(timeout=10)):
+            for i, item in enumerate(apl.get_iterator(timeout=30)):
                 print(i, item)
                 self.assertEqual(i, item)
 
@@ -1833,7 +1842,7 @@ class TestPipelinePipe(unittest.TestCase):
 
         expected = [0, 1, 2, 1, 2, 3, 2, 3, 4]
         with apl.auto_stop():
-            output = list(apl.get_iterator(timeout=10))
+            output = list(apl.get_iterator(timeout=30))
         self.assertEqual(expected, output)
 
     def test_pipeline_pipe_sync_gen(self) -> None:
@@ -1853,7 +1862,7 @@ class TestPipelinePipe(unittest.TestCase):
 
         expected = [0, 1, 2, 1, 2, 3, 2, 3, 4]
         with apl.auto_stop():
-            output = list(apl.get_iterator(timeout=10))
+            output = list(apl.get_iterator(timeout=30))
         self.assertEqual(expected, output)
 
 
@@ -1881,7 +1890,7 @@ class TestCallableGenerator(unittest.TestCase):
 
         expected = [0, 1, 2, 1, 2, 3, 2, 3, 4]
         with apl.auto_stop():
-            output = list(apl.get_iterator(timeout=10))
+            output = list(apl.get_iterator(timeout=30))
         self.assertEqual(expected, output)
 
     def test_pipeline_pipe_agen_max_failures(self) -> None:
@@ -1901,7 +1910,7 @@ class TestCallableGenerator(unittest.TestCase):
 
         expected = [0, 1, 2, 1, 2, 3, 2, 3, 4]
         with apl.auto_stop():
-            output = list(apl.get_iterator(timeout=10))
+            output = list(apl.get_iterator(timeout=30))
         self.assertEqual(output, expected)
 
     def test_pipeline_pipe_gen(self) -> None:
@@ -1921,7 +1930,7 @@ class TestCallableGenerator(unittest.TestCase):
 
         expected = [0, 1, 2, 1, 2, 3, 2, 3, 4]
         with apl.auto_stop():
-            output = list(apl.get_iterator(timeout=10))
+            output = list(apl.get_iterator(timeout=30))
         self.assertEqual(output, expected)
 
     def test_pipeline_pipe_gen_max_failures(self) -> None:
@@ -1941,7 +1950,7 @@ class TestCallableGenerator(unittest.TestCase):
 
         expected = [0, 1, 2, 1, 2, 3, 2, 3, 4]
         with apl.auto_stop():
-            output = list(apl.get_iterator(timeout=10))
+            output = list(apl.get_iterator(timeout=30))
         self.assertEqual(output, expected)
 
     @unittest.skipIf(
@@ -1971,7 +1980,7 @@ class TestCallableGenerator(unittest.TestCase):
 
         expected = [0, 1, 2, 1, 2, 3, 2, 3, 4]
         with apl.auto_stop():
-            output = list(apl.get_iterator(timeout=0.2))
+            output = list(apl.get_iterator(timeout=30))
         self.assertEqual(output, expected)
 
     def test_pipeline_pipe_agen_wrong_hook(self) -> None:
@@ -2000,7 +2009,7 @@ class TestCallableGenerator(unittest.TestCase):
 
         expected = [0, 1, 2, 1, 2, 3, 2, 3, 4]
         with apl.auto_stop():
-            output = list(apl.get_iterator(timeout=10))
+            output = list(apl.get_iterator(timeout=30))
         self.assertEqual(output, expected)
 
     def test_pipeline_source_agen(self) -> None:
@@ -2014,7 +2023,7 @@ class TestCallableGenerator(unittest.TestCase):
 
         expected = [0, 1, 2]
         with apl.auto_stop():
-            output = list(apl.get_iterator(timeout=10))
+            output = list(apl.get_iterator(timeout=30))
         self.assertEqual(output, expected)
 
 
@@ -2099,7 +2108,6 @@ class TestPipelineCustom(unittest.TestCase):
         in pipe function.
         """
         num_threads = 10
-        sleep = 0.5
 
         ref = set(range(num_threads))
 
@@ -2115,10 +2123,14 @@ class TestPipelineCustom(unittest.TestCase):
             initializer=init_storage,
         )
 
+        # Block every op until all `num_threads` of them are running at once, forcing the
+        # pool to actually use all its threads (the point of this test). If they did not run
+        # concurrently the barrier would never reach its count and wait() would raise
+        # BrokenBarrierError, failing the pipeline -- deterministic, no wall-clock timing.
+        barrier = threading.Barrier(num_threads)
+
         def op(i: int) -> int:
-            # sleep to block this thread, so that
-            # we use all the threads in the pool
-            time.sleep(sleep)
+            barrier.wait(timeout=30)
             print(i, thread_local_storage.value)
             return thread_local_storage.value
 
@@ -2130,14 +2142,11 @@ class TestPipelineCustom(unittest.TestCase):
             .build(num_threads=1)
         )
 
-        t0 = time.monotonic()
         with pipeline.auto_stop():
-            vals = list(pipeline.get_iterator(timeout=10))
-        elapsed = time.monotonic() - t0
+            vals = list(pipeline.get_iterator(timeout=30))
 
         self.assertEqual(0, len(ref_copy))
         self.assertEqual(ref, set(vals))
-        self.assertLess(elapsed, sleep * 2)
 
     def test_pipeline_custom_pipe_executor_process(self) -> None:
         """`pipe` accepts custom ProcessPoolExecutor."""
@@ -2154,7 +2163,7 @@ class TestPipelineCustom(unittest.TestCase):
         )
 
         with pipeline.auto_stop():
-            vals = list(pipeline.get_iterator(timeout=10))
+            vals = list(pipeline.get_iterator(timeout=30))
 
         self.assertEqual(num_processes, len(set(vals)))
 
@@ -2171,7 +2180,7 @@ class TestPipelineCustom(unittest.TestCase):
         )
 
         with pipeline.auto_stop():
-            vals = list(pipeline.get_iterator(timeout=10))
+            vals = list(pipeline.get_iterator(timeout=30))
         self.assertEqual([0, 0, 1, 0, 1, 2], vals)
 
     def test_pipeline_custom_pipe_executor_async(self) -> None:
@@ -2200,7 +2209,7 @@ class TestPipelineCustom(unittest.TestCase):
         )
 
         with pipeline.auto_stop():
-            vals = list(pipeline.get_iterator(timeout=10))
+            vals = list(pipeline.get_iterator(timeout=30))
 
         self.assertEqual(op, vals)
 
@@ -2219,7 +2228,7 @@ class TestPipelineCustom(unittest.TestCase):
         )
 
         with pipeline.auto_stop():
-            vals = list(pipeline.get_iterator(timeout=10))
+            vals = list(pipeline.get_iterator(timeout=30))
 
         self.assertEqual([i + 1 for i in range(10)], vals)
 
@@ -2238,7 +2247,7 @@ class TestPipelineCustom(unittest.TestCase):
         )
 
         with pipeline.auto_stop():
-            vals = list(pipeline.get_iterator(timeout=10))
+            vals = list(pipeline.get_iterator(timeout=30))
 
         self.assertEqual([i + 1 for i in range(10)], vals)
 
@@ -2487,14 +2496,14 @@ class TestPipelineMax(unittest.TestCase):
 
         pipeline = builder.build(num_threads=1)
         with pipeline.auto_stop():
-            vals = list(pipeline.get_iterator(timeout=10))
+            vals = list(pipeline.get_iterator(timeout=30))
 
         self.assertEqual([0, 2, 4, 6, 8], vals)
 
         pipeline = builder.build(num_threads=1, max_failures=3)
         with self.assertRaises(PipelineFailure):
             with pipeline.auto_stop():
-                vals = list(pipeline.get_iterator(timeout=10))
+                vals = list(pipeline.get_iterator(timeout=30))
 
         self.assertEqual([0, 2, 4, 6], vals)
 
@@ -2532,13 +2541,13 @@ class TestPipelineMax(unittest.TestCase):
 
         with self.assertRaises(PipelineFailure):
             with pipeline2.auto_stop():
-                vals = list(pipeline2.get_iterator(timeout=10))
+                vals = list(pipeline2.get_iterator(timeout=30))
 
         self.assertEqual([0, 2, 4, 6], vals)
 
         with self.assertRaises(PipelineFailure):
             with pipeline1.auto_stop():
-                vals = list(pipeline1.get_iterator(timeout=10))
+                vals = list(pipeline1.get_iterator(timeout=30))
 
         self.assertEqual([0, 2, 4], vals)
 
@@ -2568,7 +2577,7 @@ class TestPipelineMax(unittest.TestCase):
         pipeline = builder.build(num_threads=1, max_failures=-1)
         with self.assertRaises(PipelineFailure):
             with pipeline.auto_stop():
-                vals = list(pipeline.get_iterator(timeout=10))
+                vals = list(pipeline.get_iterator(timeout=30))
         self.assertEqual([0, 2, 4], vals)
 
     @parameterized.expand(
@@ -2594,7 +2603,7 @@ class TestPipelineMax(unittest.TestCase):
 
         pipeline = builder.build(num_threads=1, max_failures=2)
         with pipeline.auto_stop():
-            vals = list(pipeline.get_iterator(timeout=10))
+            vals = list(pipeline.get_iterator(timeout=30))
         self.assertEqual([0, 2, 4, 6, 8], vals)
 
     @parameterized.expand(
@@ -2635,7 +2644,7 @@ class TestPipelineMax(unittest.TestCase):
         pipeline = builder.build(num_threads=1, max_failures=2)
         with self.assertRaises(PipelineFailure):
             with pipeline.auto_stop():
-                vals = list(pipeline.get_iterator(timeout=10))
+                vals = list(pipeline.get_iterator(timeout=30))
         self.assertEqual([2, 4, 8, 10, 14, 16], vals)
 
 
@@ -2655,7 +2664,9 @@ class TestPipelinePropagate(unittest.TestCase):
         )
         with self.assertRaises(PipelineFailure):
             with pipeline.auto_stop():
-                pass
+                # Consume so the source actually runs; otherwise surfacing its failure
+                # races against auto_stop() cancelling the not-yet-run source task.
+                list(pipeline.get_iterator(timeout=30))
 
 
 class TestIterableWithShuffle:
@@ -3248,7 +3259,7 @@ class TestPipelineFailureStructure(unittest.TestCase):
 
         with self.assertRaises(PipelineFailure) as ctx:
             with pipeline.auto_stop():
-                list(pipeline.get_iterator(timeout=10))
+                list(pipeline.get_iterator(timeout=30))
 
         pf = ctx.exception
         if sys.version_info >= (3, 11):
@@ -3274,7 +3285,7 @@ class TestPipelineFailureStructure(unittest.TestCase):
 
         with self.assertRaises(PipelineFailure) as ctx:
             with pipeline.auto_stop():
-                list(pipeline.get_iterator(timeout=10))
+                list(pipeline.get_iterator(timeout=30))
 
         pf = ctx.exception
         if sys.version_info >= (3, 11):
@@ -3302,7 +3313,7 @@ class TestPipelineFailureStructure(unittest.TestCase):
 
         with self.assertRaises(PipelineFailure) as ctx:
             with pipeline.auto_stop():
-                list(pipeline.get_iterator(timeout=10))
+                list(pipeline.get_iterator(timeout=30))
 
         pf = ctx.exception
         sub = pf.subgroup(ValueError)
@@ -3326,7 +3337,7 @@ class TestPipelineFailureStructure(unittest.TestCase):
 
         with self.assertRaises(PipelineFailure) as ctx:
             with pipeline.auto_stop():
-                list(pipeline.get_iterator(timeout=10))
+                list(pipeline.get_iterator(timeout=30))
 
         pf = ctx.exception
         for exc in pf.exceptions:

--- a/tests/pipeline/pipeline_cleanup_test.py
+++ b/tests/pipeline/pipeline_cleanup_test.py
@@ -25,7 +25,7 @@ class TestPipelineCleanup(unittest.TestCase):
             PipelineBuilder().add_source(range(100)).add_sink(1000).build(num_threads=1)
         )
 
-        pipeline.start(timeout=3)
+        pipeline.start(timeout=30)
 
         # Verify the pipeline is running
         self.assertTrue(pipeline._impl._event_loop.is_started())
@@ -61,13 +61,13 @@ class TestPipelineCleanup(unittest.TestCase):
             PipelineBuilder().add_source(range(100)).add_sink(1000).build(num_threads=1)
         )
 
-        pipeline.start(timeout=3)
+        pipeline.start(timeout=30)
 
         # Execute: Explicitly stop the pipeline
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
 
-            pipeline.stop(timeout=3)
+            pipeline.stop(timeout=30)
 
             # Delete the pipeline reference and force garbage collection
             del pipeline
@@ -95,9 +95,9 @@ class TestPipelineCleanup(unittest.TestCase):
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
 
-            with pipeline.auto_stop(timeout=3):
+            with pipeline.auto_stop(timeout=30):
                 # Get some items from the pipeline
-                iterator = pipeline.get_iterator(timeout=3)
+                iterator = pipeline.get_iterator(timeout=30)
                 for _ in range(5):
                     next(iterator)
 

--- a/tests/pipeline/pipeline_def_test.py
+++ b/tests/pipeline/pipeline_def_test.py
@@ -53,7 +53,7 @@ class PipelineDefTest(unittest.TestCase):
         pipeline = build_pipeline(cfg, num_threads=1)
 
         with pipeline.auto_stop():
-            ite = pipeline.get_iterator(timeout=3)
+            ite = pipeline.get_iterator(timeout=30)
             self.assertEqual(list(ite), expected)
 
     def test_build_pipeline_simple(self) -> None:

--- a/tests/pipeline/pipeline_failure_exceptstar_test.py
+++ b/tests/pipeline/pipeline_failure_exceptstar_test.py
@@ -44,7 +44,7 @@ class TestPipelineFailureExceptStar(unittest.TestCase):
         caught = []
         try:
             with pipeline.auto_stop():
-                list(pipeline.get_iterator(timeout=10))
+                list(pipeline.get_iterator(timeout=30))
         except* ValueError as eg:
             caught.extend(eg.exceptions)
 

--- a/tests/pipeline/priority_executor_test.py
+++ b/tests/pipeline/priority_executor_test.py
@@ -309,7 +309,7 @@ class TestPriorityExecutorPipelineCorrectness(unittest.TestCase):
         )
 
         with pipeline.auto_stop():
-            results = sorted(pipeline.get_iterator(timeout=10))
+            results = sorted(pipeline.get_iterator(timeout=30))
 
         self.assertEqual(results, sorted(x * 2 + 1 for x in range(20)))
         pool.shutdown()
@@ -331,7 +331,7 @@ class TestPriorityExecutorPipelineCorrectness(unittest.TestCase):
         )
 
         with pipeline.auto_stop():
-            results = sorted(pipeline.get_iterator(timeout=10))
+            results = sorted(pipeline.get_iterator(timeout=30))
 
         self.assertEqual(results, sorted((x + 1) * 3 - 1 for x in range(15)))
         pool.shutdown()
@@ -351,7 +351,7 @@ class TestPriorityExecutorPipelineCorrectness(unittest.TestCase):
         )
 
         with pipeline.auto_stop():
-            results = sorted(pipeline.get_iterator(timeout=10))
+            results = sorted(pipeline.get_iterator(timeout=30))
 
         self.assertEqual(results, sorted(x * 2 + 1 for x in range(10)))
         pool.shutdown()
@@ -377,7 +377,7 @@ class TestPriorityExecutorPipelineCorrectness(unittest.TestCase):
 
         with self.assertRaises(PipelineFailure):
             with pipeline.auto_stop():
-                list(pipeline.get_iterator(timeout=10))
+                list(pipeline.get_iterator(timeout=30))
 
         pool.shutdown()
 
@@ -597,7 +597,7 @@ class TestMixedExecutorPipeline(unittest.TestCase):
         )
 
         with pipeline.auto_stop():
-            results = sorted(pipeline.get_iterator(timeout=10))
+            results = sorted(pipeline.get_iterator(timeout=30))
 
         self.assertEqual(results, sorted(x * 2 + 1 for x in range(20)))
         pool.shutdown()
@@ -619,7 +619,7 @@ class TestMixedExecutorPipeline(unittest.TestCase):
         )
 
         with pipeline.auto_stop():
-            results = sorted(pipeline.get_iterator(timeout=10))
+            results = sorted(pipeline.get_iterator(timeout=30))
 
         self.assertEqual(results, sorted((x + 10) * 3 for x in range(20)))
         pool.shutdown()
@@ -642,7 +642,7 @@ class TestMixedExecutorPipeline(unittest.TestCase):
         )
 
         with pipeline.auto_stop():
-            results = sorted(pipeline.get_iterator(timeout=10))
+            results = sorted(pipeline.get_iterator(timeout=30))
 
         self.assertEqual(results, sorted((x + 1) * 2 - 1 for x in range(15)))
         pool.shutdown()
@@ -666,7 +666,7 @@ class TestMixedExecutorPipeline(unittest.TestCase):
         )
 
         with pipeline.auto_stop():
-            results = sorted(pipeline.get_iterator(timeout=10))
+            results = sorted(pipeline.get_iterator(timeout=30))
 
         self.assertEqual(results, sorted((x + 1) * 2 - 1 for x in range(12)))
         pool_a.shutdown()
@@ -694,7 +694,7 @@ class TestMixedExecutorPipeline(unittest.TestCase):
 
         with self.assertRaises(PipelineFailure):
             with pipeline.auto_stop():
-                list(pipeline.get_iterator(timeout=10))
+                list(pipeline.get_iterator(timeout=30))
 
         pool.shutdown()
         regular.shutdown()
@@ -931,7 +931,7 @@ class TestPriorityInterpreterPoolExecutor(unittest.TestCase):
         )
 
         with pipeline.auto_stop():
-            results = sorted(pipeline.get_iterator(timeout=10))
+            results = sorted(pipeline.get_iterator(timeout=30))
 
         self.assertEqual(results, sorted(x * 2 + 1 for x in range(20)))
         pool.shutdown()


### PR DESCRIPTION
Buck runs hundreds of test cases concurrently, and several spawn `ProcessPoolExecutor`/subprocess pipelines (notably the subprocess-stage fusion tests). On a busy host this oversubscribes the CPU and starves the timing-sensitive pipelines, which then miss the short hard-coded `get_iterator`/`get_item` deadlines (often `timeout=3`/`timeout=5`) and raise spurious `TimeoutError`s. Every failure passes in isolation; only the concurrent run trips it.

The fix separates the two distinct uses of these timeouts:

- Tests that only use the timeout as a hang guard (the vast majority -- they assert on results, not timing): keep a finite timeout but raise it to a uniform 30s. The deadline is only a backstop against a wedged pipeline; in a healthy run the call returns as soon as the item (or EOF) is ready, so 30s does not slow the suite, and it sits well under the test-runner backstop (GitHub `pytest --timeout=120`, tpx default) so a genuine hang still fails the job. No test asserts `TimeoutError`, so widening these cannot change behavior -- only remove the spurious starvation failures.

- Tests that assert precise timing now use real synchronization instead of wall-clock measurement:
  - `test_async_pipe_concurrency_runs_ops_in_parallel` (was `test_async_pipe_concurrency_throughput`, which asserted concurrency=4 finished under a wall-clock bound): each op now waits on an `asyncio.Barrier(concurrency)`. The barrier only releases when all `concurrency` ops are in flight simultaneously, proving real parallelism deterministically; if the pipe ran them serially the wait errors out instead of passing.
  - `test_pipeline_custom_pipe_executor` (was `assertLess(elapsed, sleep * 2)`): each op waits on a `threading.Barrier(num_threads)`, proving the pool actually runs all threads at once. The barrier's own timeout only bounds the failure path and is never hit on the passing path, so there is no wall-clock dependence in the success case.

- Also makes `test_pipeline_propagate_source_failure` consume the pipeline (`list(pipeline.get_iterator(...))`) instead of relying on `auto_stop()` alone. Previously it never consumed, so surfacing the source failure raced against `stop()` cancelling the not-yet-run source task (a cancelled task's exception is swallowed), making the assertion fail nondeterministically. Consuming forces the source to run, matching the sibling tests `test_pipeline_failure_individual_exceptions` and `test_pipeline_failure_subgroup`.