### PR TITLE
[pipeline] Stop unstopped pipelines at interpreter exit to avoid hang

### DIFF
--- a/docs/source/getting_started/intro.rst
+++ b/docs/source/getting_started/intro.rst
@@ -66,9 +66,13 @@ Finally call :py:meth:`Pipeline.stop` to stop the background thread.
    [19, 21, 23]
    >>> pipeline.stop()
 
-It is important to call :py:meth:`Pipeline.stop`.
-Forgetting to do so will leave the background thread running,
-which can cause the Python interpreter to hang at exit.
+Calling :py:meth:`Pipeline.stop` promptly is good practice: it releases the
+background thread and any worker processes as soon as you are done, instead of
+leaving them running until the object is garbage collected. It is no longer
+required to avoid a hang at exit, though — a ``Pipeline`` stops itself when it is
+garbage collected, and :py:meth:`Pipeline.start` additionally registers a hook
+that stops any still-running pipeline at interpreter shutdown (see
+:py:meth:`Pipeline.start` for details).
 
 In practice, there is always a possibility that the application is
 interrupted for unexpected reasons.
@@ -97,59 +101,95 @@ To make sure that the pipeline is stopped, it is recommended to use
 Unlike processes, threads cannot be killed.
 The ``Pipeline`` object uses a thread pool, which must be shut down properly.
 
-There are seemingly unharmful patterns, which can cause a deadlock
-at the end of the Python interpreter, preventing Python from exiting.
+The library cleans a ``Pipeline`` up automatically (see below), so these
+patterns no longer hang the interpreter at exit. They can still keep the
+background thread and worker processes alive longer than necessary, so they are
+worth avoiding for prompt resource release.
 
-.. admonition:: Keeping unnecessary references to ``Pipeline``
-   :class: danger
+.. admonition:: Holding a reference to a ``Pipeline``
+   :class: note
 
-   It is recommended to keep the resulting ``Pipeline`` object as a
-   local variable of an iterator, and NOT TO assign it to an object
-   attribute.
+   A ``Pipeline`` cleans itself up automatically, so holding a reference to one
+   is safe. When the object is garbage collected, a ``weakref.finalize`` drains
+   and stops its background thread — and any worker processes or subinterpreters
+   it spawned — even if you never called :py:meth:`Pipeline.stop`. And if a
+   reference survives until the program ends, :py:meth:`Pipeline.start` has
+   registered a hook that stops any still-running pipeline at the very start of
+   interpreter finalization, so the process does not hang at exit (see
+   :py:meth:`Pipeline.start` for how that ordering works). Holding a reference is
+   in fact **required** to re-iterate a ``continuous=True`` source across epochs:
+   the same ``Pipeline`` must stay alive to be iterated again.
 
-   .. code-block::
-
-      class DataLoader:
-          ...
-
-          def __iter__(self) -> Iterator[T]:
-              # 👍 Leave the `pipeline` variable as a local variable.
-              pipeline = self.get_pipeline(...)
-              # So that the `pipeline` will get garbage collected after the
-              # iterator goes out of the scope.
-
-              with pipeline.auto_stop():
-                  yield from pipeline.get_iterator(...)
-
-              # The reference count of the `pipeline` object goes to zero
-              # here, so it will be garbage collected.
+   You should still release the reference (or call :py:meth:`Pipeline.stop`) once
+   you are done, so the worker processes and memory are freed promptly rather than
+   lingering until GC — but this is resource hygiene, not a requirement to avoid a
+   hang.
 
    .. code-block::
 
       class DataLoader:
-          ...
+          def __init__(self) -> None:
+              # Safe (and, for a continuous source, required) to keep the
+              # pipeline as an attribute so it is reused across epochs.
+              self._pipeline = self.get_pipeline(...)
 
           def __iter__(self) -> Iterator[T]:
-              # 🚫 Do not assign the pipeline to the object.
-              self.pipeline = self.get_pipeline(...)
-              #
-              # The pipeline won't get garbage collected until
-              # the DataLoader instance goes out of scope,
-              # which might cause dead-lock when Python tries to exit.
+              yield from self._pipeline.get_iterator(...)
 
-              with self.pipeline.auto_stop():
-                  yield from self.pipeline.get_iterator(...)
+          def close(self) -> None:
+              # Optional: drop the reference when done so the pipeline's
+              # resources are freed promptly instead of at GC / interpreter exit.
+              self._pipeline = None
 
-              # The `pipeline` object won't get garbage collected here.
+   Some frameworks stash the dataloader on a long-lived object.
+   `TorchTNT <https://pytorch.org/tnt/>`_, for example, keeps a strong reference
+   to the dataloader on its ``State`` (``PhaseState._dataloader``) until the
+   process exits. This no longer hangs the run — the shutdown hook cleans the
+   pipeline up at exit — but if you want its worker processes and memory released
+   as soon as training ends (e.g. between fit and eval) rather than at exit, you
+   can clear those references and force a collection with a callback:
+
+   .. code-block:: python
+
+      import gc
+
+      from torchtnt.framework.callback import Callback
+      from torchtnt.framework.state import State
+      from torchtnt.framework.unit import TEvalUnit, TPredictUnit, TTestUnit, TTrainUnit
+
+
+      class DetachDataloaderCallback(Callback):
+          """Optional: drop TNT's dataloader references at the end of training so
+          the SPDL ``Pipeline`` (and its workers) are released promptly, instead of
+          lingering on ``State`` until the pipeline is cleaned up at exit."""
+
+          def on_train_end(self, state: State, unit: TTrainUnit) -> None:
+              self._detach(state)
+
+          def on_exception(
+              self,
+              state: State,
+              unit: TTrainUnit | TEvalUnit | TPredictUnit | TTestUnit,
+              exc: BaseException,
+          ) -> None:
+              # on_train_end does not fire on failure/preemption, so reap here too.
+              self._detach(state)
+
+          def _detach(self, state: State) -> None:
+              for phase_state in (state.train_state, state.eval_state):
+                  if phase_state is not None:
+                      phase_state._dataloader = None  # pyre-ignore[8]
+              gc.collect()
 
 .. admonition:: Calling ``iter`` on Pipeline
-   :class: danger
+   :class: note
 
-   We recommend to not call the :py:func:`iter` function
-   on a ``Pipeline`` object.
-   It can prevent the :py:meth:`Pipeline.stop` method from being called
-   at the right time.
-   It in turn might make the Python interpreter hang at exit.
+   Prefer not to call the :py:func:`iter` function on a ``Pipeline`` object and
+   keep the resulting iterator around. Doing so delays :py:meth:`Pipeline.stop`
+   until the iterator is collected, keeping the background thread and worker
+   processes running longer than necessary. (It will not hang the interpreter at
+   exit — the hook registered by :py:meth:`Pipeline.start` covers that — but it
+   holds resources needlessly.)
 
    Say you wrap a ``Pipeline`` to create a class that resembles conventional
    ``DataLoader``.
@@ -194,7 +234,6 @@ at the end of the Python interpreter, preventing Python from exiting.
       # the pipeline won't be shutdown until the `ite` variable
       # goes out of scope. When does that happen??
 
-   The ``Pipeline.stop`` is not called until the garbage collector deletes
-   the object.
-   It might cause a deadlock, and prevents Python interpreter from
-   exiting.
+   Until then, ``Pipeline.stop`` is deferred to whenever the garbage collector
+   deletes the object, so the background thread and workers keep holding
+   resources longer than needed.

--- a/src/spdl/pipeline/_components/_subprocess_pipe.py
+++ b/src/spdl/pipeline/_components/_subprocess_pipe.py
@@ -39,6 +39,7 @@ from __future__ import annotations
 
 import asyncio
 import queue as _queue
+import threading
 import time
 from concurrent.futures import Executor, ThreadPoolExecutor
 from typing import Any
@@ -78,14 +79,28 @@ _EPOCH_DONE = (
 # observe cancellation between polls instead of parking a thread on an indefinite get.
 _GET_TIMEOUT: float = 0.5
 
+# How long a blocking put may wait before re-checking the teardown flag. A put onto a *full*
+# worker queue (backpressure once the consumer stops) cannot be released by pool teardown -- an
+# mp.Queue putter blocked on the queue's semaphore is not woken by closing the queue or
+# terminating the consumer workers -- so an indefinite put would park this pool thread forever and
+# hang interpreter exit (a non-daemon executor thread joined by concurrent.futures at shutdown).
+_PUT_TIMEOUT: float = 0.5
+
 # Fixed bound (15 min) on how long the collector waits for any worker message before assuming a
 # worker died abruptly and raising, instead of hanging forever. Comfortably above any per-stage
 # latency in a data loader. Not user-configurable for now.
 _WORKER_STALL_TIMEOUT: float = 900.0
 
 
-def _put(q: Any, msg: tuple[int, Any]) -> None:
-    q.put(msg)
+def _put(q: Any, msg: tuple[int, Any], stop: threading.Event) -> None:
+    # Bounded, interruptible put: poll so this pool thread wakes to observe teardown (``stop``)
+    # and exit, rather than parking forever on a full queue (see ``_PUT_TIMEOUT``).
+    while not stop.is_set():
+        try:
+            q.put(msg, timeout=_PUT_TIMEOUT)
+            return
+        except _queue.Full:
+            continue
 
 
 def _drain_one(q: Any) -> tuple[int, Any] | None:
@@ -123,6 +138,7 @@ async def _feed(
     executor: Executor,
     abort: asyncio.Event,
     feeder_idle: asyncio.Event,
+    put_stop: threading.Event,
 ) -> None:
     """Round-robin items across the per-worker queues, then end every worker's session.
 
@@ -165,13 +181,18 @@ async def _feed(
                 feeder_idle.clear()
             if is_eof(item):
                 break
-            await loop.run_in_executor(executor, _put, in_qs[i % n], (_ITEM, item))
+            await loop.run_in_executor(
+                executor, _put, in_qs[i % n], (_ITEM, item), put_stop
+            )
             i += 1
     finally:
         abort_wait.cancel()
     # Concurrent so a full/slow worker queue does not block the markers to the others.
     await asyncio.gather(
-        *(loop.run_in_executor(executor, _put, q, (_SESSION_END, None)) for q in in_qs)
+        *(
+            loop.run_in_executor(executor, _put, q, (_SESSION_END, None), put_stop)
+            for q in in_qs
+        )
     )
 
 
@@ -234,6 +255,7 @@ async def _feed_continuous(
     executor: Executor,
     epoch_barrier: asyncio.Event,
     feeder_idle: asyncio.Event,
+    put_stop: threading.Event,
 ) -> None:
     """Round-robin items to per-worker queues; broadcast and barrier each epoch boundary.
 
@@ -251,7 +273,7 @@ async def _feed_continuous(
     async def _broadcast(msg: tuple[int, Any]) -> None:
         # Concurrent so a full/slow worker queue does not block the broadcast to the others.
         await asyncio.gather(
-            *(loop.run_in_executor(executor, _put, q, msg) for q in in_qs)
+            *(loop.run_in_executor(executor, _put, q, msg, put_stop) for q in in_qs)
         )
 
     i = 0
@@ -268,7 +290,9 @@ async def _feed_continuous(
             await _broadcast((_EPOCH, None))
             await epoch_barrier.wait()
             continue
-        await loop.run_in_executor(executor, _put, in_qs[i % n], (_ITEM, item))
+        await loop.run_in_executor(
+            executor, _put, in_qs[i % n], (_ITEM, item), put_stop
+        )
         i += 1
 
 
@@ -352,12 +376,16 @@ async def _subprocess_pipeline(
     # it to tell input starvation (no work dispatched, no worker message expected) apart from an
     # unresponsive worker, so its stall guard does not fire spuriously on a slow/idle source.
     feeder_idle = asyncio.Event()
+    # Signals threads parked in a blocking ``_put`` to stop and exit on teardown. Needed because a
+    # put onto a full worker queue cannot be released by pool teardown (see ``_PUT_TIMEOUT``), so
+    # without it such a thread would outlive this stage and hang interpreter exit.
+    put_stop = threading.Event()
     async with _queue_stage_hook(output_queue):
         if handle.continuous:
             epoch_barrier = asyncio.Event()
             feeder = create_task(
                 _feed_continuous(
-                    input_queue, in_qs, executor, epoch_barrier, feeder_idle
+                    input_queue, in_qs, executor, epoch_barrier, feeder_idle, put_stop
                 )
             )
             collector = create_task(
@@ -374,7 +402,7 @@ async def _subprocess_pipeline(
             # Set by the collector on a worker error so the feeder stops forwarding new items.
             abort = asyncio.Event()
             feeder = create_task(
-                _feed(input_queue, in_qs, executor, abort, feeder_idle)
+                _feed(input_queue, in_qs, executor, abort, feeder_idle, put_stop)
             )
             collector = create_task(
                 _collect(out_q, num_workers, output_queue, executor, abort, feeder_idle)
@@ -387,6 +415,8 @@ async def _subprocess_pipeline(
             await asyncio.gather(feeder, collector, return_exceptions=True)
             raise
         finally:
-            # Don't wait on threads still parked in a blocking get/put — the pool teardown
-            # unblocks them. ``cancel_futures`` discards anything not yet started.
+            # Release any thread parked in a blocking ``_put`` so it exits instead of outliving
+            # this stage, then drop the executor. ``cancel_futures`` discards anything not yet
+            # started; a still-parked get self-releases within ``_GET_TIMEOUT``.
+            put_stop.set()
             executor.shutdown(wait=False, cancel_futures=True)

--- a/src/spdl/pipeline/_pipeline.py
+++ b/src/spdl/pipeline/_pipeline.py
@@ -10,6 +10,7 @@ import asyncio
 import concurrent.futures
 import logging
 import queue
+import threading
 import time
 import warnings
 import weakref
@@ -405,6 +406,35 @@ def _stop_impl(impl: _PipelineImpl[Any]) -> None:
         _LG.debug("Exception during automatic pipeline shutdown.", exc_info=True)
 
 
+def _register_stop_at_exit(impl: _PipelineImpl[Any]) -> None:
+    """Register :py:func:`_stop_impl` to run for ``impl`` at the start of interpreter finalization.
+
+    Uses ``threading._register_atexit`` -- **not** ``atexit.register``: threading-atexit callbacks
+    run inside ``threading._shutdown()``, before non-daemon threads and child processes are joined,
+    whereas an ``atexit`` hook runs *after*, by which point the interpreter has already hung joining
+    the pipeline's non-daemon event-loop thread. This is the same private API, for the same reason,
+    that ``concurrent.futures`` uses. Called from :py:meth:`Pipeline.start` (after the pipeline
+    started its own threads/processes, so this registers last and, being LIFO, runs first). The
+    hook holds only a weak reference, so it never keeps the pipeline alive; once the pipeline is
+    stopped or collected it is a safe no-op (``stop`` is idempotent).
+    """
+    ref = weakref.ref(impl)
+
+    def _hook() -> None:
+        if (impl := ref()) is not None:
+            _stop_impl(impl)
+
+    try:
+        threading._register_atexit(_hook)  # pyre-ignore[16]
+    except (AttributeError, RuntimeError):
+        # Defensive around a private stdlib API: ``RuntimeError`` if the interpreter is already
+        # shutting down, ``AttributeError`` if a future Python drops the hook. The exit hook is
+        # only a safety net (explicit ``stop()`` and the GC finalizer still work), so failing to
+        # register must never break pipeline start; a unit test asserts the API exists so a genuine
+        # regression surfaces loudly in CI.
+        _LG.debug("Could not register interpreter-exit stop hook.", exc_info=True)
+
+
 class Pipeline(Generic[T]):
     """Pipeline()
 
@@ -489,9 +519,16 @@ class Pipeline(Generic[T]):
                    # do something with the decoded image
                    ...
 
-    When the ``Pipeline`` object is garbage collected, the background thread is
-    automatically stopped. You can still use :py:meth:`auto_stop` or
-    :py:meth:`stop` for deterministic, scoped lifecycle management.
+    A ``Pipeline`` cleans up its background thread and worker processes
+    automatically, so a forgotten pipeline will not hang the process at exit: it
+    is stopped when the object is garbage collected, and — as a safety net for a
+    reference held until the program ends — by a hook that :py:meth:`start`
+    registers to run at interpreter shutdown. Even so, it is **recommended to
+    release the resources explicitly** once you are done, either by calling
+    :py:meth:`stop` (or using the :py:meth:`auto_stop` context manager) or by
+    dropping all strong references to the ``Pipeline`` so it is garbage collected.
+    This frees the background thread, worker processes, and memory promptly,
+    rather than leaving them alive until exit.
 
     .. versionchanged:: 0.4.0
 
@@ -502,6 +539,16 @@ class Pipeline(Generic[T]):
        is stopped automatically via :py:func:`weakref.finalize`.
        Explicit :py:meth:`start` / :py:meth:`stop` and the :py:meth:`auto_stop`
        context manager continue to work as before.
+
+    .. versionchanged:: 0.6.0
+
+       Cleanup is now more robust: :py:meth:`start` registers a hook (via
+       ``threading._register_atexit``) that stops a still-running pipeline at
+       interpreter shutdown, so a reference held until the program ends no longer
+       risks a hang at exit. Explicitly releasing resources is still recommended
+       — call :py:meth:`stop` (or use :py:meth:`auto_stop`), or drop all strong
+       references so the pipeline is garbage collected — to free them promptly.
+       See :py:meth:`start` for details.
     """
 
     def __init__(
@@ -531,8 +578,59 @@ class Pipeline(Generic[T]):
         .. note::
 
            Calling ``start`` multiple times raises ``RuntimeError``.
+
+        .. note::
+
+           **Cleanup at interpreter exit.** The pipeline runs a background, *non-daemon*
+           event-loop thread (and may own worker subprocesses). They are released
+           when you :py:meth:`stop` the pipeline, or when the object is garbage
+           collected -- a :py:func:`weakref.finalize` stops it at GC. But if a strong
+           reference is held until the program ends (e.g. a training loop that keeps
+           the dataloader for the whole run), GC does not run before interpreter
+           shutdown, which would otherwise **hang** joining the still-running
+           event-loop thread.
+
+           To prevent that, :py:meth:`start` registers a process-wide hook that
+           stops the pipeline at the very start of interpreter finalization. It holds
+           only a weak reference, so it never keeps the pipeline alive; explicit
+           :py:meth:`stop` and the GC path are unaffected.
+
+           The hook uses ``threading._register_atexit`` and **not**
+           :py:func:`atexit.register`, because of *when* CPython runs each. A plain
+           ``atexit`` hook runs **after** non-daemon threads are already joined --
+           too late. ``threading._register_atexit`` callbacks run earlier, inside
+           ``threading._shutdown()``, *before* that join (the same mechanism, and the
+           same reason, that :py:mod:`concurrent.futures` uses):
+
+           .. mermaid::
+
+              flowchart TD
+
+                  subgraph C["run threading._register_atexit hooks (LIFO)"]
+                      S1["Pipeline's stop hook runs here: pipeline stopped"]
+                  end
+
+                  subgraph E["atexit hooks (LIFO)"]
+                      M1["multiprocessing joins children;"]
+                      M2["weakref.finalize"]
+                  end
+
+                  A["Python reaches the end of program"]
+                  --> B["threading._shutdown()"]
+                  --> C
+                  --> D["join non-daemon threads"]
+                  --> E
+                  --> F["GC and module teardown"]
+
+           The stop hook runs before the non-daemon-thread join and before
+           the ``atexit`` phase, so the pipeline is torn down before anything
+           blocks on it.
         """
         self._impl.start(timeout=timeout, **kwargs)
+        # Register only after a successful start (raises if already started -> no
+        # double-register) and after the pipeline's threads/processes are up, so this
+        # hook lands after the stdlib atexit hooks and -- being LIFO -- runs first.
+        _register_stop_at_exit(self._impl)
 
     def stop(self, *, timeout: float | None = None) -> None:
         """Stop the pipeline.
@@ -578,11 +676,13 @@ class Pipeline(Generic[T]):
             EOFError: When the pipeline is exhausted or cancelled and there are no more items
                 in the sink.
         """
-        # Ensure that the pipeline is started before accessing the sink queue.
+        # Ensure that the pipeline is started before accessing the sink queue. Route through the
+        # facade `start` (not `_impl.start`) so an auto-started pipeline also registers the
+        # interpreter-exit stop hook.
         # Note: This check-then-start pattern is not thread-safe, but `get_item` is not
-        # it is not supposed to be called from multiple threads.
+        # supposed to be called from multiple threads.
         if self._impl._event_loop_state == _EventLoopState.NOT_STARTED:
-            self._impl.start()
+            self.start()
         return self._impl.get_item(timeout=timeout)
 
     def get_iterator(self, *, timeout: float | None = None) -> Iterator[T]:

--- a/tests/pipeline/shutdown_hook_test.py
+++ b/tests/pipeline/shutdown_hook_test.py
@@ -1,0 +1,253 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import gc
+import multiprocessing as mp
+import threading
+import unittest
+import unittest.mock
+import weakref
+from typing import Any, Callable
+
+from spdl.pipeline import _pipeline as _pipeline_mod, Pipeline, PipelineBuilder
+from spdl.pipeline._components._subprocess_pipe import _put
+
+
+def _add_one(x: int) -> int:
+    return x + 1
+
+
+def _build_pipeline() -> Pipeline[int]:
+    """Build a simple thread-only pipeline (not started)."""
+    return (
+        PipelineBuilder()
+        .add_source(range(4))
+        .pipe(_add_one)
+        .add_sink(2)
+        .build(num_threads=1)
+    )
+
+
+class _CaptureRegisteredHooks:
+    """Capture callbacks the pipeline registers via ``threading._register_atexit``.
+
+    Spies on the real private API (so a stdlib rename/removal makes this fail loudly) but does
+    not actually register, keeping the process-wide atexit list clean across tests. This tests
+    the contract -- that ``start()`` hands a working stop callback to
+    ``threading._register_atexit`` -- without depending on the stdlib's internal storage, which
+    differs across Python versions.
+    """
+
+    def __init__(self) -> None:
+        self.hooks: list[Callable[[], Any]] = []
+
+    def __enter__(self) -> "_CaptureRegisteredHooks":
+        self._patch = unittest.mock.patch.object(
+            threading, "_register_atexit", side_effect=self.hooks.append
+        )
+        self._patch.start()
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self._patch.stop()
+
+
+class ShutdownHookRegistrationTest(unittest.TestCase):
+    """Registration of the interpreter-exit stop hook on Pipeline.start()."""
+
+    def test_register_atexit_api_available(self) -> None:
+        """The private ``threading._register_atexit`` the fix relies on still exists."""
+        self.assertTrue(hasattr(threading, "_register_atexit"))
+
+    def test_start_registers_exactly_one_hook(self) -> None:
+        """Starting a pipeline registers exactly one interpreter-exit stop hook."""
+        with _CaptureRegisteredHooks() as cap:
+            p = _build_pipeline()
+            p.start()
+        try:
+            self.assertEqual(len(cap.hooks), 1)
+        finally:
+            p.stop()
+
+    def test_build_without_start_registers_no_hook(self) -> None:
+        """Building (without starting) a pipeline registers no hook."""
+        with _CaptureRegisteredHooks() as cap:
+            p = _build_pipeline()
+        try:
+            self.assertEqual(cap.hooks, [])
+        finally:
+            p.stop()
+
+    def test_each_started_pipeline_registers_its_own_hook(self) -> None:
+        """Each started pipeline registers its own hook (one per instance)."""
+        with _CaptureRegisteredHooks() as cap:
+            p1 = _build_pipeline()
+            p1.start()
+            p2 = _build_pipeline()
+            p2.start()
+        try:
+            self.assertEqual(len(cap.hooks), 2)
+        finally:
+            p1.stop()
+            p2.stop()
+
+
+class ShutdownHookBehaviorTest(unittest.TestCase):
+    """Behavior of the registered interpreter-exit stop hook."""
+
+    def test_hook_stops_the_pipeline(self) -> None:
+        """Invoking the exit hook stops the (still-running) pipeline."""
+        with _CaptureRegisteredHooks() as cap:
+            p = _build_pipeline()
+            p.start()
+        try:
+            (hook,) = cap.hooks
+            self.assertLess(
+                p._impl._event_loop_state, _pipeline_mod._EventLoopState.STOPPED
+            )
+            hook()
+            self.assertEqual(
+                p._impl._event_loop_state, _pipeline_mod._EventLoopState.STOPPED
+            )
+        finally:
+            p.stop()
+
+    def test_hook_does_not_pin_the_pipeline(self) -> None:
+        """The hook holds only a weak ref, so the pipeline stays collectible; then it no-ops."""
+        with _CaptureRegisteredHooks() as cap:
+            p = _build_pipeline()
+            p.start()
+        (hook,) = cap.hooks
+        wref = weakref.ref(p._impl)
+        # Drop the only strong reference; the GC finalizer stops the impl and releases it.
+        del p
+        gc.collect()
+        self.assertIsNone(wref())
+        hook()  # dead weakref -> safe no-op, must not raise
+
+    def test_hook_is_noop_after_pipeline_collected(self) -> None:
+        """Once the pipeline is cleaned up, its exit hook is a safe no-op (dead weakref).
+
+        Simulates the stdlib firing the interpreter-exit hooks after the pipeline object has
+        already been stopped and garbage-collected: the callback must observe a dead weakref and
+        return without raising.
+        """
+        with _CaptureRegisteredHooks() as cap:
+            p = _build_pipeline()
+            p.start()
+        (hook,) = cap.hooks
+        wref = weakref.ref(p._impl)
+        p.stop()
+        del p
+        gc.collect()
+        self.assertIsNone(wref())
+        hook()  # must not raise
+
+    def test_hook_tolerates_raising_stop(self) -> None:
+        """The hook swallows an exception raised by stop() so shutdown proceeds."""
+        with _CaptureRegisteredHooks() as cap:
+            p = _build_pipeline()
+            p.start()
+        try:
+            (hook,) = cap.hooks
+            with unittest.mock.patch.object(
+                p._impl, "stop", side_effect=RuntimeError("boom")
+            ):
+                hook()  # must not propagate
+        finally:
+            p.stop()
+
+
+# --------------------------------------------------------------------------------------------
+# End-to-end interpreter-exit regression across pipeline topologies.
+#
+# Each scenario builds a pipeline, keeps a strong reference to it (mimicking a framework
+# holding the dataloader), iterates a few items, and returns WITHOUT stopping -- so the
+# reference survives to interpreter shutdown. Run in a child process: with the fix the child
+# exits cleanly; without it the child hangs at exit and the join below times out.
+# --------------------------------------------------------------------------------------------
+
+# Strong reference that outlives the scenario function inside the child process.
+_HELD: dict[str, object] = {}
+
+
+def _double(x: int) -> int:
+    return x * 2
+
+
+def _scenario_plain(mp_ctx: str) -> None:
+    """A plain thread-only pipeline (non-daemon event-loop thread)."""
+    p = (
+        PipelineBuilder()
+        .add_source(range(1000), continuous=True)
+        .aggregate(8)
+        .pipe(_double)
+        .add_sink(4)
+        .build(num_threads=2)
+    )
+    _HELD["dl"] = p
+    for i, _ in enumerate(p.get_iterator(timeout=60)):
+        if i >= 10:
+            break
+
+
+def _child_exit_code(
+    scenario: Callable[[str], None], mp_ctx: str, timeout: float = 120.0
+) -> int | None:
+    """Run ``scenario`` in a child process; return its exit code, or None if it hung."""
+    ctx: Any = mp.get_context(mp_ctx)
+    proc = ctx.Process(target=scenario, args=(mp_ctx,))
+    proc.start()
+    proc.join(timeout)
+    if proc.is_alive():
+        proc.terminate()
+        proc.join(10)
+        return None
+    return proc.exitcode
+
+
+class InterpreterExitTopologyTest(unittest.TestCase):
+    """Held, unstopped pipelines exit cleanly at interpreter exit, across topologies."""
+
+    def test_plain_forkserver(self) -> None:
+        """Plain thread-only pipeline exits cleanly (forkserver)."""
+        self.assertEqual(_child_exit_code(_scenario_plain, "forkserver"), 0)
+
+    def test_plain_spawn(self) -> None:
+        """Plain thread-only pipeline exits cleanly (spawn)."""
+        self.assertEqual(_child_exit_code(_scenario_plain, "spawn"), 0)
+
+
+# Note: the `.to(ProcessPoolExecutorConfig)` region topology's interpreter-exit teardown is
+# covered alongside the region API tests (which is where `.to()` is defined). The nested
+# ``run_pipeline_in_subprocess`` topologies (MTP, or a subprocess-run pipeline whose config also
+# has a `.to(...)` region) are covered end-to-end by the standalone repro and the SPDL Hive loader
+# validation, not here: nesting a subprocess inside another child of this torch-laden test binary
+# makes ``forkserver``/``spawn`` re-import too slow, and ``fork`` unsafe (torch threads).
+
+
+class SubprocessPutInterruptibleTest(unittest.TestCase):
+    """The bridge-stage _put releases parked threads on teardown."""
+
+    def test_put_returns_when_stopped_on_full_queue(self) -> None:
+        """_put parked on a full queue exits once its stop event is set."""
+        q = mp.get_context("spawn").Queue(maxsize=1)
+        try:
+            q.put((0, "x"))  # fill the single slot
+            stop = threading.Event()
+            t = threading.Thread(target=_put, args=(q, (0, "y"), stop))
+            t.start()
+            # Blocked on the full queue: it must not have returned yet.
+            t.join(timeout=1.0)
+            self.assertTrue(t.is_alive())
+            stop.set()
+            t.join(timeout=5.0)
+            self.assertFalse(t.is_alive())
+        finally:
+            q.cancel_join_thread()
+            q.close()

--- a/tests/pipeline/subprocess_pipeline_fuse_test.py
+++ b/tests/pipeline/subprocess_pipeline_fuse_test.py
@@ -981,9 +981,12 @@ class FeedAbortTest(unittest.TestCase):
             )  # stays empty -> get() blocks
             abort = asyncio.Event()
             feeder_idle = asyncio.Event()
+            put_stop = threading.Event()
             with ThreadPoolExecutor(max_workers=num_workers + 1) as ex:
                 task = asyncio.ensure_future(
-                    _subprocess_pipe._feed(input_queue, in_qs, ex, abort, feeder_idle)
+                    _subprocess_pipe._feed(
+                        input_queue, in_qs, ex, abort, feeder_idle, put_stop
+                    )
                 )
                 await asyncio.sleep(0.1)  # let the feeder park on input_queue.get()
                 self.assertFalse(task.done(), "feeder should be parked on empty queue")

--- a/tools/skills/authoring/building_pipelines.md
+++ b/tools/skills/authoring/building_pipelines.md
@@ -73,6 +73,46 @@ For production training, isolate the CPU-heavy stages in a subprocess and keep o
 
 See `migrating_to_spdl_pipeline.md` for the full MTP construction pattern, pickling/thread-safety constraints, and media (`spdl.io`) recipes — they apply identically to a from-scratch build. See `optimization_strategies.md` for deep tuning: concurrency search, subprocess IPC / shared-memory arena, GPU (NVDEC) video decode, decoder-thread tuning, GC-stall mitigation, and headspace analysis.
 
+## Pipeline Lifecycle and Cleanup
+
+A `Pipeline` cleans itself up, so holding a reference to one is safe. It drains its background thread and any worker processes/subinterpreters on two occasions: when it is garbage collected (via `weakref.finalize`), and — if a reference is still held when the program ends — at the very start of interpreter finalization, via a hook `Pipeline.start()` registers with `threading._register_atexit`. You do **not** have to call `Pipeline.stop()` for cleanup to happen, keeping the `Pipeline` alive as an attribute is fine, and it is in fact **required** for a `continuous=True` source re-iterated across epochs, since the same object must survive to be iterated again. (See `Pipeline.start`'s docstring for why the exit hook uses `threading._register_atexit` rather than `atexit`.)
+
+Releasing the reference (or calling `Pipeline.stop()`) as soon as you are done is still good hygiene — it frees the worker processes and memory promptly instead of at GC/exit — but it is no longer needed to avoid a hang.
+
+This matters when a framework stashes the loader on a long-lived object. TorchTNT, for example, holds the dataloader on its `State` (`PhaseState._dataloader`) until the process exits. This no longer hangs the run (the exit hook cleans the pipeline up), but if you want its resources released as soon as training ends (e.g. between fit and eval) rather than at exit, detach it and force a collection with a callback:
+
+```python
+import gc
+
+from torchtnt.framework.callback import Callback
+from torchtnt.framework.state import State
+from torchtnt.framework.unit import TEvalUnit, TPredictUnit, TTestUnit, TTrainUnit
+
+
+class DetachDataloaderCallback(Callback):
+    """Optional: drop TNT's dataloader refs at train end so the SPDL Pipeline
+    (and its workers) are released promptly, instead of lingering on State until
+    the pipeline is cleaned up at exit."""
+
+    def on_train_end(self, state: State, unit: TTrainUnit) -> None:
+        self._detach(state)
+
+    def on_exception(
+        self,
+        state: State,
+        unit: TTrainUnit | TEvalUnit | TPredictUnit | TTestUnit,
+        exc: BaseException,
+    ) -> None:
+        # on_train_end does not fire on failure/preemption, so reap here too.
+        self._detach(state)
+
+    def _detach(self, state: State) -> None:
+        for phase_state in (state.train_state, state.eval_state):
+            if phase_state is not None:
+                phase_state._dataloader = None  # pyre-ignore[8]
+        gc.collect()
+```
+
 ## Structuring the Construction Code
 
 When code builds a `Pipeline` (or `PipelineConfig`) in more than one shape — e.g. a script that supports several execution modes, or a loader with optional stages — keep **each pipeline's construction in one place**. The maintainability win is being able to read a single fluent chain top-to-bottom and see the whole pipeline; it is lost when the construction is scattered across helpers that each tack on a few stages.
@@ -151,3 +191,4 @@ When variants genuinely differ in topology (not just an argument), inline each o
 - [ ] Production build uses MTP with picklable stage functions
 - [ ] Iterated via `get_iterator(timeout=...)`
 - [ ] Each pipeline shape is a single readable builder chain (no partial-construction helpers)
+- [ ] Long-lived holders (e.g. TorchTNT `State`) release the `Pipeline` reference promptly to free resources (optional hygiene; cleanup at exit is automatic)


### PR DESCRIPTION
A program that keeps a strong reference to a `Pipeline` and never calls `stop()` (e.g. a training framework that stores the dataloader for the whole run) can hang at interpreter exit. The pipeline's background event-loop thread is non-daemon, so CPython joins it inside `threading._shutdown()` during finalization; because nothing stopped the pipeline, that join blocks forever. The existing `weakref.finalize` cleanup runs too late: it is an `atexit`-module callback (a later finalization phase), after non-daemon threads have already been joined.

Fix: register a per-pipeline shutdown hook via `threading._register_atexit` (the same private mechanism `concurrent.futures` relies on) so it runs inside `threading._shutdown()` — before non-daemon threads and child processes are joined — and stops the pipeline first. The hook is a thin weakref wrapper around the existing `_stop_impl` (the single stop-with-timeout helper, shared with the GC finalizer), registered in `Pipeline.start()` after the pipeline's own threads/processes are up, so it lands after the stdlib's atexit hooks and — being LIFO — runs before them. It holds only a weak reference so it never keeps the pipeline alive, and is a safe no-op once the pipeline is stopped or collected. A regular `atexit.register` hook was verified insufficient: it runs after the non-daemon thread join and still hangs.

Also make the subprocess-region bridge's blocking queue put interruptible. A `.to(...)` region feeder parked on a full worker queue (backpressure once the consumer stopped) cannot be released by pool teardown, so at exit it is joined — and hangs — by `concurrent.futures`. It now polls a teardown event and exits promptly. This also fixes a pre-existing hang that reproduced on an explicit `stop()`.

No public API change; holding a `Pipeline` reference and relying on GC is unchanged.