### PR TITLE
[pipeline] Fix silent drop in fused subprocess pipeline 

### DIFF
--- a/src/spdl/pipeline/_components/_subprocess_pipe.py
+++ b/src/spdl/pipeline/_components/_subprocess_pipe.py
@@ -14,12 +14,17 @@ whose coroutine, defined here, streams items to a worker pool that runs the run 
 :py:mod:`spdl.pipeline._subprocess_pipeline_pool`; this stage only talks to it through the
 queues carried by a handle.
 
-There are two modes, selected by ``handle.continuous``:
+There are two modes, selected by ``handle.continuous``. Each worker has its own input queue in
+both:
 
-- **Non-continuous:** items are fed onto one shared queue that the workers steal from, and the
-  stage finishes when every worker reports ``_DONE``.
-- **Continuous:** the source emits epoch boundaries (``_EPOCH_END``). Each worker has its own
-  input queue so a boundary can be broadcast to all of them, and the collector applies the same
+- **Non-continuous:** items are round-robined across the per-worker queues and one
+  ``_SESSION_END`` is sent to each, so every worker ends its session exactly once; the stage
+  finishes when every worker reports ``_DONE``. A per-worker queue (rather than one shared
+  queue the workers steal from) is what guarantees a fast worker cannot consume a second
+  ``_SESSION_END`` meant for a slower peer and let the stage finish before that peer flushes
+  its items.
+- **Continuous:** the source emits epoch boundaries (``_EPOCH_END``). Each worker's own input
+  queue lets a boundary be broadcast to all of them, and the collector applies the same
   cross-stream barrier as :py:func:`spdl.pipeline._components._pipe._default_merge` — it emits one
   ``_EPOCH_END`` downstream only once every worker has reached the boundary. The feeder gates the
   next epoch's items behind that barrier so epochs stay correctly ordered across the pool.
@@ -108,36 +113,42 @@ def _check_stall(last_progress: float) -> None:
 
 
 ########################################################################################
-# Non-continuous: shared work-stealing input queue, finish when all workers report _DONE.
+# Non-continuous: per-worker input queues, finish when all workers report _DONE.
 ########################################################################################
 
 
 async def _feed(
     input_queue: AsyncQueue,
-    in_q: Any,
-    num_workers: int,
+    in_qs: list[Any],
     executor: Executor,
     abort: asyncio.Event,
     feeder_idle: asyncio.Event,
 ) -> None:
-    """Forward items to the shared worker queue, then end the session.
+    """Round-robin items across the per-worker queues, then end every worker's session.
 
-    Sends exactly one ``_SESSION_END`` per worker: a worker consumes exactly one such marker to
-    end its current session, so the per-worker count ends every worker exactly once even though
-    the input queue is shared. ``abort`` is set by :py:func:`_collect` on a worker error; once
-    set, forwarding stops early and only the per-worker ``_SESSION_END`` markers are sent, so
-    the workers wind down their current sessions instead of churning through the rest of the
-    stream.
+    Sends exactly one ``_SESSION_END`` onto each worker's own queue, so every worker ends
+    its session exactly once. Per-worker queues (rather than one shared queue the workers
+    steal from) are what make this guarantee hold: on a shared queue a worker that reaches
+    ``_SESSION_END`` early can loop back and consume a second marker meant for a slower peer
+    still holding un-flushed items — the peer then never ends, :py:func:`_collect` reaches
+    its ``_DONE`` count from the wrong workers and finishes, and the peer's items are
+    silently dropped.
+
+    ``abort`` is set by :py:func:`_collect` on a worker error; once set, forwarding stops early
+    and only the per-worker ``_SESSION_END`` markers are sent, so the workers wind down their
+    current sessions instead of churning through the rest of the stream.
 
     The next-item ``get`` is raced against ``abort`` rather than awaited directly: on the error
     path the feeder is often parked here waiting on a slow/idle upstream, and ``abort`` must still
     interrupt it so the ``_SESSION_END`` markers go out. Otherwise the workers would block on
-    ``in_q`` waiting for a marker that never arrives and :py:func:`_collect` would never see every
-    ``_DONE`` — a hang bounded only by the collector's stall timeout. The pending item is dropped
-    because the pipeline is already failing.
+    their queues waiting for a marker that never arrives and :py:func:`_collect` would never see
+    every ``_DONE`` — a hang bounded only by the collector's stall timeout. The pending item is
+    dropped because the pipeline is already failing.
     """
     loop = asyncio.get_running_loop()
     abort_wait = create_task(abort.wait())
+    i = 0
+    n = len(in_qs)
     try:
         while not abort.is_set():
             get_task = create_task(input_queue.get())
@@ -154,11 +165,14 @@ async def _feed(
                 feeder_idle.clear()
             if is_eof(item):
                 break
-            await loop.run_in_executor(executor, _put, in_q, (_ITEM, item))
+            await loop.run_in_executor(executor, _put, in_qs[i % n], (_ITEM, item))
+            i += 1
     finally:
         abort_wait.cancel()
-    for _ in range(num_workers):
-        await loop.run_in_executor(executor, _put, in_q, (_SESSION_END, None))
+    # Concurrent so a full/slow worker queue does not block the markers to the others.
+    await asyncio.gather(
+        *(loop.run_in_executor(executor, _put, q, (_SESSION_END, None)) for q in in_qs)
+    )
 
 
 async def _collect(
@@ -328,8 +342,9 @@ async def _subprocess_pipeline(
     """
     in_qs, out_q = handle.in_qs, handle.out_q
     num_workers = handle.max_workers
-    # One thread parked per concurrent blocking op: a put per input queue plus the collector get.
-    max_threads = (len(in_qs) if handle.continuous else 1) + 1
+    # One thread parked per concurrent blocking op: a put per input queue (the feeder broadcasts
+    # epoch/session-end markers across all of them at once) plus the collector get.
+    max_threads = len(in_qs) + 1
     executor = ThreadPoolExecutor(
         max_workers=max_threads, thread_name_prefix="spdl_fused_bridge_"
     )
@@ -359,7 +374,7 @@ async def _subprocess_pipeline(
             # Set by the collector on a worker error so the feeder stops forwarding new items.
             abort = asyncio.Event()
             feeder = create_task(
-                _feed(input_queue, in_qs[0], num_workers, executor, abort, feeder_idle)
+                _feed(input_queue, in_qs, executor, abort, feeder_idle)
             )
             collector = create_task(
                 _collect(out_q, num_workers, output_queue, executor, abort, feeder_idle)

--- a/src/spdl/pipeline/_subprocess_pipeline_pool.py
+++ b/src/spdl/pipeline/_subprocess_pipeline_pool.py
@@ -15,12 +15,15 @@ module runs one submitted ``fn(*args)`` per task, here each worker process runs 
 back over a shared queue, so the op→op handoff between fused stages stays inside one worker
 process — no inter-stage IPC, and intermediate values need not be picklable.
 
-Two layouts, chosen by ``continuous``:
+Each worker has its own input queue in both layouts (chosen by ``continuous``):
 
-- **Non-continuous:** all workers steal from one shared input queue; each worker runs one session
-  (until ``_SESSION_END``) and reports ``_DONE``.
-- **Continuous:** each worker has its own input queue (so the bridge can broadcast epoch
-  boundaries) and runs a long-lived *continuous* sub-pipeline, emitting ``_EPOCH_DONE`` at each
+- **Non-continuous:** the bridge round-robins items across the per-worker queues and sends one
+  ``_SESSION_END`` to each; each worker runs one session (until its ``_SESSION_END``) and
+  reports ``_DONE``. A per-worker queue (rather than one shared queue the workers steal from)
+  guarantees every worker receives exactly one end marker, so a fast worker cannot steal a
+  slow peer's marker and let the collector finish before the peer flushes its items.
+- **Continuous:** the per-worker queue also lets the bridge broadcast epoch boundaries cleanly;
+  each worker runs a long-lived *continuous* sub-pipeline, emitting ``_EPOCH_DONE`` at each
   boundary and staying warm across epochs.
 
 Like :py:class:`spdl.pipeline._subprocess_worker_pool._WorkerPool`, the worker processes are
@@ -238,9 +241,9 @@ class _SubprocessPipelineHandle:
     Holds only the queues, worker count, and mode, so it is cheap to carry inside a
     :py:class:`~spdl.pipeline.defs.PipelineConfig` — including across the pickle boundary into a
     pipeline subprocess (the queues travel as ``Process`` spawn arguments, the only context in
-    which an ``mp.Queue`` may be pickled). ``in_qs`` is the shared input queue (length 1) in
-    non-continuous mode, or one queue per worker in continuous mode. The worker processes
-    themselves are owned by the main process, so this handle holds no process references.
+    which an ``mp.Queue`` may be pickled). ``in_qs`` holds one input queue per worker in both
+    modes. The worker processes themselves are owned by the main process, so this handle
+    holds no process references.
     """
 
     def __init__(
@@ -270,23 +273,21 @@ class _SubprocessPipelinePool:
         size = max(4, max_workers * 2)
         self._continuous = continuous
         self._out_q: Any = ctx.Queue(maxsize=size)
-        if continuous:
-            # One queue per worker so the bridge can broadcast epoch boundaries cleanly.
-            self._in_qs: list[Any] = [
-                ctx.Queue(maxsize=size) for _ in range(max_workers)
-            ]
-            worker_in_qs = self._in_qs
-        else:
-            # One shared queue the workers steal from.
-            shared = ctx.Queue(maxsize=size)
-            self._in_qs = [shared]
-            worker_in_qs = [shared] * max_workers
+        # One input queue per worker in both modes. Continuous mode needs it to broadcast epoch
+        # boundaries cleanly; non-continuous mode needs it so each worker receives exactly one
+        # ``_SESSION_END`` on its own queue. A single shared queue cannot guarantee that — a
+        # worker that drains its stream and reaches ``_SESSION_END`` early can loop back and
+        # steal a second marker meant for a slower peer still holding (un-flushed) items. That
+        # peer then never ends, the collector reaches its ``_DONE`` count from the wrong workers
+        # and finishes, and the slow peer's items are silently dropped. Per-worker queues remove
+        # the shared marker entirely, so every worker ends exactly once.
+        self._in_qs: list[Any] = [ctx.Queue(maxsize=size) for _ in range(max_workers)]
         self._max_workers = max_workers
         self._procs: list[Any] = [
             ctx.Process(
                 target=_pipeline_worker_loop,
                 args=(
-                    worker_in_qs[i],
+                    self._in_qs[i],
                     self._out_q,
                     sub_config,
                     build_kwargs,
@@ -335,12 +336,8 @@ class _SubprocessPipelinePool:
         )
 
     def _broadcast_shutdown(self) -> None:
-        # Continuous: one shutdown per worker queue. Non-continuous: N onto the shared queue,
-        # where each worker consumes exactly one (it stops pulling the instant it gets one).
-        targets = (
-            self._in_qs if self._continuous else [self._in_qs[0]] * self._max_workers
-        )
-        for q in targets:
+        # One shutdown marker per worker, onto that worker's own input queue.
+        for q in self._in_qs:
             try:
                 # Non-blocking: the queues are bounded and on the error path workers may have
                 # stalled on a full ``_out_q`` (the bridge stage stops draining after relaying

--- a/tests/pipeline/subprocess_pipeline_fuse_test.py
+++ b/tests/pipeline/subprocess_pipeline_fuse_test.py
@@ -128,6 +128,33 @@ def _run(pipeline: Pipeline[Any], timeout: float = 60.0) -> list[Any]:
         return list(pipeline.get_iterator(timeout=timeout))
 
 
+def stall_on_first(x: int) -> int:
+    """Stall only on the earliest item, so one worker holds it while its peer races ahead."""
+    if x == 0:
+        time.sleep(3.0)
+    return x + 1
+
+
+class _Buffer1Queue(AsyncQueue):
+    """An ``AsyncQueue`` pinned to ``buffer_size=1`` (no prefetch slack)."""
+
+    def __init__(
+        self, info: Any, *, buffer_size: int = 1, interval: float = -1
+    ) -> None:
+        super().__init__(info, buffer_size=1)
+
+
+def _install_small_buffers() -> None:
+    """Executor initializer: pin the worker sub-pipeline's queues to ``buffer_size=1``.
+
+    A single-slot buffer stops the worker holding the earliest item from prefetching past it, so
+    that worker stays parked on the slow item while its peer drains the rest — the timing that
+    surfaces the startup race below (a cheap, deterministic stand-in for the recording overhead
+    that first exposed it under stress).
+    """
+    set_default_queue_class(_Buffer1Queue)
+
+
 class SubprocessPipelineFuseTest(unittest.TestCase):
     def test_two_pool_stages_fused_match_unfused(self) -> None:
         """A fused two-stage process-pool pipeline matches the unfused result."""
@@ -250,6 +277,36 @@ class SubprocessPipelineFuseTest(unittest.TestCase):
             .build(num_threads=4, fuse_subprocess_stages=False)
         )
         self.assertEqual(sorted(_run(pipeline)), ref)
+
+
+class StartupRaceFuseTest(unittest.TestCase):
+    """A slow worker holding the earliest items must not have them silently dropped.
+
+    Regression test for the silent earliest-item drop in the non-continuous fused
+    pipeline. With a single shared work-stealing input queue, a worker that drains its
+    stream and reaches ``_SESSION_END`` early could loop back and consume a second end
+    marker meant for a slower peer still holding (un-flushed) items; that peer then
+    never ended, the collector reached its ``_DONE`` count from the wrong workers and
+    finished, and the peer's earliest items were dropped with no error. Per-worker input
+    queues (one ``_SESSION_END`` each) make that impossible. ``stall_on_first`` +
+    ``buffer_size=1`` deterministically pin the worker that grabs item ``0`` while its
+    peer races through the rest — exactly the interleaving the race needs.
+    """
+
+    def test_slow_worker_does_not_drop_earliest_items(self) -> None:
+        """A worker stalled on the earliest item still delivers it instead of dropping it."""
+        n = 16
+        ref = sorted((x + 1) * 2 for x in range(n))
+        ex = ProcessPoolExecutor(max_workers=2, initializer=_install_small_buffers)
+        fused = (
+            PipelineBuilder()
+            .add_source(range(n))
+            .pipe(stall_on_first, executor=ex, concurrency=1)
+            .pipe(times_two, executor=ex, concurrency=1)
+            .add_sink(n)
+            .build(num_threads=4, fuse_subprocess_stages=True)
+        )
+        self.assertEqual(sorted(_run(fused)), ref)
 
 
 class ContinuousFuseTest(unittest.TestCase):
@@ -692,34 +749,36 @@ class FeedAbortTest(unittest.TestCase):
     def test_feed_ends_session_when_aborted_while_idle(self) -> None:
         """A feeder parked on an empty input queue still emits the per-worker _SESSION_END.
 
-        On a worker error the collector sets ``abort`` while the feeder is typically blocked
-        waiting on a slow/idle upstream. The feeder must wake and send one ``_SESSION_END`` per
-        worker so the collector can drain every ``_DONE`` instead of hanging until its stall
-        timeout. Driving ``_feed`` directly keeps the abort-while-idle race deterministic.
+        On a worker error the collector sets ``abort`` while the feeder is typically
+        blocked waiting on a slow/idle upstream. The feeder must wake and send exactly one
+        ``_SESSION_END`` onto each worker's own queue so the collector can drain every
+        ``_DONE`` instead of hanging until its stall timeout. Driving ``_feed`` directly
+        keeps the abort-while-idle race deterministic.
         """
         num_workers = 3
 
-        async def _scenario() -> list[Any]:
-            in_q: _queue.Queue[Any] = _queue.Queue()
+        async def _scenario() -> list[list[Any]]:
+            in_qs: list[_queue.Queue[Any]] = [
+                _queue.Queue() for _ in range(num_workers)
+            ]
             input_queue = AsyncQueue(
                 StageInfo(pipeline_id=0, stage_id="0", stage_name="input")
             )  # stays empty -> get() blocks
             abort = asyncio.Event()
             feeder_idle = asyncio.Event()
-            with ThreadPoolExecutor(max_workers=2) as ex:
+            with ThreadPoolExecutor(max_workers=num_workers + 1) as ex:
                 task = asyncio.ensure_future(
-                    _subprocess_pipe._feed(
-                        input_queue, in_q, num_workers, ex, abort, feeder_idle
-                    )
+                    _subprocess_pipe._feed(input_queue, in_qs, ex, abort, feeder_idle)
                 )
                 await asyncio.sleep(0.1)  # let the feeder park on input_queue.get()
                 self.assertFalse(task.done(), "feeder should be parked on empty queue")
                 abort.set()
                 await asyncio.wait_for(task, timeout=5.0)
-            return [in_q.get_nowait() for _ in range(in_q.qsize())]
+            return [[q.get_nowait() for _ in range(q.qsize())] for q in in_qs]
 
         msgs = asyncio.run(_scenario())
-        self.assertEqual(msgs, [(_subprocess_pipe._SESSION_END, None)] * num_workers)
+        # Every worker's own queue receives exactly one _SESSION_END.
+        self.assertEqual(msgs, [[(_subprocess_pipe._SESSION_END, None)]] * num_workers)
 
 
 class StallGuardTest(unittest.TestCase):


### PR DESCRIPTION
**Problem.** A non-continuous fused subprocess pipeline (`fuse_subprocess_stages=True`) could silently drop its earliest items under concurrent/instrumented startup. Root cause (confirmed by instrumenting `_run_sessions`): the non-continuous workers shared one work-stealing input queue, and the bridge `_feed` put `num_workers` anonymous `_SESSION_END` markers on it. A worker that drained its stream and reached `_SESSION_END` early could loop back and consume a *second* marker meant for a slower peer still holding un-flushed items. That peer never ended, `_collect` reached its `_DONE` count from the wrong workers and finished, and the peer's earliest items were discarded with no error or log.

A startup READY-handshake (the original hypothesis) does **not** fix this — items in a bounded `mp.Queue` are never lost before draining; the loss is the double-`_SESSION_END` consumption on the shared queue.

**Fix.** Give each non-continuous worker its own input queue (continuous mode already does this). The bridge round-robins items across the per-worker queues and sends exactly one `_SESSION_END` to each, so every worker ends exactly once and no worker can steal a peer's marker. `_broadcast_shutdown` now sends one `_POOL_SHUTDOWN` per worker queue. This unifies both modes and removes the shared marker entirely.