### PR TITLE
Upgrade fmt to 11.0.2

### DIFF
--- a/src/libspdl/CMakeLists.txt
+++ b/src/libspdl/CMakeLists.txt
@@ -19,7 +19,22 @@ if (MSVC)
    # Temporary.
    # TODO: Set the visibility of public functions.
    set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
+
+   # fmt >= 11 statically asserts that MSVC compiles with /utf-8 when its Unicode
+   # support is enabled (the assert keys off the _MSVC_EXECUTION_CHARACTER_SET
+   # macro). For pure C++ targets, /utf-8 sets that macro and satisfies it.
+   #
+   # For .cu files this cannot be fixed with a flag: nvcc parses the headers in a
+   # separate device pass (the EDG frontend) that impersonates MSVC but never
+   # sees -Xcompiler flags and never defines _MSVC_EXECUTION_CHARACTER_SET, so
+   # the assert fires regardless. Disable fmt's Unicode support for CUDA instead.
+   add_compile_options(
+     $<$<COMPILE_LANGUAGE:CXX>:/utf-8>
+     $<$<COMPILE_LANGUAGE:CUDA>:-DFMT_UNICODE=0>
+     )
+
 endif(MSVC)
+
 
 add_subdirectory(core)
 if (SPDL_USE_CUDA)

--- a/src/third_party/fmt/CMakeLists.txt
+++ b/src/third_party/fmt/CMakeLists.txt
@@ -5,8 +5,8 @@ message(STATUS "########################################")
 set(BUILD_SHARED_LIBS OFF)
 FetchContent_Declare(
   fmt
-  URL https://github.com/fmtlib/fmt/archive/refs/tags/10.1.1.tar.gz
-  URL_HASH SHA256=78b8c0a72b1c35e4443a7e308df52498252d1cefc2b08c9a97bc9ee6cfe61f8b
+  URL https://github.com/fmtlib/fmt/archive/refs/tags/11.0.2.tar.gz
+  URL_HASH SHA256=6cb1e6d37bdcb756dbbe59be438790db409cdb4868c66e888d5df9f13f7c027f
   DOWNLOAD_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../cache"
   )
 FetchContent_MakeAvailable(fmt)


### PR DESCRIPTION
fmt 10.1.1 validates format strings inside a consteval constructor (basic_format_string), and that constant-evaluation path contains a subexpression (format_str_.remove_prefix(detail::to_unsigned(it - begin())) in fmt/core.h) that newer Clang front-ends correctly reject as not a constant expression. Older Clang accepted it. The accompanying -Wdeprecated-literal-operator warning on operator"" _a confirms the failing runs are on a recent AppleClang (Clang 16+).