### PR TITLE
[pipeline] Fix subprocess tests for Python 3.14 forkserver default

### DIFF
--- a/tests/pipeline/continuous_pipeline_test.py
+++ b/tests/pipeline/continuous_pipeline_test.py
@@ -682,6 +682,10 @@ class TestContinuousPipelineValidation(unittest.TestCase):
             build_pipeline(merged_config, num_threads=1)
 
 
+def _double(x: int) -> int:
+    return x * 2
+
+
 class _RecordIDs:
     """Pipe function that records the thread ID and process ID."""
 
@@ -760,13 +764,10 @@ class TestContinuousSubprocessPipelineReuse(unittest.TestCase):
         reused across epochs in the subprocess.
         """
 
-        def double(x: int) -> int:
-            return x * 2
-
         backend = (
             PipelineBuilder()
             .add_source(SourceIterable(10), continuous=True)
-            .pipe(double, concurrency=4)
+            .pipe(_double, concurrency=4)
             .aggregate(3, drop_last=False)
             .add_sink(buffer_size=2)
         )

--- a/tests/pipeline/pipeline_builder_test.py
+++ b/tests/pipeline/pipeline_builder_test.py
@@ -3105,16 +3105,22 @@ class TestHoistProcessPools(unittest.TestCase):
 
             def Process(self, *args: Any, **kwargs: Any) -> Process:
                 proc = real_ctx.Process(*args, **kwargs)
-                real_start = proc.start
 
-                def start() -> None:
-                    if len(started) >= 1:
-                        raise OSError("cannot allocate worker")
-                    real_start()
-                    started.append(proc)
+                # Proxy the process rather than monkeypatching ``proc.start``: under the
+                # forkserver start method ``start()`` pickles the ``Process`` object, and a
+                # closure stashed on its instance dict would be unpicklable. The real process
+                # stays clean (only it is ever started); the proxy enforces the failure.
+                class _Proxy:
+                    def start(self_inner) -> None:
+                        if len(started) >= 1:
+                            raise OSError("cannot allocate worker")
+                        proc.start()
+                        started.append(proc)
 
-                proc.start = start  # pyre-ignore[8]
-                return proc
+                    def __getattr__(self_inner, name: str) -> Any:
+                        return getattr(proc, name)
+
+                return cast(Process, _Proxy())
 
         with self.assertRaises(OSError):
             _WorkerPool(cast(mp.context.BaseContext, _FlakyCtx()), 3, None, ())


### PR DESCRIPTION
Python 3.14 switches the default `multiprocessing` start method on Linux from `fork` to `forkserver`. Under `fork` the child inherits the parent's memory so the `Process` object and its `target`/`args` are never pickled; under `forkserver` the entire `Process` object is pickled to the forkserver. Two subprocess tests embedded local objects (closures defined inside the test method) that are unpicklable — they only passed because `fork` never pickled them, and now fail on CI with `_pickle.PicklingError: Can't pickle local object`.

`test_continuous_subprocess_concurrent_aggregate_crisp_boundary` passed a local `double` into `.pipe(...)`, which rides into the subprocess inside the `PipelineConfig`. Hoisted it to a module-level `_double`, matching the existing module-level helper pattern (e.g. `_RecordIDs`).

`test_worker_pool_cleans_up_on_partial_start_failure` monkeypatched `proc.start` with a local closure; under forkserver the real worker's `start()` then pickles a `Process` whose instance dict holds that closure, failing before the cleanup logic under test runs. Replaced the in-place mutation with a proxy that owns `start()` and delegates everything else to the real (clean) process via `__getattr__`, so only the untouched real process is ever pickled. The assertions are unchanged since `started` still holds the real process.

Both fixes are start-method agnostic rather than pinning the tests to `fork`.