### PR TITLE
Define SPDL InterpreterPoolExecutor tests conditionally instead of skipping them (#1573)

### DIFF
--- a/tests/pipeline/continuous_pipeline_test.py
+++ b/tests/pipeline/continuous_pipeline_test.py
@@ -786,55 +786,66 @@ class TestContinuousSubprocessPipelineReuse(unittest.TestCase):
             self.assertEqual(flat, expected_items, f"epoch {epoch}: items")
 
 
-@unittest.skipIf(
-    sys.version_info < (3, 14),
-    "Subinterpreters require Python 3.14+",
-)
-class TestContinuousSubinterpreterPipelineReuse(unittest.TestCase):
-    @_ignore_fork_warning
-    def test_subinterpreter_pipeline_reused_across_epochs(self) -> None:
-        """Thread and process IDs stay the same across epochs in subinterpreter."""
-        recorder = _RecordIDs()
+def _has_interpreter_pool_executor() -> bool:
+    if sys.version_info < (3, 14):
+        return False
+    try:
+        from concurrent.futures.interpreter import InterpreterPoolExecutor  # noqa: F401
+    except ImportError:
+        return False
+    return True
 
-        config = (
-            PipelineBuilder()
-            .add_source(SourceIterable(5), continuous=True)
-            .pipe(recorder, concurrency=1)
-            .add_sink(buffer_size=3)
-            .get_config()
-        )
-        source = run_pipeline_in_subinterpreter(
-            config,
-            num_threads=1,
-            timeout=10,
-        )
 
-        all_thread_ids: list[set[int]] = []
-        all_process_ids: list[set[int]] = []
+_HAS_INTERPRETER: bool = _has_interpreter_pool_executor()
 
-        for epoch in range(3):
-            recorder.thread_ids.clear()
-            recorder.process_ids.clear()
-            result = list(source)
-            self.assertEqual(sorted(result), [0, 1, 2, 3, 4], f"epoch {epoch}")
-            all_thread_ids.append(set(recorder.thread_ids))
-            all_process_ids.append(set(recorder.process_ids))
 
-        # All epochs should use the same thread(s) — pipeline was reused
-        self.assertEqual(
-            all_thread_ids[0],
-            all_thread_ids[1],
-            "Thread IDs changed between epoch 0 and 1 — pipeline was rebuilt",
-        )
-        self.assertEqual(
-            all_thread_ids[1],
-            all_thread_ids[2],
-            "Thread IDs changed between epoch 1 and 2 — pipeline was rebuilt",
-        )
+if _HAS_INTERPRETER:
 
-        # All epochs should run in the same process (subinterpreter shares process)
-        self.assertEqual(
-            all_process_ids[0],
-            all_process_ids[1],
-            "Process IDs changed between epoch 0 and 1",
-        )
+    class TestContinuousSubinterpreterPipelineReuse(unittest.TestCase):
+        @_ignore_fork_warning
+        def test_subinterpreter_pipeline_reused_across_epochs(self) -> None:
+            """Thread and process IDs stay the same across epochs in subinterpreter."""
+            recorder = _RecordIDs()
+
+            config = (
+                PipelineBuilder()
+                .add_source(SourceIterable(5), continuous=True)
+                .pipe(recorder, concurrency=1)
+                .add_sink(buffer_size=3)
+                .get_config()
+            )
+            source = run_pipeline_in_subinterpreter(
+                config,
+                num_threads=1,
+                timeout=10,
+            )
+
+            all_thread_ids: list[set[int]] = []
+            all_process_ids: list[set[int]] = []
+
+            for epoch in range(3):
+                recorder.thread_ids.clear()
+                recorder.process_ids.clear()
+                result = list(source)
+                self.assertEqual(sorted(result), [0, 1, 2, 3, 4], f"epoch {epoch}")
+                all_thread_ids.append(set(recorder.thread_ids))
+                all_process_ids.append(set(recorder.process_ids))
+
+            # All epochs should use the same thread(s) — pipeline was reused
+            self.assertEqual(
+                all_thread_ids[0],
+                all_thread_ids[1],
+                "Thread IDs changed between epoch 0 and 1 — pipeline was rebuilt",
+            )
+            self.assertEqual(
+                all_thread_ids[1],
+                all_thread_ids[2],
+                "Thread IDs changed between epoch 1 and 2 — pipeline was rebuilt",
+            )
+
+            # All epochs should run in the same process (subinterpreter shares process)
+            self.assertEqual(
+                all_process_ids[0],
+                all_process_ids[1],
+                "Process IDs changed between epoch 0 and 1",
+            )

--- a/tests/pipeline/pipeline_builder_test.py
+++ b/tests/pipeline/pipeline_builder_test.py
@@ -2728,7 +2728,7 @@ class TestRunPipeline(unittest.TestCase):
             pass
 
 
-def _interpreter_pool_available() -> bool:
+def _has_interpreter_pool_executor() -> bool:
     if sys.version_info < (3, 14):
         return False
     try:
@@ -2736,6 +2736,9 @@ def _interpreter_pool_available() -> bool:
     except ImportError:
         return False
     return True
+
+
+_HAS_INTERPRETER: bool = _has_interpreter_pool_executor()
 
 
 def _config_with_executor(executor) -> PipelineConfig:
@@ -2925,22 +2928,6 @@ class TestExecutorProxy(unittest.TestCase):
     def test_run_in_subprocess_with_threadpool(self) -> None:
         """run_pipeline_in_subprocess works with a ThreadPoolExecutor on a pipe."""
         config = _config_with_executor(ThreadPoolExecutor(max_workers=2))
-        results = list(run_pipeline_in_subprocess(config, num_threads=1))
-        self.assertEqual(sorted(results), [2 * i for i in range(10)])
-
-    @unittest.skipUnless(
-        _interpreter_pool_available(),
-        "InterpreterPoolExecutor requires Python 3.14+",
-    )
-    @_ignore_warnings(_FORK_WARNING, _UNAWAITED_COROUTINE)
-    def test_run_in_subprocess_with_interpreterpool(self) -> None:
-        """run_pipeline_in_subprocess works with an InterpreterPoolExecutor on a pipe."""
-        import importlib
-
-        interpreter_mod = importlib.import_module("concurrent.futures.interpreter")
-        executor = interpreter_mod.InterpreterPoolExecutor(max_workers=2)
-
-        config = _config_with_executor(executor)
         results = list(run_pipeline_in_subprocess(config, num_threads=1))
         self.assertEqual(sorted(results), [2 * i for i in range(10)])
 
@@ -3452,3 +3439,19 @@ class TestStageFinalizationCancellation(unittest.TestCase):
                 queue_class=_SlowFinalizeQueue,
             )
         )
+
+
+if _HAS_INTERPRETER:
+
+    class TestExecutorProxyInterpreterPool(unittest.TestCase):
+        @_ignore_warnings(_FORK_WARNING, _UNAWAITED_COROUTINE)
+        def test_run_in_subprocess_with_interpreterpool(self) -> None:
+            """run_pipeline_in_subprocess works with an InterpreterPoolExecutor on a pipe."""
+            import importlib
+
+            interpreter_mod = importlib.import_module("concurrent.futures.interpreter")
+            executor = interpreter_mod.InterpreterPoolExecutor(max_workers=2)
+
+            config = _config_with_executor(executor)
+            results = list(run_pipeline_in_subprocess(config, num_threads=1))
+            self.assertEqual(sorted(results), [2 * i for i in range(10)])

--- a/tests/pipeline/priority_executor_test.py
+++ b/tests/pipeline/priority_executor_test.py
@@ -864,74 +864,84 @@ class TestPriorityExecutorGarbageCollection(unittest.TestCase):
 
 # ─── PriorityInterpreterPoolExecutor tests (Python 3.14+ only) ───
 
-_has_interpreter_pool: bool = sys.version_info >= (3, 14)
+
+def _has_interpreter_pool_executor() -> bool:
+    if sys.version_info < (3, 14):
+        return False
+    try:
+        from concurrent.futures.interpreter import InterpreterPoolExecutor  # noqa: F401
+    except ImportError:
+        return False
+    return True
 
 
-@unittest.skipUnless(
-    _has_interpreter_pool, "InterpreterPoolExecutor requires Python 3.14+"
-)
-class TestPriorityInterpreterPoolExecutor(unittest.TestCase):
-    def test_basic_execution(self) -> None:
-        from spdl.pipeline import PriorityInterpreterPoolExecutor
+_HAS_INTERPRETER: bool = _has_interpreter_pool_executor()
 
-        executor = PriorityInterpreterPoolExecutor(max_workers=2)
-        stage = executor.get_executor()
-        futs = [stage.submit(pow, 2, x) for x in range(10)]
-        results = {f.result(timeout=10) for f in futs}
-        self.assertEqual(results, {2**x for x in range(10)})
-        executor.shutdown()
 
-    def test_exception_propagation(self) -> None:
-        from spdl.pipeline import PriorityInterpreterPoolExecutor
+if _HAS_INTERPRETER:
 
-        executor = PriorityInterpreterPoolExecutor(max_workers=1)
-        stage = executor.get_executor()
+    class TestPriorityInterpreterPoolExecutor(unittest.TestCase):
+        def test_basic_execution(self) -> None:
+            from spdl.pipeline import PriorityInterpreterPoolExecutor
 
-        def fail() -> None:
-            raise ValueError("interpreter boom")
+            executor = PriorityInterpreterPoolExecutor(max_workers=2)
+            stage = executor.get_executor()
+            futs = [stage.submit(pow, 2, x) for x in range(10)]
+            results = {f.result(timeout=10) for f in futs}
+            self.assertEqual(results, {2**x for x in range(10)})
+            executor.shutdown()
 
-        fut = stage.submit(fail)
-        with self.assertRaises(ValueError):
-            fut.result(timeout=10)
-        executor.shutdown()
+        def test_exception_propagation(self) -> None:
+            from spdl.pipeline import PriorityInterpreterPoolExecutor
 
-    def test_submit_after_shutdown_raises(self) -> None:
-        from spdl.pipeline import PriorityInterpreterPoolExecutor
+            executor = PriorityInterpreterPoolExecutor(max_workers=1)
+            stage = executor.get_executor()
 
-        executor = PriorityInterpreterPoolExecutor(max_workers=1)
-        stage = executor.get_executor()
-        executor.shutdown()
-        with self.assertRaises(RuntimeError):
-            executor._submit_with_priority(  # pyre-ignore[16]
-                (0, 0), lambda: None, (), {}
+            def fail() -> None:
+                raise ValueError("interpreter boom")
+
+            fut = stage.submit(fail)
+            with self.assertRaises(ValueError):
+                fut.result(timeout=10)
+            executor.shutdown()
+
+        def test_submit_after_shutdown_raises(self) -> None:
+            from spdl.pipeline import PriorityInterpreterPoolExecutor
+
+            executor = PriorityInterpreterPoolExecutor(max_workers=1)
+            executor.get_executor()
+            executor.shutdown()
+            with self.assertRaises(RuntimeError):
+                executor._submit_with_priority(  # pyre-ignore[16]
+                    (0, 0), lambda: None, (), {}
+                )
+
+        def test_is_executor_compatible(self) -> None:
+            from spdl.pipeline import PriorityInterpreterPoolExecutor
+
+            executor = PriorityInterpreterPoolExecutor(max_workers=1)
+            stage = executor.get_executor()
+            self.assertIsInstance(stage, Executor)
+            executor.shutdown()
+
+        def test_pipeline_two_stage(self) -> None:
+            from spdl.pipeline import PriorityInterpreterPoolExecutor
+
+            pool = PriorityInterpreterPoolExecutor(max_workers=4)
+            s1 = pool.get_executor()
+            s2 = pool.get_executor()
+
+            pipeline = (
+                PipelineBuilder()
+                .add_source(range(20))
+                .pipe(lambda x: x * 2, executor=s1, concurrency=4)
+                .pipe(lambda x: x + 1, executor=s2, concurrency=4)
+                .add_sink(3)
+                .build(num_threads=1)
             )
 
-    def test_is_executor_compatible(self) -> None:
-        from spdl.pipeline import PriorityInterpreterPoolExecutor
+            with pipeline.auto_stop():
+                results = sorted(pipeline.get_iterator(timeout=30))
 
-        executor = PriorityInterpreterPoolExecutor(max_workers=1)
-        stage = executor.get_executor()
-        self.assertIsInstance(stage, Executor)
-        executor.shutdown()
-
-    def test_pipeline_two_stage(self) -> None:
-        from spdl.pipeline import PriorityInterpreterPoolExecutor
-
-        pool = PriorityInterpreterPoolExecutor(max_workers=4)
-        s1 = pool.get_executor()
-        s2 = pool.get_executor()
-
-        pipeline = (
-            PipelineBuilder()
-            .add_source(range(20))
-            .pipe(lambda x: x * 2, executor=s1, concurrency=4)
-            .pipe(lambda x: x + 1, executor=s2, concurrency=4)
-            .add_sink(3)
-            .build(num_threads=1)
-        )
-
-        with pipeline.auto_stop():
-            results = sorted(pipeline.get_iterator(timeout=30))
-
-        self.assertEqual(results, sorted(x * 2 + 1 for x in range(20)))
-        pool.shutdown()
+            self.assertEqual(results, sorted(x * 2 + 1 for x in range(20)))
+            pool.shutdown()

--- a/tests/pipeline/subprocess_pipeline_fuse_test.py
+++ b/tests/pipeline/subprocess_pipeline_fuse_test.py
@@ -216,26 +216,6 @@ class SubprocessPipelineFuseTest(unittest.TestCase):
         self.assertTrue(all(v == 3 for v in out))
         self.assertEqual(sum(out), n)
 
-    @unittest.skipUnless(
-        sys.version_info >= (3, 14), "InterpreterPoolExecutor requires Python 3.14+"
-    )
-    def test_interpreter_pool_stages_fused(self) -> None:
-        """Stages sharing an InterpreterPoolExecutor are recognized and fused."""
-        from concurrent.futures import InterpreterPoolExecutor  # pyre-ignore[21]
-
-        n = 12
-        ref = sorted((x + 1) * 2 for x in range(n))
-        ex = InterpreterPoolExecutor(max_workers=2)
-        fused = (
-            PipelineBuilder()
-            .add_source(range(n))
-            .pipe(add_one, executor=ex, concurrency=2)
-            .pipe(times_two, executor=ex, concurrency=2)
-            .add_sink(n)
-            .build(num_threads=4, fuse_subprocess_stages=True)
-        )
-        self.assertEqual(sorted(_run(fused)), ref)
-
     def test_initializer_failure_surfaces_not_hangs(self) -> None:
         """A worker initializer that raises surfaces as a failure instead of hanging.
 
@@ -1020,3 +1000,37 @@ class FuseHookTest(unittest.TestCase):
             # ``_await_evidence`` polls for the files rather than assuming they are already there.
             self.assertEqual(sorted(src), ref)
             self._assert_hooks_fired(self._await_evidence(evidence_dir, n), n)
+
+
+def _has_interpreter_pool_executor() -> bool:
+    if sys.version_info < (3, 14):
+        return False
+    try:
+        from concurrent.futures.interpreter import InterpreterPoolExecutor  # noqa: F401
+    except ImportError:
+        return False
+    return True
+
+
+_HAS_INTERPRETER: bool = _has_interpreter_pool_executor()
+
+
+if _HAS_INTERPRETER:
+
+    class SubprocessPipelineInterpreterPoolFuseTest(unittest.TestCase):
+        def test_interpreter_pool_stages_fused(self) -> None:
+            """Stages sharing an InterpreterPoolExecutor are recognized and fused."""
+            from concurrent.futures import InterpreterPoolExecutor  # pyre-ignore[21]
+
+            n = 12
+            ref = sorted((x + 1) * 2 for x in range(n))
+            ex = InterpreterPoolExecutor(max_workers=2)
+            fused = (
+                PipelineBuilder()
+                .add_source(range(n))
+                .pipe(add_one, executor=ex, concurrency=2)
+                .pipe(times_two, executor=ex, concurrency=2)
+                .add_sink(n)
+                .build(num_threads=4, fuse_subprocess_stages=True)
+            )
+            self.assertEqual(sorted(_run(fused)), ref)


### PR DESCRIPTION
Summary:

The `InterpreterPoolExecutor`-based tests under `spdl/tests/pipeline` require Python 3.14+. They were previously gated with `unittest.skipUnless`/`unittest.skipIf`, so on profiles running an older interpreter (e.g. TestX) they showed up as *skipped*, which is noisy.

Instead of skipping, gate the *definition* of these tests on the Python version so they simply do not exist on older interpreters. Each affected file now defines an identical module-level constant `PYTHON_HAS_INTERPRETER_POOL_EXECUTOR` (a `sys.version_info >= (3, 14)` check plus an `ImportError` guard against `concurrent.futures.interpreter.InterpreterPoolExecutor`) and wraps the relevant `TestCase` in `if PYTHON_HAS_INTERPRETER_POOL_EXECUTOR:`. This matches the existing pattern in `subinterpreter_test.py`.

Whole skipped classes were wrapped directly:
- `priority_executor_test.py`: `TestPriorityInterpreterPoolExecutor`
- `continuous_pipeline_test.py`: `TestContinuousSubinterpreterPipelineReuse`

Individually-skipped test methods were moved into dedicated guarded classes:
- `pipeline_builder_test.py`: `test_run_in_subprocess_with_interpreterpool` -> `TestExecutorProxyInterpreterPool` (also removes the now-unused `_interpreter_pool_available` helper)
- `fb/logging_test.py`: `test_get_pipe_info_with_interpreter_pool_executor` -> `LoggingInterpreterPoolTest`
- `subprocess_pipeline_fuse_test.py`: `test_interpreter_pool_stages_fused` -> `SubprocessPipelineInterpreterPoolFuseTest`

Also drops an unused `stage` local in `test_submit_after_shutdown_raises`.

Reviewed By: gl3lan

Differential Revision: D109949913


