### PR TITLE
[pipeline] Shield stage hook finalization so failures survive cancel

### DIFF
--- a/src/spdl/pipeline/_components/_common.py
+++ b/src/spdl/pipeline/_components/_common.py
@@ -5,10 +5,12 @@
 # LICENSE file in the root directory of this source tree.
 
 __all__ = [
+    "_drive_to_completion",
     "_EOF",
     "_EPOCH_END",
     "_periodic_dispatch",
     "_P2Percentile",
+    "_ShieldedHook",
     "_SKIP",
     "_StatsCounter",
     "_time_str",
@@ -22,7 +24,7 @@ import time
 from asyncio import Task
 from collections.abc import Callable, Coroutine, Iterator
 from contextlib import contextmanager
-from typing import Any, TypeVar
+from typing import Any, AsyncContextManager, TypeVar
 
 from spdl.pipeline._common._misc import create_task
 from spdl.pipeline._common._types import StageInfo as StageInfo  # noqa: F811
@@ -249,3 +251,84 @@ async def _periodic_dispatch(
 
     if pending:
         await asyncio.wait(pending)
+
+
+async def _drive_to_completion(
+    coro: Coroutine[Any, Any, T],
+) -> tuple[T, asyncio.CancelledError | None]:
+    """Drive ``coro`` to completion, absorbing repeated cancellations.
+
+    A task can be cancelled more than once: each ``cancel()`` queues another
+    ``CancelledError`` for the next suspension point. A single ``asyncio.shield``
+    only absorbs one, so we loop until the shielded task actually finishes.
+
+    Returns the coroutine's result together with the first ``CancelledError``
+    seen (or ``None``). The caller is responsible for re-raising the
+    cancellation once any remaining shielded work is done — it is never
+    swallowed here. A non-cancellation exception from ``coro`` propagates
+    immediately and takes priority over a pending cancellation.
+
+    The surrounding task may be cancelled repeatedly (e.g. the pipeline
+    executor re-cancels orphaned stages on every loop iteration). Each delivery
+    interrupts our ``await`` with ``CancelledError`` even after ``coro`` itself
+    has already finished. We disambiguate via ``task.cancelled()``: if ``coro``
+    was itself cancelled, that is its result and we propagate it; otherwise the
+    ``CancelledError`` is a cancellation of *our* wait, so we keep ``coro``'s
+    real result (value or non-cancel exception) and report the cancellation for
+    the caller to handle.
+    """
+    task = asyncio.ensure_future(coro)
+    cancelled: asyncio.CancelledError | None = None
+    while True:
+        try:
+            return await asyncio.shield(task), cancelled
+        except asyncio.CancelledError as e:
+            cancelled = cancelled or e
+            if task.done():
+                if task.cancelled():
+                    raise
+                # ``coro`` finished; ``task.result()`` returns its value or
+                # re-raises its (non-cancel) exception.
+                return task.result(), cancelled
+
+
+class _ShieldedHook:
+    """Wrap a stage-hook context manager so ``__aenter__``/``__aexit__`` run to
+    completion even when the surrounding task is cancelled.
+
+    The cancellation is re-raised once the shielded enter/exit finishes, so the
+    stage still shuts down — it is only deferred, not dropped. This protects
+    finalization that must not be lost (e.g. flushing the final task stats in
+    ``TaskStatsHook.stage_hook`` or the queue stats in ``StatsQueue.stage_hook``).
+
+    .. caution::
+
+       This makes the hook's enter/exit uninterruptible. Only wrap finalization
+       that is trusted to terminate; a ``stage_hook`` that blocks after ``yield``
+       would make the whole stage impossible to cancel.
+    """
+
+    def __init__(self, cm: AsyncContextManager[Any]) -> None:
+        self._cm = cm
+
+    async def __aenter__(self) -> Any:
+        res, cancelled = await _drive_to_completion(self._cm.__aenter__())
+        if cancelled is None:
+            return res
+        # Entered successfully but we were cancelled; release before re-raising
+        # so a half-initialized hook is not leaked. The exit is shielded too.
+        await _drive_to_completion(self._cm.__aexit__(None, None, None))
+        raise cancelled
+
+    async def __aexit__(self, *exc_info: Any) -> Any:
+        result, cancelled = await _drive_to_completion(self._cm.__aexit__(*exc_info))
+        # Surface a deferred cancellation only when there is no original
+        # exception to preserve, or the hook suppressed it (truthy ``result``).
+        # When an exception is already propagating into this exit (e.g. a stage
+        # failure) and the hook did not suppress it, that exception must win —
+        # a cancellation that arrived during finalization must not mask it.
+        # ``result`` is the hook's exception-suppression signal, which we also
+        # return to honor the context-manager contract.
+        if cancelled is not None and (exc_info[0] is None or result):
+            raise cancelled
+        return result

--- a/src/spdl/pipeline/_components/_hook.py
+++ b/src/spdl/pipeline/_components/_hook.py
@@ -20,6 +20,7 @@ from spdl.pipeline._common._misc import create_task
 from ._common import (
     _P2Percentile,
     _periodic_dispatch,
+    _ShieldedHook,
     _StatsCounter,
     _time_str,
     StageInfo,
@@ -196,14 +197,18 @@ class TaskHook(ABC):
 
 
 def _stage_hooks(hooks: Sequence[TaskHook]) -> AsyncContextManager[None]:
-    hs: list[AsyncContextManager[None]] = [hook.stage_hook() for hook in hooks]
+    raw: list[AsyncContextManager[None]] = [hook.stage_hook() for hook in hooks]
 
-    if not all(hasattr(h, "__aenter__") and hasattr(h, "__aexit__") for h in hs):
+    if not all(hasattr(h, "__aenter__") and hasattr(h, "__aexit__") for h in raw):
         raise ValueError(
             "`stage_hook()` must return an object that has `__aenter__` and"
             " `__aexit__` method. "
             "Make sure that `stage_hook()` is decorated with `asynccontextmanager`."
         )
+
+    # Shield enter/exit so stage finalization (e.g. final stats reporting) is not
+    # lost when the pipeline is cancelled during shutdown.
+    hs: list[AsyncContextManager[None]] = [_ShieldedHook(h) for h in raw]
 
     @asynccontextmanager
     async def stage_hooks() -> AsyncIterator[None]:

--- a/src/spdl/pipeline/_components/_queue.py
+++ b/src/spdl/pipeline/_components/_queue.py
@@ -17,7 +17,14 @@ from typing import Any
 
 from spdl.pipeline._common._misc import create_task
 
-from ._common import _EOF, _periodic_dispatch, _StatsCounter, _time_str, StageInfo
+from ._common import (
+    _EOF,
+    _periodic_dispatch,
+    _ShieldedHook,
+    _StatsCounter,
+    _time_str,
+    StageInfo,
+)
 
 __all__ = [
     "_queue_stage_hook",
@@ -75,7 +82,11 @@ async def _queue_stage_hook(queue: AsyncQueue) -> AsyncGenerator[None, None]:
     # Note:
     # `asyncio.CancelledError` is a subclass of BaseException, so it won't be
     # caught in the following, and EOF won't be passed to the output queue.
-    async with queue.stage_hook():
+    #
+    # The stage hook is shielded so its finalization (e.g. flushing the final
+    # `StatsQueue` stats) runs to completion even when the cancellation that
+    # ends the stage propagates through this `async with`.
+    async with _ShieldedHook(queue.stage_hook()):
         try:
             yield
         except Exception:

--- a/src/spdl/pipeline/_components/_variants.py
+++ b/src/spdl/pipeline/_components/_variants.py
@@ -21,7 +21,7 @@ from typing import Any
 
 from spdl.pipeline._common._convert import _to_async
 
-from ._common import _EOF, _EPOCH_END, is_eof, is_epoch_end
+from ._common import _EOF, _EPOCH_END, _ShieldedHook, is_eof, is_epoch_end
 from ._hook import _stage_hooks, TaskHook
 from ._queue import AsyncQueue
 
@@ -55,7 +55,11 @@ async def _queue_stage_hook(queues: Sequence[AsyncQueue]) -> AsyncGenerator[None
     cancelled = False
     async with AsyncExitStack() as stack:
         for q in queues:
-            await stack.enter_async_context(q.stage_hook())
+            # Use the shared guarded wrapper so stage finalization (e.g. final
+            # stats flush) survives cancellation, consistently with the other
+            # pipes. This stage's only bespoke behavior is the multi-queue EOF
+            # broadcast below, which the shared hook does not cover.
+            await stack.enter_async_context(_ShieldedHook(q.stage_hook()))
         try:
             yield
         except asyncio.CancelledError:

--- a/tests/pipeline/pipeline_builder_test.py
+++ b/tests/pipeline/pipeline_builder_test.py
@@ -34,6 +34,7 @@ from typing import Any, cast, TypeVar
 from parameterized import parameterized
 from spdl.pipeline import (
     AsyncQueue,
+    Pipeline,
     PipelineBuilder,
     PipelineFailure,
     PriorityThreadPoolExecutor,
@@ -3355,3 +3356,99 @@ class TestPipelineFailureStructure(unittest.TestCase):
             self.assertTrue(
                 any(note.startswith("Pipeline stage:") for note in notes),
             )
+
+
+class _SlowFinalizeQueue(AsyncQueue):
+    """AsyncQueue whose stage finalization sleeps.
+
+    Holding the stage open during finalization guarantees that the executor's
+    orphan-cancellation (issued once a downstream stage completes) lands while
+    the failing stage is still finalizing — the exact window the fix protects.
+    """
+
+    @asynccontextmanager
+    async def stage_hook(self):
+        try:
+            yield
+        finally:
+            await asyncio.sleep(0.3)
+
+
+class TestStageFinalizationCancellation(unittest.TestCase):
+    """A stage failure must survive a cancellation that races stage finalization.
+
+    When a stage raises and its stage/queue hook finalization is then interrupted
+    by an external cancellation (the executor orphan-cancels the stage once a
+    downstream stage completes), the cancellation must not mask the failure.
+    Otherwise the task is marked cancelled, ``_gather_error`` drops its exception,
+    and no ``PipelineFailure`` is raised. This surfaced intermittently with
+    ``use_thread_output_queue=True`` (it perturbs shutdown scheduling, hitting the
+    race on roughly half of the runs).
+
+    The hooks are shielded so finalization runs to completion and re-raises the
+    failure instead of the cancellation. ``_SlowFinalizeQueue`` makes the race
+    deterministic, so a regression fails on every run without a stress loop.
+    """
+
+    def _assert_fails(self, pipeline: Pipeline) -> None:
+        with self.assertRaises(PipelineFailure):
+            with pipeline.auto_stop():
+                list(pipeline.get_iterator(timeout=30))
+
+    def test_max_failures(self) -> None:
+        """Exceeding max_failures surfaces despite finalization cancellation."""
+
+        def fail_odd(x):
+            if x % 2:
+                raise ValueError(f"Only even numbers are allowed. {x}")
+            return x
+
+        self._assert_fails(
+            PipelineBuilder()
+            .add_source(range(10))
+            .pipe(fail_odd)
+            .add_sink(1)
+            .build(
+                num_threads=1,
+                max_failures=3,
+                use_thread_output_queue=True,
+                queue_class=_SlowFinalizeQueue,
+            )
+        )
+
+    def test_type_error(self) -> None:
+        """A stage TypeError surfaces despite finalization cancellation."""
+
+        async def wrong_sig(i, _):
+            return i
+
+        self._assert_fails(
+            PipelineBuilder()
+            .add_source(range(10))
+            # pyre-ignore[6]
+            .pipe(wrong_sig)
+            .add_sink(1)
+            .build(
+                num_threads=1,
+                use_thread_output_queue=True,
+                queue_class=_SlowFinalizeQueue,
+            )
+        )
+
+    def test_source_failure(self) -> None:
+        """A source exception surfaces despite finalization cancellation."""
+
+        def failure_source():
+            raise RuntimeError("Foo")
+            yield None
+
+        self._assert_fails(
+            PipelineBuilder()
+            .add_source(failure_source())
+            .add_sink(1)
+            .build(
+                num_threads=1,
+                use_thread_output_queue=True,
+                queue_class=_SlowFinalizeQueue,
+            )
+        )


### PR DESCRIPTION
A pipeline stage failure could be silently dropped when an external cancellation raced the stage's finalization. This surfaced intermittently with `use_thread_output_queue=True` (reported in T277502960), which perturbs shutdown scheduling enough to hit the race on roughly half of the runs.

# Root cause

When a stage raises (e.g. `_FailCounter.raise_for_failures`, a stage `TypeError`, or a source exception), it propagates through the stage's finalization: the `_stage_hooks`/`_queue_stage_hook` `__aexit__` bodies and the `_queue_stage_hook` EOF put. Delivering `_EOF` lets the downstream stage complete, and the executor's `_cancel_orphaned` then cancels the still-finalizing failing stage — repeatedly, since `_run_pipeline_coroutines` re-runs it on every loop iteration. The cancellation replaces the in-flight exception, `task.cancelled()` becomes `True`, and `_gather_error` skips the task, so no `PipelineFailure` is raised.

# Fix

Shield the stage hook finalization from cancellation with a shared `_ShieldedHook` wrapper (in `_common.py`), applied consistently in `_stage_hooks` (`_hook.py`), `_queue_stage_hook` (`_queue.py`), and the fan-out queue hook (`_variants.py`, which previously rolled its own enter logic). The wrapper drives `__aenter__`/`__aexit__` to completion via `_drive_to_completion`, deferring the cancellation until finalization finishes instead of letting it interrupt and mask the failure.

Two subtleties handled by `_drive_to_completion` and `_ShieldedHook.__aexit__`:
- The surrounding task is cancelled repeatedly, so a single `asyncio.shield` is not enough; we loop and disambiguate via `task.cancelled()` so a re-delivered cancellation on an already-finished finalization does not override the result.
- `contextlib`'s `__aexit__` returns `False` (rather than re-raising) when the hook propagates the in-flight exception, so we surface a deferred cancellation only when there is no original exception to preserve — otherwise the stage failure wins.