### PR TITLE
[pipeline] fix fused subprocess pool teardown hang on full queue

### DIFF
--- a/src/spdl/pipeline/_subprocess_pipeline_pool.py
+++ b/src/spdl/pipeline/_subprocess_pipeline_pool.py
@@ -311,6 +311,7 @@ class _SubprocessPipelinePool:
             # processes or pipe fds. Mirrors ``_WorkerPool.__init__``.
             self._terminate(started)
             for q in (*self._in_qs, self._out_q):
+                q.cancel_join_thread()
                 q.close()
                 q.join_thread()
             raise
@@ -362,7 +363,12 @@ class _SubprocessPipelinePool:
         self._terminate(self._procs)
         # Close this process's queue handles so the feeder threads created on first ``put``
         # exit; otherwise a process that creates many pipelines leaks threads and pipe fds.
+        # The workers are already reaped, so any item still buffered in this process's feeder
+        # threads can never be delivered — ``cancel_join_thread`` first so ``join_thread``
+        # does not block forever flushing it into a pipe no worker drains (e.g. a continuous
+        # run torn down with a full ``in_q`` behind the broadcast shutdown markers).
         for q in (*self._in_qs, self._out_q):
+            q.cancel_join_thread()
             q.close()
             q.join_thread()
 

--- a/tests/pipeline/subprocess_pipeline_fuse_test.py
+++ b/tests/pipeline/subprocess_pipeline_fuse_test.py
@@ -12,6 +12,7 @@ import os
 import queue as _queue
 import sys
 import tempfile
+import threading
 import time
 import unittest
 from collections.abc import AsyncIterator, Iterator
@@ -378,6 +379,46 @@ class ContinuousFuseTest(unittest.TestCase):
         )
         for _ in range(3):  # one epoch per iteration
             self.assertEqual(sorted(src), ref)
+
+    def test_teardown_mid_stream_does_not_hang(self) -> None:
+        """Tearing a continuous fused subprocess pipeline down mid-stream must not hang.
+
+        A teardown before the stream is drained leaves the per-worker input queue full; the
+        pool shutdown must cancel the queue feeder-thread join instead of blocking forever
+        waiting to flush buffered items into a pipe the (terminated) workers no longer drain.
+        Uses the same path data loaders do — ``run_pipeline_in_subprocess`` + fusion — and
+        triggers teardown via the iterable's documented ``_finalizer`` handle.
+        """
+        n = 100_000  # far more than any buffer, so the stream is still full at teardown
+        ex = ProcessPoolExecutor(max_workers=2)
+        self.addCleanup(ex.shutdown)
+        config = (
+            PipelineBuilder()
+            .add_source(range(n), continuous=True)
+            .pipe(add_one, executor=ex, concurrency=2)
+            .pipe(times_two, executor=ex, concurrency=2)
+            .add_sink(2)
+            .get_config()
+        )
+        src = run_pipeline_in_subprocess(
+            config, num_threads=4, fuse_subprocess_stages=True
+        )
+        it = iter(src)
+        next(it)  # consume a couple of items so the queues stay backed up
+        next(it)
+        torn_down = threading.Event()
+
+        def _teardown() -> None:
+            src._finalizer()  # pyre-ignore[16]: documented teardown handle
+            torn_down.set()
+
+        t = threading.Thread(target=_teardown, daemon=True)
+        t.start()
+        self.assertTrue(
+            torn_down.wait(timeout=60),
+            "fused-pool teardown hung on a full input queue after a mid-stream stop",
+        )
+        t.join(timeout=10)
 
 
 class FuseInSubprocessTest(unittest.TestCase):


### PR DESCRIPTION
The fused subprocess pipeline pool's `shutdown()` closed and joined its multiprocessing queues with `close()` + `join_thread()`. When a continuous-source run is torn down mid-stream (the consumer stops before the stream is drained), the per-worker input queue is left full: the workers are terminated without draining it, so this process's own queue feeder thread — created when `shutdown` broadcasts the `_POOL_SHUTDOWN` markers via `put_nowait` — can never flush its buffered item into a pipe no worker is reading, and `join_thread()` blocks forever.

Call `cancel_join_thread()` before `close()`/`join_thread()` in both `shutdown()` and the constructor's start-failure cleanup. The workers are already reaped at that point, so any item still buffered in this process's feeder threads is undeliverable and is intentionally discarded.

This only affects teardown of a fused run; a run that drains fully before teardown leaves the input queue empty and was never affected.