### PR TITLE
[pipeline] Skip process-group stats monitor in daemon processes

### DIFF
--- a/src/spdl/pipeline/_pgrp_stats.py
+++ b/src/spdl/pipeline/_pgrp_stats.py
@@ -630,7 +630,20 @@ class ProcessGroupStatsMonitor(BackgroundTask):
         or this coroutine is cancelled.  On cancellation the subprocess
         is terminated (then killed if it does not exit within 5 seconds)
         and ``CancelledError`` is re-raised.
+
+        A daemon process cannot spawn children, so the monitor subprocess cannot
+        be started from one (e.g. a worker-pool process running a nested pipeline,
+        which runs as a daemon). In that case this skips with a warning rather
+        than raising: a main-process monitor already covers the whole process
+        group, so a per-worker monitor here would be redundant anyway.
         """
+        if multiprocessing.current_process().daemon:
+            _LG.warning(
+                "Skipping process-group stats monitor: a daemon process cannot "
+                "spawn the monitor subprocess (pid=%d).",
+                os.getpid(),
+            )
+            return
         ctx = self._mp_context or multiprocessing.get_context()
         # pyrefly: ignore [missing-attribute]
         proc = ctx.Process(


### PR DESCRIPTION
`ProcessGroupStatsMonitor.run()` spawns a `multiprocessing` subprocess to read `/proc` for per-process-group CPU/mem/IO stats. When the pipeline is built inside a daemon process — e.g. a worker-pool process running a nested pipeline (a `.to()` region worker, or the old fused-subprocess pool worker) — `proc.start()` raises `AssertionError: daemonic processes are not allowed to have children`, which the background-task runner logs as an ERROR (once per worker, repeatedly noisy in MAST logs).

A daemon genuinely cannot spawn the monitor subprocess, and a per-worker monitor would be redundant anyway: the main-process monitor already collects stats for the whole process group (it sums over the shared PGID). So guard the spawn — if the current process is a daemon, log a single WARNING and return cleanly instead of letting the assertion surface as an error.