### PR TITLE
Pin macos-15

### DIFF
--- a/.github/workflows/_build_macos.yml
+++ b/.github/workflows/_build_macos.yml
@@ -15,7 +15,7 @@ on:
         default: 'false'
         type: string
       machine:
-        default: "macos-latest"
+        default: "macos-15"
         type: string
       test-concurrency:
         required: false
@@ -42,6 +42,9 @@ jobs:
         env:
           SPDL_USE_TRACING: 1
         run: |
+          xcodebuild -version
+          ls -alh /Applications/ | grep Xcode
+
           curl -LsSf https://astral.sh/uv/install.sh | sh
           set -ex
 


### PR DESCRIPTION
Github is rolling out a migration of the `macos-latest` to macOS 26. This takes about 30 days and we are getting random mix between 15 and 26, so we pin to 15.