### PR TITLE
[test] Update GHA CI to macOS-26

### DIFF
--- a/.github/workflows/_build_macos.yml
+++ b/.github/workflows/_build_macos.yml
@@ -15,7 +15,7 @@ on:
         default: 'false'
         type: string
       machine:
-        default: "macos-15"
+        default: "macos-26"
         type: string
       test-concurrency:
         required: false


### PR DESCRIPTION
The macOS CI builds (.github/workflows/_build_macos.yml) have been intermittently failing while compiling fmt itself, with errors like call to consteval function 'fmt::basic_format_string<...>' is not a constant expression originating in fmt/src/os.cc and fmt/src/format-inl.h. The flakiness is misleading: this is a deterministic toolchain incompatibility, not a transient failure.

Root cause: fmt 10.1.1 validates format strings inside a consteval constructor (basic_format_string), and that constant-evaluation path contains a subexpression (format_str_.remove_prefix(detail::to_unsigned(it - begin())) in fmt/core.h) that newer Clang front-ends correctly reject as not a constant expression. Older Clang accepted it. The accompanying -Wdeprecated-literal-operator warning on operator"" _a confirms the failing runs are on a recent AppleClang (Clang 16+).

The build is "flaky" only because the workflow pins neither the runner nor the toolchain — it uses runs-on: macos-latest with no Xcode pin. During GitHub's macos-latest image rollouts, jobs land on either an older or newer image (hence newer or older AppleClang) more or less at random, so retries occasionally reschedule onto an older image that still compiles 10.1.1. As the new image fully rolls out this would become a hard, every-time failure.
Upstream fmt reworked the consteval / compile-time format-string-checker constant-evaluation path in the 10.2.x → 11.x releases, which resolves both the error and the deprecation warning. Bumping to 11.0.2 fixes the build against modern Clang while keeping compile-time format-string safety intact.
