### PR TITLE
[pipeline] fuse path-variants stages with same-pool branches

### DIFF
--- a/src/spdl/pipeline/_build.py
+++ b/src/spdl/pipeline/_build.py
@@ -275,11 +275,14 @@ def build_pipeline(
             stage that executes the run as one nested pipeline inside a worker pool. This
             eliminates the inter-stage IPC that otherwise round-trips data back to this process
             between each stage (so intermediate values need not be picklable), while each fused
-            stage keeps its own ``concurrency`` and per-stage stats. Only adjacent pool stages
-            fuse: an ``aggregate``/``disaggregate`` between two pool stages is not fused (it
-            keeps its main-process batching) and splits them into separate runs. Continuous
-            sources are supported (the fused worker sub-pipelines stay warm across epochs and
-            epoch boundaries are propagated across the pool). Default: ``False``.
+            stage keeps its own ``concurrency`` and per-stage stats. A ``path_variants`` stage
+            whose branches all use the same pool executor is fused too — the whole routing
+            construct (router and branches) moves into the worker — and fuses on its own even
+            when it is the only such stage. An ``aggregate``/``disaggregate`` between two pool
+            stages is not fused (it keeps its main-process batching) and splits them into
+            separate runs. Continuous sources are supported (the fused worker sub-pipelines stay
+            warm across epochs and epoch boundaries are propagated across the pool). Default:
+            ``False``.
 
             .. versionadded:: 0.6.0
                The ``fuse_subprocess_stages`` argument.
@@ -498,8 +501,9 @@ def run_pipeline_in_subprocess(
             processes are spawned in (and owned by) the main process, exactly like a hoisted
             ``ProcessPoolExecutor``; the pipeline subprocess drives them through a queue handle.
             This removes the per-stage round-trip between the pipeline subprocess and the pool
-            workers (so intermediate values need not be picklable). Continuous sources are
-            supported. Default: ``False``.
+            workers (so intermediate values need not be picklable). A ``path_variants`` stage
+            whose branches all use the same pool executor is fused too (router and branches move
+            into the worker). Continuous sources are supported. Default: ``False``.
 
             .. versionadded:: 0.6.0
                The ``fuse_subprocess_stages`` argument.

--- a/src/spdl/pipeline/_builder.py
+++ b/src/spdl/pipeline/_builder.py
@@ -340,10 +340,11 @@ class PipelineBuilder(Generic[T, U]):
                 single stage that runs the run as one nested pipeline inside a worker pool. This
                 eliminates the inter-stage IPC that otherwise round-trips data back to this
                 process between each stage (so intermediate values need not be picklable), while
-                each fused stage keeps its own ``concurrency`` and per-stage stats. Only
-                adjacent pool stages fuse; an ``aggregate``/``disaggregate`` between them is
-                not fused and runs in the main process with its usual batching. Default:
-                ``False``.
+                each fused stage keeps its own ``concurrency`` and per-stage stats. A
+                ``path_variants`` stage whose branches all use the same pool executor is fused
+                too (router and branches move into the worker), and fuses on its own. An
+                ``aggregate``/``disaggregate`` between pool stages is not fused and runs in the
+                main process with its usual batching. Default: ``False``.
 
                 .. versionadded:: 0.6.0
                    The ``fuse_subprocess_stages`` argument.

--- a/src/spdl/pipeline/_fuse.py
+++ b/src/spdl/pipeline/_fuse.py
@@ -19,6 +19,13 @@ combined into a single nested :py:class:`~spdl.pipeline.Pipeline` executed insid
 pool, so the op→op handoff stays in-process. The actual config rewrite and worker-pool spawning
 build on the runs found here.
 
+A :py:class:`~spdl.pipeline.defs.PathVariantsConfig` whose branches all use the same pool
+executor is fusable as a unit: the whole routing construct moves into the nested pipeline, where
+the router and any async/thread branch stages run on the worker's loop/threads. Because the
+nested pipeline is built by the normal :py:func:`~spdl.pipeline._build.build_pipeline`, which
+already supports path-variants, no execution machinery is special-cased here — only detection and
+the executor-stripping rewrite know about it.
+
 The detection is a pure function over the stage configs (no process spawning), which keeps the
 fusion policy easy to reason about and to test in isolation.
 """
@@ -44,6 +51,7 @@ from spdl.pipeline.defs._defs import (
     _PipeType,
     _SubprocessPipelineConfig,
     MergeConfig,
+    PathVariantsConfig,
     PipeConfig,
     PipelineConfig,
     SinkConfig,
@@ -124,9 +132,11 @@ def _is_isolating_pool(executor: Executor | type[Executor] | None) -> bool:
 class _FusableRun:
     """A maximal span of ``pipes`` that can be fused into one subprocess sub-pipeline.
 
-    The fused stages are ``pipes[start:stop]`` — two or more *adjacent* pool-pipes sharing
-    :py:attr:`executor`. Only consecutive pool-pipes fuse; aggregate/disaggregate micro-stages
-    are never absorbed (so their batching semantics are unchanged) and instead bound a run.
+    The fused stages are ``pipes[start:stop]`` — *adjacent* stages sharing :py:attr:`executor`:
+    pool-pipes, and path-variants stages whose branches all use it. A span of two or more always
+    fuses; a single path-variants stage fuses on its own (its branches otherwise round-trip per
+    stage). Aggregate/disaggregate micro-stages are never absorbed (so their batching semantics
+    are unchanged) and instead bound a run.
     """
 
     start: int
@@ -155,27 +165,86 @@ def _fusable_pool_executor(cfg: object) -> Executor | None:
     return None
 
 
+def _scan_variant_pool_executors(
+    cfg: PathVariantsConfig[Any], acc: list[Executor]
+) -> bool:
+    """Collect the isolating-pool executors of every pool-pipe in ``cfg``'s branches.
+
+    Recurses into nested path-variants. Appends each completion-ordered pool-pipe's executor to
+    ``acc``; async/thread/default pipes are ignored (they run on the worker's own loop/threads
+    once the stage is fused). Returns ``False`` if any branch holds an *input-ordered*
+    (``output_order="input"``) pool-pipe, which is not fusable for the same reason a top-level
+    one is not — its global input order cannot be preserved across the pool workers.
+    """
+    for path in cfg.paths:
+        for stage in path:
+            if isinstance(stage, PathVariantsConfig):
+                if not _scan_variant_pool_executors(stage, acc):
+                    return False
+                continue
+            executor = _fusable_pool_executor(stage)
+            if executor is not None:
+                acc.append(executor)
+            elif (
+                isinstance(stage, PipeConfig)
+                and stage._args.executor is not None
+                and _is_isolating_pool(stage._args.executor)
+            ):
+                # A pool-pipe that _fusable_pool_executor rejected -> input-ordered: not fusable.
+                return False
+    return True
+
+
+def _path_variants_executor(cfg: object) -> Executor | None:
+    """Return the shared isolating-pool executor if ``cfg`` is a fusable path-variants stage.
+
+    A :py:class:`~spdl.pipeline.defs.PathVariantsConfig` is fusable when every pool-pipe across
+    all of its branches (recursively) shares the **same** isolating-pool executor instance — the
+    whole routing construct then moves into one worker's nested pipeline, where the router and any
+    async/thread branch stages run on the worker's loop/threads and the pool stages run on its
+    thread pool. Returns ``None`` for a non-path-variants stage, a stage with no pool-pipe (no
+    isolation to gain), or branches that mix more than one pool executor / hold an input-ordered
+    pool-pipe.
+    """
+    if not isinstance(cfg, PathVariantsConfig):
+        return None
+    executors: list[Executor] = []
+    if not _scan_variant_pool_executors(cfg, executors) or not executors:
+        return None
+    first = executors[0]
+    return first if all(e is first for e in executors) else None
+
+
+def _fusable_executor(cfg: object) -> Executor | None:
+    """The isolating-pool executor a stage fuses onto: a pool-pipe's, or a path-variants'
+    shared one. ``None`` if the stage is not fusable."""
+    return _fusable_pool_executor(cfg) or _path_variants_executor(cfg)
+
+
 def _scan_run(
     pipes: Sequence[object], start: int, executor: Executor
 ) -> tuple[_FusableRun | None, int]:
-    """Scan one fusable run of adjacent same-executor pool-pipes from ``pipes[start]``.
+    """Scan one fusable run of adjacent same-executor fusable stages from ``pipes[start]``.
 
-    Greedily consumes the immediately-following pool-pipes that share ``executor``, stopping at
-    the first stage that is anything else — a different executor, a thread/None/async pipe, an
-    aggregate/disaggregate micro-stage, a path-variant stage, an input-ordered pool-pipe, or the
-    end. Only adjacent pool-pipes fuse, so a micro-stage between two pool-pipes splits them into
-    separate (and therefore unfused) runs and keeps its main-process batching semantics.
+    Greedily consumes the immediately-following stages that share ``executor`` — pool-pipes and
+    path-variants stages whose branches all use it — stopping at the first stage that is anything
+    else: a different executor, a thread/None/async pipe, an aggregate/disaggregate micro-stage,
+    or the end. A micro-stage between two fusable stages splits them into separate runs and keeps
+    its main-process batching semantics.
+
+    A run of two or more stages always fuses. A lone stage fuses only if it is a path-variants
+    stage — its branches otherwise round-trip per stage, so moving the whole construct into one
+    worker is the win — whereas a lone pool-pipe gains nothing from fusion.
 
     Returns:
         A tuple ``(run, next_index)``. ``run`` is the emitted :py:class:`_FusableRun`, or
-        ``None`` for a lone pool-pipe with no same-executor neighbour. ``next_index`` is where
-        the outer scan should resume.
+        ``None`` for a lone pool-pipe. ``next_index`` is where the outer scan should resume.
     """
     j = start + 1
     n = len(pipes)
-    while j < n and _fusable_pool_executor(pipes[j]) is executor:
+    while j < n and _fusable_executor(pipes[j]) is executor:
         j += 1
-    if j - start >= 2:
+    if j - start >= 2 or isinstance(pipes[start], PathVariantsConfig):
         return _FusableRun(start, j, executor), j
     return None, j
 
@@ -183,10 +252,12 @@ def _scan_run(
 def _find_fusable_runs(pipes: Sequence[object]) -> list[_FusableRun]:
     """Find all maximal fusable runs in a pipeline config's ``pipes``.
 
-    A run is a span of ≥2 adjacent completion-ordered :py:func:`~spdl.pipeline.defs.Pipe`
-    stages sharing the same isolating-pool executor instance. A lone pool-pipe, and any
-    aggregate/disaggregate micro-stage, break a run and are left unchanged in the main process.
-    Returned runs are ordered by position and never overlap.
+    A run is a span of adjacent stages sharing the same isolating-pool executor instance: either
+    ≥2 such stages (completion-ordered :py:func:`~spdl.pipeline.defs.Pipe` stages and/or
+    path-variants stages), or a single :py:class:`~spdl.pipeline.defs.PathVariantsConfig` (whose
+    branches round-trip per stage when unfused). A lone pool-pipe, and any aggregate/disaggregate
+    micro-stage, break a run and are left unchanged in the main process. Returned runs are ordered
+    by position and never overlap.
 
     Args:
         pipes: The ordered stage configs from a :py:class:`~spdl.pipeline.defs.PipelineConfig`.
@@ -198,7 +269,7 @@ def _find_fusable_runs(pipes: Sequence[object]) -> list[_FusableRun]:
     i = 0
     n = len(pipes)
     while i < n:
-        executor = _fusable_pool_executor(pipes[i])
+        executor = _fusable_executor(pipes[i])
         if executor is None:
             i += 1
             continue
@@ -224,10 +295,30 @@ def _has_continuous_source(config: PipelineConfig[Any]) -> bool:
 
 
 def _strip_executor(cfg: object) -> object:
-    """Strip a pool-pipe's executor so it runs on the worker's own pool."""
+    """Strip a stage's executor(s) so it runs on the worker's own pool.
+
+    Recurses into a path-variants stage, stripping every branch pipe's executor (the branch ops
+    then run on the worker's nested thread pool). A pickling boundary is crossed when the config
+    ships to the worker, so any live executor — pool or thread — must be removed regardless.
+    """
     if isinstance(cfg, PipeConfig):
         return replace(cfg, _args=replace(cfg._args, executor=None))
+    if isinstance(cfg, PathVariantsConfig):
+        new_paths = tuple(
+            tuple(_strip_executor(stage) for stage in path) for path in cfg.paths
+        )
+        return replace(cfg, paths=new_paths)
     return cfg
+
+
+def _stage_concurrency(cfg: object) -> int:
+    """Total worker-thread demand of a fused stage: a pipe's ``concurrency``, or the sum across
+    every branch pipe of a path-variants stage (recursively). Other stages contribute 0."""
+    if isinstance(cfg, PipeConfig):
+        return cfg._args.concurrency
+    if isinstance(cfg, PathVariantsConfig):
+        return sum(_stage_concurrency(s) for path in cfg.paths for s in path)
+    return 0
 
 
 def _stage_name(cfg: object) -> str:
@@ -279,9 +370,7 @@ def _build_fused_stage(
 ) -> tuple[_SubprocessPipelineConfig, _SubprocessPipelinePool]:
     """Build the worker pool and replacement stage for one fusable run."""
     stripped = [_strip_executor(s) for s in stages]
-    num_threads = max(
-        1, sum(s._args.concurrency for s in stages if isinstance(s, PipeConfig))
-    )
+    num_threads = max(1, sum(_stage_concurrency(s) for s in stages))
     sub_config: PipelineConfig[Any] = PipelineConfig(
         src=SourceConfig(
             []

--- a/tests/pipeline/subprocess_pipeline_fuse_test.py
+++ b/tests/pipeline/subprocess_pipeline_fuse_test.py
@@ -22,6 +22,7 @@ from typing import Any
 
 from spdl.pipeline import (
     AsyncQueue,
+    build_pipeline,
     Pipeline,
     PipelineBuilder,
     PipelineFailure,
@@ -30,7 +31,9 @@ from spdl.pipeline import (
 )
 from spdl.pipeline._components import _subprocess_pipe
 from spdl.pipeline._components._common import StageInfo
+from spdl.pipeline._fuse import _find_fusable_runs
 from spdl.pipeline.config import set_default_hook_class, set_default_queue_class
+from spdl.pipeline.defs import Pipe
 
 
 def add_one(x: int) -> int:
@@ -47,6 +50,16 @@ def times_two(x: int) -> int:
 
 def boom(x: int) -> int:
     raise ValueError("boom")
+
+
+def route_by_parity(x: int) -> int:
+    """Router: even items to path 0, odd items to path 1."""
+    return x % 2
+
+
+async def aident(x: int) -> int:
+    """An async (no-executor) branch stage; runs on the worker's loop once fused."""
+    return x
 
 
 class _Unpicklable:
@@ -419,6 +432,126 @@ class ContinuousFuseTest(unittest.TestCase):
             "fused-pool teardown hung on a full input queue after a mid-stream stop",
         )
         t.join(timeout=10)
+
+
+class PathVariantsFuseTest(unittest.TestCase):
+    """Fusion of a path-variants stage whose branches share one pool executor."""
+
+    def test_lone_path_variants_pool_branches_fused_match_unfused(self) -> None:
+        """A single path-variants stage with same-pool branches fuses and matches unfused.
+
+        Even items take the ``add_one`` branch, odd items the ``times_two`` branch. The whole
+        routing construct moves into one worker, so the result must match the unfused run.
+        """
+        n = 16
+        ref = sorted(x + 1 if x % 2 == 0 else x * 2 for x in range(n))
+        ex = ProcessPoolExecutor(max_workers=2)
+        builder = (
+            PipelineBuilder()
+            .add_source(range(n))
+            .path_variants(
+                route_by_parity,
+                [[Pipe(add_one, executor=ex)], [Pipe(times_two, executor=ex)]],
+            )
+            .add_sink(n)
+        )
+        config = builder.get_config()
+        # A lone same-pool path-variants is a fusable run on its own.
+        self.assertEqual(len(_find_fusable_runs(config.pipes)), 1)
+        pipeline = build_pipeline(config, num_threads=4, fuse_subprocess_stages=True)
+        self.assertEqual(sorted(_run(pipeline)), ref)
+
+    def test_path_variants_async_branch_stage_fuses(self) -> None:
+        """A branch mixing an async (no-executor) stage with a pool stage still fuses.
+
+        Mirrors a cache miss-path shape (async I/O then pool CPU): the async stage runs on the
+        worker's loop and the pool stage on its threads, all inside one worker.
+        """
+        n = 16
+        ref = sorted(x + 1 if x % 2 == 0 else x * 2 for x in range(n))
+        ex = ProcessPoolExecutor(max_workers=2)
+        builder = (
+            PipelineBuilder()
+            .add_source(range(n))
+            .path_variants(
+                route_by_parity,
+                [
+                    [Pipe(add_one, executor=ex)],
+                    [Pipe(aident), Pipe(times_two, executor=ex)],
+                ],
+            )
+            .add_sink(n)
+        )
+        config = builder.get_config()
+        self.assertEqual(len(_find_fusable_runs(config.pipes)), 1)
+        pipeline = build_pipeline(config, num_threads=4, fuse_subprocess_stages=True)
+        self.assertEqual(sorted(_run(pipeline)), ref)
+
+    def test_path_variants_mixed_executors_not_fused(self) -> None:
+        """Branches on two different pool executors are not fused, and still run correctly."""
+        n = 16
+        ref = sorted(x + 1 if x % 2 == 0 else x * 2 for x in range(n))
+        ex1 = ProcessPoolExecutor(max_workers=2)
+        ex2 = ProcessPoolExecutor(max_workers=2)
+        builder = (
+            PipelineBuilder()
+            .add_source(range(n))
+            .path_variants(
+                route_by_parity,
+                [[Pipe(add_one, executor=ex1)], [Pipe(times_two, executor=ex2)]],
+            )
+            .add_sink(n)
+        )
+        config = builder.get_config()
+        self.assertEqual(_find_fusable_runs(config.pipes), [])
+        pipeline = build_pipeline(config, num_threads=4, fuse_subprocess_stages=True)
+        self.assertEqual(sorted(_run(pipeline)), ref)
+
+    def test_path_variants_fused_with_adjacent_pool_pipe(self) -> None:
+        """A pool-pipe adjacent to a same-pool path-variants stage fuses into one run."""
+        n = 16
+        # add_one shifts each item to v=x+1; then even v -> add_one (v+1), odd v -> times_two (v*2).
+        ref = sorted(
+            (v + 1) if v % 2 == 0 else (v * 2) for v in (x + 1 for x in range(n))
+        )
+        ex = ProcessPoolExecutor(max_workers=2)
+        builder = (
+            PipelineBuilder()
+            .add_source(range(n))
+            .pipe(add_one, executor=ex)
+            .path_variants(
+                route_by_parity,
+                [[Pipe(add_one, executor=ex)], [Pipe(times_two, executor=ex)]],
+            )
+            .add_sink(n)
+        )
+        config = builder.get_config()
+        runs = _find_fusable_runs(config.pipes)
+        self.assertEqual(len(runs), 1)
+        self.assertEqual(
+            (runs[0].start, runs[0].stop), (0, 2)
+        )  # both stages in one run
+        pipeline = build_pipeline(config, num_threads=4, fuse_subprocess_stages=True)
+        self.assertEqual(sorted(_run(pipeline)), ref)
+
+    def test_path_variants_fused_multi_epoch(self) -> None:
+        """A fused path-variants stage stays correct across epochs of a continuous source."""
+        n = 12
+        ref = sorted(x + 1 if x % 2 == 0 else x * 2 for x in range(n))
+        ex = ProcessPoolExecutor(max_workers=2)
+        pipeline = (
+            PipelineBuilder()
+            .add_source(range(n), continuous=True)
+            .path_variants(
+                route_by_parity,
+                [[Pipe(add_one, executor=ex)], [Pipe(times_two, executor=ex)]],
+            )
+            .add_sink(n)
+            .build(num_threads=4, fuse_subprocess_stages=True)
+        )
+        with pipeline.auto_stop():
+            for _ in range(3):  # three epochs from the same warm worker pool
+                self.assertEqual(sorted(pipeline.get_iterator(timeout=60)), ref)
 
 
 class FuseInSubprocessTest(unittest.TestCase):


### PR DESCRIPTION
Extends subprocess-stage fusion (`fuse_subprocess_stages=True`) to absorb a `path_variants` stage whose branches all use the same isolating-pool executor instance. Previously a `PathVariantsConfig` broke a fusable run and ran in the main process, round-tripping each branch op back over IPC.

The whole routing construct now moves into one worker's nested pipeline: the router and any async/thread branch stages run on the worker's loop/threads, and the pool branch stages run on its thread pool — so a hit/miss-style router with async I/O on the miss path (download) plus pool CPU (decode/extract) fuses cleanly. No execution machinery is special-cased: the worker already builds its nested run with `build_pipeline`, which supports `path_variants`, so only fusion's detection and the executor-stripping rewrite learn about it.

Details:
- `_path_variants_executor` returns the shared pool executor of a `PathVariantsConfig` when every pool-pipe across all branches (recursively) uses the same instance; mixed executors, an input-ordered pool branch pipe, or no pool pipe make it non-fusable.
- A lone fusable `path_variants` fuses on its own (its branches otherwise round-trip per stage), unlike a lone pool-pipe which gains nothing.
- `_strip_executor` recurses into branches; `_stage_concurrency` sums branch-pipe concurrency for the nested pipeline's thread count.

Composes with the existing continuous-source and `run_pipeline_in_subprocess` paths.