### PR TITLE
Disable check-docstring-first

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,6 @@ repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.0.1
     hooks:
-      - id: check-docstring-first
       - id: check-toml
       - id: check-yaml
       - id: end-of-file-fixer


### PR DESCRIPTION
Causes a false positive where the docstring for a module-level attribute (or sentinel value) is confused with module docstring.