### PR TITLE
[pipeline] 2/4: Fuse placement-marked regions into worker-pool pipelines

### DIFF
--- a/src/spdl/pipeline/_build.py
+++ b/src/spdl/pipeline/_build.py
@@ -35,7 +35,11 @@ from spdl.pipeline._components import (
     TaskHook,
 )
 from spdl.pipeline._executor_proxy import _make_config_executors_picklable
-from spdl.pipeline._fuse import _fuse_subprocess_stages, _strip_async_executor_tags
+from spdl.pipeline._fuse import (
+    _fuse_marked_regions,
+    _fuse_subprocess_stages,
+    _strip_async_executor_tags,
+)
 from spdl.pipeline._iter_utils import iterate_in_subinterpreter, iterate_in_subprocess
 from spdl.pipeline._random_seed import _capture_rng_initializers
 from spdl.pipeline._subprocess_pipeline_pool import _shutdown_pipeline_pools
@@ -147,14 +151,30 @@ def _build_pipeline(
             _LG.exception("Build callback failed.")
 
     pools: list[Any] = []
-    if fuse_subprocess_stages:
-        # Fuse consecutive same-pool stages so each run executes as one nested pipeline inside a
-        # worker pool, eliminating the inter-stage IPC. The pools are owned by the returned
-        # Pipeline and reaped when it stops.
-        # stacklevel=4: _fuse_subprocess_stages -> _build_pipeline -> build_pipeline -> user.
-        pipeline_cfg, pools = _fuse_subprocess_stages(
+    # Both fusion passes eagerly spawn worker pools. Reap them together on failure: each pass
+    # only reaps its own pools if it raises, so without this a failure in the second pass would
+    # leak the pools the first already spawned -- this half-built pipeline is never returned to
+    # the caller to be stopped.
+    try:
+        # Honor explicit `.to()` region markers first. This is a no-op when the config has no
+        # markers, so it is always safe to run and independent of `fuse_subprocess_stages`.
+        # stacklevel=4: _fuse_marked_regions -> _build_pipeline -> build_pipeline -> user.
+        pipeline_cfg, region_pools = _fuse_marked_regions(
             pipeline_cfg, report_stats_interval=report_stats_interval, stacklevel=4
         )
+        pools.extend(region_pools)
+        if fuse_subprocess_stages:
+            # Fuse consecutive same-pool stages so each run executes as one nested pipeline
+            # inside a worker pool, eliminating the inter-stage IPC. The pools are owned by the
+            # returned Pipeline and reaped when it stops.
+            # stacklevel=4: _fuse_subprocess_stages -> _build_pipeline -> build_pipeline -> user.
+            pipeline_cfg, id_pools = _fuse_subprocess_stages(
+                pipeline_cfg, report_stats_interval=report_stats_interval, stacklevel=4
+            )
+            pools.extend(id_pools)
+    except BaseException:
+        _shutdown_pipeline_pools(pools)
+        raise
 
     desc = repr(pipeline_cfg)
 
@@ -605,33 +625,55 @@ def run_pipeline_in_subprocess(
         else config_or_builder.get_config()  # pyre-ignore[16]
     )
 
-    # Fuse runs of same-pool stages into nested-pipeline stages first, so a fused run executes
-    # as one pipeline inside the (main-owned) worker pool instead of round-tripping per stage.
-    # Runs before hoisting so only the *non-fused* ProcessPoolExecutor stages remain to be
-    # hoisted. The fused stage's queue handle is picklable and rides into the pipeline
-    # subprocess with the config, where the bridge stage drives the main-owned workers.
+    # Every pass below eagerly spawns worker pools, so they all run inside one try/except:
+    # ``_fuse_marked_regions`` spawns ``fuse_pools`` up front, and if any *later* pass
+    # (``_fuse_subprocess_stages``, ``_hoist_process_pools``) or the iterable creation
+    # raises, both ``fuse_pools`` and the hoisted ``pools`` must be reaped -- this half-built
+    # iterable is never returned to the caller to be stopped. Mirrors ``_build_pipeline``.
     fuse_pools: list[Any] = []
-    if fuse_subprocess_stages:
-        # stacklevel=3: _fuse_subprocess_stages -> run_pipeline_in_subprocess -> user.
-        config, fuse_pools = _fuse_subprocess_stages(
+    pools: list[Any] = []
+    try:
+        # Fuse each `.to()` region into a nested-pipeline stage here, in the main process (a
+        # no-op when the config has no markers), so its worker pool is main-owned -- spawned
+        # here, not inside the daemonic pipeline subprocess (a daemon cannot have children),
+        # and not orphaned if that subprocess is force-killed. Runs before hoisting so only
+        # the *non-region* ProcessPoolExecutor stages remain to be hoisted. The fused stage's
+        # queue handle is picklable and rides into the subprocess with the config (where the
+        # inner build sees no markers and is a no-op), and the bridge stage there drives the
+        # main-owned workers.
+        # stacklevel=3: _fuse_marked_regions -> run_pipeline_in_subprocess -> user.
+        config, region_pools = _fuse_marked_regions(
             config,
-            mp_context=kwargs.get("mp_context"),
             report_stats_interval=report_stats_interval,
             stacklevel=3,
         )
+        fuse_pools.extend(region_pools)
+        # Also fuse runs of same-pool stages tagged with an identical executor into one nested
+        # pipeline inside a worker pool, eliminating the inter-stage IPC (before hoisting, so
+        # only unfused ProcessPoolExecutor stages remain).
+        if fuse_subprocess_stages:
+            # stacklevel=3: _fuse_subprocess_stages -> run_pipeline_in_subprocess -> user.
+            config, id_pools = _fuse_subprocess_stages(
+                config,
+                mp_context=kwargs.get("mp_context"),
+                report_stats_interval=report_stats_interval,
+                stacklevel=3,
+            )
+            fuse_pools.extend(id_pools)
 
-    # Clear executor tags left on any unfused async op: they are subprocess fusion-group hints,
-    # not real pools, and the executor-hoisting/pickling passes below are op-agnostic -- an async
-    # op's process-pool tag would otherwise spawn an idle worker pool it never submits to.
-    config = _strip_async_executor_tags(config)
+        # Clear executor tags left on any unfused async op: they are subprocess fusion-group
+        # hints, not real pools, and the executor-hoisting/pickling passes below are op-agnostic
+        # -- an async op's process-pool tag would otherwise spawn an idle pool it never uses.
+        config = _strip_async_executor_tags(config)
 
-    # Spawn workers for any stdlib ``ProcessPoolExecutor`` in the main process (as children of
-    # main, not grandchildren via the pipeline subprocess), then replace the executor with a
-    # queue-backed proxy that the subprocess submits to. The remaining stdlib executors
-    # (Thread/Interpreter pools, whose workers live inside the subprocess and die with it) are
-    # made picklable via lazy-reconstruction proxies.
-    config, pools = _hoist_process_pools(config, kwargs.get("mp_context"))
-    try:
+        # Spawn workers for any stdlib ``ProcessPoolExecutor`` in the main process (as children
+        # of main, not grandchildren via the pipeline subprocess), then replace the executor
+        # with a queue-backed proxy that the subprocess submits to. The remaining stdlib
+        # executors (Thread/Interpreter pools, whose workers live inside the subprocess and die
+        # with it) are made picklable via lazy-reconstruction proxies.
+        config, hoisted_pools = _hoist_process_pools(config, kwargs.get("mp_context"))
+        pools.extend(hoisted_pools)
+
         config = _make_config_executors_picklable(config)
 
         initializer = _get_initializer(kwargs, shareable_rng_only=False)
@@ -651,10 +693,9 @@ def run_pipeline_in_subprocess(
             **kwargs,
         )
     except BaseException:
-        # If anything between the hoist and the iterable raises (e.g.
-        # ``iterate_in_subprocess`` fails to start the subprocess), the iterable is never
-        # returned to the caller — reap the pools here so their worker processes and pipe
-        # fds do not leak.
+        # Any eager-spawn pass above (region fusion, identity fusion, hoisting) or the iterable
+        # creation failed; the iterable is never returned to the caller, so reap the region and
+        # hoisted pools here to avoid leaking their worker processes and pipe fds.
         _shutdown_pools(pools)
         _shutdown_pipeline_pools(fuse_pools)
         raise

--- a/src/spdl/pipeline/_components/_node.py
+++ b/src/spdl/pipeline/_components/_node.py
@@ -26,6 +26,7 @@ from spdl.pipeline.defs import (
     PathVariantsConfig,
     PipeConfig,
     PipelineConfig,
+    PlacementConfig,
     SinkConfig,
     SourceConfig,
 )
@@ -312,6 +313,7 @@ def _convert_pipes(
         | DisaggregateConfig
         | PathVariantsConfig
         | _SubprocessPipelineConfig
+        | PlacementConfig
     ],
     n: _TNodes,
     q_class: type[AsyncQueue],
@@ -340,6 +342,12 @@ def _convert_pipes(
         match cfg:
             case PathVariantsConfig():
                 n = _convert_path_variants(cfg, n, q_class, pipeline_id, stage_id, idx)
+            case PlacementConfig():
+                # Region markers are build-time directives resolved before the pipeline is
+                # built; they must never reach node construction.
+                raise ValueError(
+                    "PlacementConfig region markers must be resolved before building nodes."
+                )
             case _:
                 in_q = _get_output_queue(n, idx)
                 info = _get_stage_info(cfg, pipeline_id, stage_id)

--- a/src/spdl/pipeline/_fuse.py
+++ b/src/spdl/pipeline/_fuse.py
@@ -48,12 +48,16 @@ from spdl.pipeline._components import _get_global_id, _set_global_id
 from spdl.pipeline._executor_proxy import _ensure_executor_unused
 from spdl.pipeline._subprocess_pipeline_pool import _SubprocessPipelinePool
 from spdl.pipeline.defs._defs import (
+    _MainProcess,
     _PipeType,
     _SubprocessPipelineConfig,
+    InterpreterPoolExecutorConfig,
     MergeConfig,
     PathVariantsConfig,
     PipeConfig,
     PipelineConfig,
+    PlacementConfig,
+    ProcessPoolExecutorConfig,
     SinkConfig,
     SourceConfig,
 )
@@ -61,6 +65,7 @@ from spdl.pipeline.defs._defs import (
 __all__ = [
     "_FusableRun",
     "_find_fusable_runs",
+    "_fuse_marked_regions",
     "_fuse_subprocess_stages",
     "_strip_async_executor_tags",
 ]
@@ -316,16 +321,22 @@ def _warn_fork_with_threads(ctx: Any, stacklevel: int) -> None:
         )
 
 
-def _build_fused_stage(
+def _build_fused_stage_core(
     stages: Sequence[object],
-    executor: Executor,
+    *,
     ctx: Any,
+    num_threads: int,
+    max_workers: int,
+    user_initializer: Any,
+    user_initargs: tuple[Any, ...],
     report_stats_interval: float,
     continuous: bool,
 ) -> tuple[_SubprocessPipelineConfig, _SubprocessPipelinePool]:
-    """Build the worker pool and replacement stage for one fusable run."""
+    """Spawn a worker pool that runs ``stages`` as a nested pipeline, and return the pool and its
+    replacement stage. Shared by the executor-identity fusion (:py:func:`_build_fused_stage`) and
+    the ``.to()`` marker fusion (:py:func:`_build_fused_stage_from_spec`) — the two differ only in
+    where the pool parameters come from (a live executor vs. a serializable spec)."""
     stripped = [_strip_executor(s) for s in stages]
-    num_threads = max(1, sum(_stage_concurrency(s) for s in stages))
     sub_config: PipelineConfig[Any] = PipelineConfig(
         src=SourceConfig(
             []
@@ -333,7 +344,6 @@ def _build_fused_stage(
         pipes=stripped,  # pyre-ignore[6]
         sink=SinkConfig(_FUSED_SINK_BUFFER),
     )
-    max_workers, user_initializer, user_initargs = _pool_params(executor)
     build_kwargs = {
         "num_threads": num_threads,
         "report_stats_interval": report_stats_interval,
@@ -352,6 +362,53 @@ def _build_fused_stage(
     )
     name = "subprocess_pipeline(" + "+".join(_stage_name(s) for s in stages) + ")"
     return _SubprocessPipelineConfig(name=name, handle=pool.make_handle()), pool
+
+
+def _build_fused_stage(
+    stages: Sequence[object],
+    executor: Executor,
+    ctx: Any,
+    report_stats_interval: float,
+    continuous: bool,
+) -> tuple[_SubprocessPipelineConfig, _SubprocessPipelinePool]:
+    """Build the worker pool and replacement stage for one executor-identity fusable run."""
+    max_workers, user_initializer, user_initargs = _pool_params(executor)
+    return _build_fused_stage_core(
+        stages,
+        ctx=ctx,
+        num_threads=max(1, sum(_stage_concurrency(s) for s in stages)),
+        max_workers=max_workers,
+        user_initializer=user_initializer,
+        user_initargs=user_initargs,
+        report_stats_interval=report_stats_interval,
+        continuous=continuous,
+    )
+
+
+def _build_fused_stage_from_spec(
+    stages: Sequence[object],
+    spec: ProcessPoolExecutorConfig,
+    ctx: Any,
+    report_stats_interval: float,
+    continuous: bool,
+) -> tuple[_SubprocessPipelineConfig, _SubprocessPipelinePool]:
+    """Build the worker pool and replacement stage for one ``.to()`` region, reading the pool
+    parameters from ``spec``. ``num_threads`` for the nested pipeline is the sum of the region
+    stages' concurrency, ``max_workers`` falls back to the CPU count, and
+    ``report_stats_interval`` is inherited from
+    :py:func:`~spdl.pipeline._build.build_pipeline`."""
+    num_threads = max(1, sum(_stage_concurrency(s) for s in stages))
+    max_workers = spec.max_workers or os.cpu_count() or 1
+    return _build_fused_stage_core(
+        stages,
+        ctx=ctx,
+        num_threads=num_threads,
+        max_workers=max_workers,
+        user_initializer=spec.initializer,
+        user_initargs=spec.initargs,
+        report_stats_interval=report_stats_interval,
+        continuous=continuous,
+    )
 
 
 def _fuse_subprocess_stages(
@@ -420,6 +477,94 @@ def _fuse_subprocess_stages(
         # later pool fails to spawn) would otherwise leak the workers already started by the
         # pools built so far. Reap them before propagating, since the caller never receives the
         # ``pools`` list to reap them itself.
+        for pool in pools:
+            pool.shutdown()
+        raise
+    return replace(config, pipes=new_pipes), pools  # pyre-ignore[6]
+
+
+def _has_executor_markers(pipes: Sequence[object]) -> bool:
+    """Whether ``pipes`` contains any ``.to()`` region marker."""
+    return any(isinstance(p, PlacementConfig) for p in pipes)
+
+
+def _fuse_marked_regions(
+    config: PipelineConfig[Any],
+    *,
+    report_stats_interval: float = -1,
+    stacklevel: int = 3,
+) -> tuple[PipelineConfig[Any], list[_SubprocessPipelinePool]]:
+    """Fuse each ``.to()`` region into one subprocess-pipeline stage.
+
+    Walks ``config.pipes`` tracking the current execution target set by
+    :py:class:`~spdl.pipeline.defs.PlacementConfig` markers (a pipeline starts on the main
+    process). Every maximal span of stages under a subprocess target — pipes *and* the
+    aggregate/disaggregate/path-variants stages between them, which the executor-identity fusion
+    leaves in the main process — is replaced by a single stage that runs the span as one nested
+    pipeline inside a worker pool. Main-process spans are kept unchanged, and the marker nodes
+    themselves are dropped. The spawned pools are returned for the caller to reap at teardown; the
+    input ``config`` is not mutated.
+
+    This is a no-op (returns ``config`` and no pools) when there are no markers, so it is safe to
+    run unconditionally and leaves the executor-identity :py:func:`_fuse_subprocess_stages` path
+    unchanged.
+
+    Args:
+        config: The pipeline configuration to rewrite.
+        report_stats_interval: Fallback stats interval for a region whose spec does not set one.
+        stacklevel: ``warnings.warn`` stack level measured at this function. The fork-with-threads
+            warning is raised from the nested ``_flush`` closure (two frames deeper), so it uses
+            ``stacklevel + 2``.
+
+    Returns:
+        A tuple ``(new_config, pools)``. ``pools`` is empty when no region is fused.
+    """
+    pipes = list(config.pipes)
+    if not _has_executor_markers(pipes):
+        return config, []
+
+    continuous = _has_continuous_source(config)
+    pools: list[_SubprocessPipelinePool] = []
+    new_pipes: list[object] = []
+    target: ProcessPoolExecutorConfig | InterpreterPoolExecutorConfig | _MainProcess = (
+        _MainProcess()
+    )
+    region: list[object] = []
+
+    def _flush() -> None:
+        if not region:
+            return
+        if isinstance(target, InterpreterPoolExecutorConfig):
+            raise NotImplementedError(
+                "Subinterpreter regions (`.to(InterpreterPoolExecutorConfig(...))`) are not yet "
+                "supported; use `ProcessPoolExecutorConfig` for now."
+            )
+        assert isinstance(
+            target, ProcessPoolExecutorConfig
+        )  # narrowed: not main, not subinterpreter
+        ctx = mp.get_context(target.mp_context)
+        # +2, not +1: this runs inside the nested ``_flush`` closure, one frame deeper than
+        # ``_fuse_marked_regions`` itself, so the warning still points at the user's call site.
+        _warn_fork_with_threads(ctx, stacklevel + 2)
+        fused, pool = _build_fused_stage_from_spec(
+            region, target, ctx, report_stats_interval, continuous
+        )
+        pools.append(pool)
+        new_pipes.append(fused)
+        region.clear()
+
+    try:
+        for p in pipes:
+            if isinstance(p, PlacementConfig):
+                _flush()  # close the span running under the previous target
+                target = p.target
+            elif isinstance(target, _MainProcess):
+                new_pipes.append(p)
+            else:
+                region.append(p)
+        _flush()  # close a region left open at the end of the pipes
+    except BaseException:
+        # Reap any pools spawned before the failure; the caller never receives them to reap.
         for pool in pools:
             pool.shutdown()
         raise

--- a/src/spdl/pipeline/_profile.py
+++ b/src/spdl/pipeline/_profile.py
@@ -25,6 +25,7 @@ from spdl.pipeline.defs import (
     PathVariantsConfig,
     PipeConfig,
     PipelineConfig,
+    PlacementConfig,
     SinkConfig,
     SourceConfig,
 )
@@ -263,7 +264,9 @@ def _profile_pipeline(
         raise ValueError(f"Unexpected source type {type(cfg.src)}")
 
     for pipe in cfg.pipes:
-        if isinstance(pipe, (PathVariantsConfig, _SubprocessPipelineConfig)):
+        if isinstance(
+            pipe, (PathVariantsConfig, _SubprocessPipelineConfig, PlacementConfig)
+        ):
             _LG.warning(
                 "Skipping %s stage in profiling (not supported).", type(pipe).__name__
             )

--- a/src/spdl/pipeline/defs/__init__.py
+++ b/src/spdl/pipeline/defs/__init__.py
@@ -26,6 +26,7 @@ The following step explains the steps to build a pipeline using the building blo
 """
 
 from ._defs import (
+    _MainProcess,
     _PipeArgs,
     _PipeType,
     _SubprocessPipelineConfig,
@@ -36,6 +37,9 @@ from ._defs import (
     Collate,
     Disaggregate,
     DisaggregateConfig,
+    ExecutorConfig,
+    InterpreterPoolExecutorConfig,
+    MAIN_PROCESS,
     Merge,
     MergeConfig,
     PathVariants,
@@ -43,11 +47,14 @@ from ._defs import (
     Pipe,
     PipeConfig,
     PipelineConfig,
+    PlacementConfig,
+    ProcessPoolExecutorConfig,
     SinkConfig,
     SourceConfig,
 )
 
 __all__ = [
+    "_MainProcess",
     "_PipeArgs",
     "_PipeType",
     "_SubprocessPipelineConfig",
@@ -62,6 +69,9 @@ __all__ = [
     "Collate",
     "Disaggregate",
     "DisaggregateConfig",
+    "ExecutorConfig",
+    "InterpreterPoolExecutorConfig",
+    "MAIN_PROCESS",
     "Merge",
     "MergeConfig",
     "PathVariants",
@@ -69,6 +79,8 @@ __all__ = [
     "Pipe",
     "PipeConfig",
     "PipelineConfig",
+    "PlacementConfig",
+    "ProcessPoolExecutorConfig",
     "SinkConfig",
     "SourceConfig",
 ]

--- a/src/spdl/pipeline/defs/_defs.py
+++ b/src/spdl/pipeline/defs/_defs.py
@@ -40,6 +40,12 @@ __all__ = [
     "Collate",
     "DisaggregateConfig",
     "_SubprocessPipelineConfig",
+    "_MainProcess",
+    "ExecutorConfig",
+    "ProcessPoolExecutorConfig",
+    "InterpreterPoolExecutorConfig",
+    "MAIN_PROCESS",
+    "PlacementConfig",
     "PipelineConfig",
     "SinkConfig",
     "SourceConfig",
@@ -437,6 +443,110 @@ class _SubprocessPipelineConfig:
 
 
 ################################################################################
+# Executor placement (region markers for `.to()`)
+################################################################################
+
+
+@dataclass(frozen=True)
+class ExecutorConfig:
+    """**[Experimental]** Base spec for a worker-pool executor.
+
+    A serializable description of a pool of workers, materialized into a live executor by
+    the pipeline. Subclassed by :py:class:`ProcessPoolExecutorConfig` and
+    :py:class:`InterpreterPoolExecutorConfig`; those subclasses are used as ``.to()``
+    placement targets (via :py:class:`PlacementConfig`).
+
+    .. versionadded:: 0.6.0
+    """
+
+    max_workers: int | None = None
+    """Number of workers. If ``None``, defaults to the number of CPUs."""
+
+    initializer: Callable[..., object] | None = None
+    """Callable run once in each worker before it processes any work."""
+
+    initargs: tuple[Any, ...] = ()
+    """Positional arguments passed to ``initializer``."""
+
+
+@dataclass(frozen=True)
+class ProcessPoolExecutorConfig(ExecutorConfig):
+    """**[Experimental]** A worker-pool executor backed by subprocesses.
+
+    Used as a ``.to()`` target to run a region's stages in a pool of worker *processes*
+    as one nested pipeline — the op->op handoff stays in the worker, so intermediate
+    values are not copied back to the main process and need not be picklable. The region
+    ends at the next ``.to()`` target (see :py:data:`MAIN_PROCESS`).
+
+    .. versionadded:: 0.6.0
+    """
+
+    mp_context: str | None = None
+    """Multiprocessing start method (e.g. ``"spawn"``, ``"fork"``, ``"forkserver"``),
+    as accepted by :py:func:`multiprocessing.get_context`. ``None`` uses the default
+    context."""
+
+
+@dataclass(frozen=True)
+class InterpreterPoolExecutorConfig(ExecutorConfig):
+    """**[Experimental]** A worker-pool executor backed by subinterpreters.
+
+    Like :py:class:`ProcessPoolExecutorConfig`, but the workers are Python
+    *subinterpreters* (:py:mod:`concurrent.interpreters`) sharing the process rather than
+    separate processes. There is no ``mp_context`` because no new process is started.
+
+    .. note::
+
+       Requires Python 3.14 or later; using this target on an older interpreter is an
+       error. NumPy and PyTorch cannot be imported inside a subinterpreter, so a region
+       whose stages need them must use :py:class:`ProcessPoolExecutorConfig` instead.
+
+    .. versionadded:: 0.6.0
+    """
+
+
+@dataclass(frozen=True)
+class _MainProcess:
+    """Sentinel ``.to()`` target for the main process. Use the :py:data:`MAIN_PROCESS`
+    singleton rather than instantiating this type."""
+
+    def __repr__(self) -> str:
+        return "MAIN_PROCESS"
+
+
+MAIN_PROCESS: _MainProcess = _MainProcess()
+"""**[Experimental]** The main-process execution target. Pass to
+:py:meth:`spdl.pipeline.PipelineBuilder.to`
+to close a worker-pool region and bring subsequent stages back to the main process.
+
+.. versionadded:: 0.6.0
+"""
+
+
+@dataclass(frozen=True)
+class PlacementConfig:
+    """**[Experimental]** A region marker designating where the subsequent stages execute.
+
+    Sits among the stage configs in :py:attr:`PipelineConfig.pipes`: every stage after
+    this marker (until the next :py:class:`PlacementConfig`) runs on :py:attr:`target`.
+    :py:meth:`spdl.pipeline.PipelineBuilder.to` appends one of these. A pipeline
+    implicitly starts on the main process, so a marker is needed only to enter a
+    worker-pool region and (with :py:data:`MAIN_PROCESS`) to leave it.
+
+    .. versionadded:: 0.6.0
+    """
+
+    target: "ProcessPoolExecutorConfig | InterpreterPoolExecutorConfig | _MainProcess"
+    """Where the stages following this marker execute."""
+
+    name: str = "placement"
+    """Name of the marker (used only for display)."""
+
+    def __repr__(self) -> str:
+        return f"{self.name}({self.target!r})"
+
+
+################################################################################
 # PathVariants
 ################################################################################
 
@@ -607,6 +717,7 @@ class PipelineConfig(Generic[U]):
         | DisaggregateConfig[Any]
         | PathVariantsConfig[Any]
         | _SubprocessPipelineConfig
+        | PlacementConfig
     ]
     """Pipe configurations."""
 

--- a/tests/pipeline/executor_config_test.py
+++ b/tests/pipeline/executor_config_test.py
@@ -1,0 +1,64 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import unittest
+
+from spdl.pipeline.defs import (
+    InterpreterPoolExecutorConfig,
+    MAIN_PROCESS,
+    PlacementConfig,
+    ProcessPoolExecutorConfig,
+)
+
+# NOTE: The behavior of these config types (how a region's worker pool is built and run from a
+# spec), including that a ``PipelineConfig`` accepts region markers in its ``pipes``, is covered
+# end-to-end by ``marked_region_fuse_test`` and ``builder_to_test``. The tests here cover only what
+# those cannot: the hand-written ``__repr__`` methods and the deliberate structural contract of
+# ``InterpreterPoolExecutorConfig`` (that it rejects an ``mp_context``). Plain-dataclass mechanics
+# (default values, field storage, ``frozen``, auto-generated ``__eq__``) are intentionally not
+# re-tested.
+
+
+class TestInterpreterPoolExecutorConfig(unittest.TestCase):
+    """Verify the InterpreterPoolExecutorConfig spec."""
+
+    def test_rejects_mp_context(self) -> None:
+        """InterpreterPoolExecutorConfig rejects ``mp_context``; ProcessPoolExecutorConfig honors it.
+
+        A subinterpreter shares the process, so there is no multiprocessing start method to choose.
+        Passing ``mp_context`` must raise rather than be silently accepted and ignored -- unlike
+        :py:class:`ProcessPoolExecutorConfig`, which starts real processes and stores the chosen
+        start method.
+        """
+        self.assertEqual(
+            ProcessPoolExecutorConfig(mp_context="spawn").mp_context, "spawn"
+        )
+        with self.assertRaises(TypeError):
+            InterpreterPoolExecutorConfig(mp_context="spawn")  # pyre-ignore[28]
+
+
+class TestMainProcess(unittest.TestCase):
+    """Verify the MAIN_PROCESS sentinel target."""
+
+    def test_repr(self) -> None:
+        """The sentinel's custom ``__repr__`` renders its public name for readable configs."""
+        self.assertEqual(repr(MAIN_PROCESS), "MAIN_PROCESS")
+
+
+class TestPlacementConfig(unittest.TestCase):
+    """Verify the PlacementConfig region marker."""
+
+    def test_repr_includes_target(self) -> None:
+        """The marker's custom ``__repr__`` surfaces its target for readable pipeline dumps."""
+        self.assertEqual(
+            repr(PlacementConfig(target=MAIN_PROCESS)), "placement(MAIN_PROCESS)"
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/pipeline/marked_region_fuse_test.py
+++ b/tests/pipeline/marked_region_fuse_test.py
@@ -1,0 +1,210 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import os
+import unittest
+from collections.abc import Sequence
+from typing import Any
+
+from spdl.pipeline import build_pipeline, Pipeline
+from spdl.pipeline.defs import (
+    Aggregate,
+    InterpreterPoolExecutorConfig,
+    MAIN_PROCESS,
+    Pipe,
+    PipelineConfig,
+    PlacementConfig,
+    ProcessPoolExecutorConfig,
+    SinkConfig,
+    SourceConfig,
+)
+
+
+def add_one(x: int) -> int:
+    return x + 1
+
+
+def times_two(x: int) -> int:
+    return x * 2
+
+
+class _Unpicklable:
+    """An object that refuses to be pickled, to prove it never crosses a process boundary."""
+
+    def __init__(self, value: int) -> None:
+        self.value = value
+
+    def __reduce__(self) -> Any:
+        raise TypeError("_Unpicklable must not be pickled")
+
+
+def wrap(x: int) -> _Unpicklable:
+    return _Unpicklable(x + 1)
+
+
+def unwrap(o: _Unpicklable) -> int:
+    return o.value * 2
+
+
+class _PidStamp:
+    """A picklable item stages stamp their ``os.getpid()`` into, to prove process-locality."""
+
+    def __init__(self, value: int) -> None:
+        self.value = value
+        self.pids: dict[str, int] = {}
+
+
+def stamp_region(item: _PidStamp) -> _PidStamp:
+    """A region stage: records the pid it runs in."""
+    item.pids["region"] = os.getpid()
+    return item
+
+
+def stamp_main(item: _PidStamp) -> _PidStamp:
+    """A main-process stage (after the region closes): records the pid it runs in."""
+    item.pids["main"] = os.getpid()
+    return item
+
+
+def _cfg(src: Any, pipes: Sequence[Any], buffer: int = 16) -> PipelineConfig[Any]:
+    return PipelineConfig(
+        src=SourceConfig(src), pipes=list(pipes), sink=SinkConfig(buffer)
+    )
+
+
+def _run(pipeline: Pipeline[Any], timeout: float = 60.0) -> list[Any]:
+    with pipeline.auto_stop():
+        return list(pipeline.get_iterator(timeout=timeout))
+
+
+class MarkedRegionFuseTest(unittest.TestCase):
+    def test_region_of_two_pipes(self) -> None:
+        """Two pipes inside a subprocess region produce the same result as running inline."""
+        n = 16
+        config = _cfg(
+            range(n),
+            [
+                PlacementConfig(target=ProcessPoolExecutorConfig(max_workers=2)),
+                Pipe(add_one),
+                Pipe(times_two),
+                PlacementConfig(target=MAIN_PROCESS),
+            ],
+        )
+        pipeline = build_pipeline(config, num_threads=4)
+        self.assertEqual(sorted(_run(pipeline)), sorted((x + 1) * 2 for x in range(n)))
+
+    def test_aggregate_inside_region(self) -> None:
+        """An aggregate stage inside a region is absorbed and runs in the worker."""
+        config = _cfg(
+            range(10),
+            [
+                PlacementConfig(target=ProcessPoolExecutorConfig(max_workers=1)),
+                Pipe(add_one),
+                Aggregate(3),
+                PlacementConfig(target=MAIN_PROCESS),
+            ],
+        )
+        pipeline = build_pipeline(config, num_threads=2)
+        result = _run(pipeline)
+        # add_one over 0..9, then batched by 3 (one worker preserves order).
+        self.assertEqual(result, [[1, 2, 3], [4, 5, 6], [7, 8, 9], [10]])
+
+    def test_unpicklable_intermediate_stays_in_region(self) -> None:
+        """An unpicklable value handed between two region stages never crosses a boundary."""
+        n = 5
+        config = _cfg(
+            range(n),
+            [
+                PlacementConfig(target=ProcessPoolExecutorConfig(max_workers=1)),
+                Pipe(wrap),
+                Pipe(unwrap),
+                PlacementConfig(target=MAIN_PROCESS),
+            ],
+        )
+        pipeline = build_pipeline(config, num_threads=2)
+        self.assertEqual(sorted(_run(pipeline)), sorted((x + 1) * 2 for x in range(n)))
+
+    def test_region_runs_in_worker_main_runs_in_main(self) -> None:
+        """A region stage runs in a worker process; a stage after MAIN_PROCESS runs in main."""
+        config = _cfg(
+            [_PidStamp(i) for i in range(4)],
+            [
+                PlacementConfig(target=ProcessPoolExecutorConfig(max_workers=1)),
+                Pipe(stamp_region),
+                PlacementConfig(target=MAIN_PROCESS),
+                Pipe(stamp_main),
+            ],
+        )
+        pipeline = build_pipeline(config, num_threads=2)
+        results = _run(pipeline)
+        self.assertEqual(len(results), 4)
+        for item in results:
+            self.assertNotEqual(item.pids["region"], os.getpid())
+            self.assertEqual(item.pids["main"], os.getpid())
+
+    def test_no_markers_is_unchanged(self) -> None:
+        """A config with no markers builds and runs entirely in the main process."""
+        n = 8
+        config = _cfg(range(n), [Pipe(add_one), Pipe(times_two)])
+        pipeline = build_pipeline(config, num_threads=2)
+        self.assertEqual(sorted(_run(pipeline)), sorted((x + 1) * 2 for x in range(n)))
+
+    def test_multiple_regions(self) -> None:
+        """Two separate subprocess regions around a main-process stage both fuse correctly.
+
+        Exercises the main -> subprocess -> main -> subprocess -> main transition cycle, so a
+        bug carrying stale ``target``/``region`` state across ``_flush()`` calls would surface.
+        """
+        n = 8
+        config = _cfg(
+            range(n),
+            [
+                PlacementConfig(target=ProcessPoolExecutorConfig(max_workers=1)),
+                Pipe(add_one),  # region 1: x + 1
+                PlacementConfig(target=MAIN_PROCESS),
+                Pipe(times_two),  # main: (x + 1) * 2
+                PlacementConfig(target=ProcessPoolExecutorConfig(max_workers=1)),
+                Pipe(add_one),  # region 2: (x + 1) * 2 + 1
+                PlacementConfig(target=MAIN_PROCESS),
+            ],
+        )
+        pipeline = build_pipeline(config, num_threads=2)
+        self.assertEqual(
+            sorted(_run(pipeline)), sorted((x + 1) * 2 + 1 for x in range(n))
+        )
+
+    def test_region_open_at_end_of_pipes(self) -> None:
+        """A region left open at the end of the pipes is flushed (no closing MAIN_PROCESS).
+
+        Covers the ``_flush()`` after the segmentation loop, which closes a region that runs to
+        the end of ``pipes``; the sink still executes in the main process.
+        """
+        n = 8
+        config = _cfg(
+            range(n),
+            [
+                PlacementConfig(target=ProcessPoolExecutorConfig(max_workers=1)),
+                Pipe(add_one),
+                Pipe(times_two),
+            ],
+        )
+        pipeline = build_pipeline(config, num_threads=2)
+        self.assertEqual(sorted(_run(pipeline)), sorted((x + 1) * 2 for x in range(n)))
+
+    def test_subinterpreter_region_not_yet_supported(self) -> None:
+        """A subinterpreter region raises until the subinterpreter backend lands."""
+        config = _cfg(
+            range(4),
+            [
+                PlacementConfig(target=InterpreterPoolExecutorConfig(max_workers=1)),
+                Pipe(add_one),
+                PlacementConfig(target=MAIN_PROCESS),
+            ],
+        )
+        with self.assertRaises(NotImplementedError):
+            build_pipeline(config, num_threads=2)

--- a/tests/pipeline/shutdown_hook_test.py
+++ b/tests/pipeline/shutdown_hook_test.py
@@ -214,13 +214,29 @@ def _child_exit_code(
 class InterpreterExitTopologyTest(unittest.TestCase):
     """Held, unstopped pipelines exit cleanly at interpreter exit, across topologies."""
 
+    @unittest.skipUnless(
+        "forkserver" in mp.get_all_start_methods(),
+        "forkserver start method is unavailable on this platform (e.g. Windows)",
+    )
     def test_plain_forkserver(self) -> None:
         """Plain thread-only pipeline exits cleanly (forkserver)."""
-        self.assertEqual(_child_exit_code(_scenario_plain, "forkserver"), 0)
+        exit_code = _child_exit_code(_scenario_plain, "forkserver")
+        self.assertIsNotNone(
+            exit_code,
+            "Child process hung (did not exit within timeout); the pipeline's "
+            "non-daemon event-loop thread likely blocked interpreter shutdown.",
+        )
+        self.assertEqual(exit_code, 0)
 
     def test_plain_spawn(self) -> None:
         """Plain thread-only pipeline exits cleanly (spawn)."""
-        self.assertEqual(_child_exit_code(_scenario_plain, "spawn"), 0)
+        exit_code = _child_exit_code(_scenario_plain, "spawn")
+        self.assertIsNotNone(
+            exit_code,
+            "Child process hung (did not exit within timeout); the pipeline's "
+            "non-daemon event-loop thread likely blocked interpreter shutdown.",
+        )
+        self.assertEqual(exit_code, 0)
 
 
 # Note: the `.to(ProcessPoolExecutorConfig)` region topology's interpreter-exit teardown is


### PR DESCRIPTION
Part 2/4 of the `.to()` region API; see https://github.com/facebookresearch/spdl/pull/1584 for the overall design and rationale. Behind-the-scenes engine change — backward compatible and dormant until region markers exist, so it lands before the public `.to()` surface (4/4) without altering any current behavior.

Adds `_fuse_marked_regions`: it walks `PipelineConfig.pipes`, tracks the current execution target set by `PlacementConfig` markers (a pipeline starts on the main process), and replaces each maximal span of stages under a `ProcessPoolExecutorConfig` target with one stage that runs the span as a nested pipeline in a worker pool — eliminating inter-stage IPC within the region. Crucially, `aggregate`/`disaggregate`/`path_variants` stages inside a region are absorbed into it, which the existing executor-identity fusion cannot do (it bounds a run at those stages). Pool parameters come from the serializable spec rather than a live executor; the region's worker thread count is derived from the concurrency of the stages it fuses, and the stats interval is inherited from `build_pipeline`.

`_build_fused_stage` is refactored to share a core with the new spec-driven builder. `build_pipeline` now runs `_fuse_marked_regions` unconditionally; it is a no-op when the config has no markers, so the existing `fuse_subprocess_stages` path is untouched. Subinterpreter regions raise `NotImplementedError` pending the subinterpreter worker-pool backend (3/4).