### PR TITLE
[pipeline] Add batched routing to path_variants

### DIFF
--- a/src/spdl/pipeline/_builder.py
+++ b/src/spdl/pipeline/_builder.py
@@ -386,17 +386,30 @@ class PipelineBuilder(Generic[T, U]):
         router: Callable,
         paths: Sequence,
         name: str | None = None,
+        batched: bool = False,
     ) -> "PipelineBuilder[T, U]":
         """Route items to different processing paths based on a router function.
 
+        .. versionadded:: 0.6.0
+           The ``batched`` argument.
+
         Args:
-            router: A callable that takes an item and returns an int index
-                selecting which path the item should be routed to.
+            router: A callable that selects the path for each input. In per-item
+                mode (default) it takes an item and returns an int index. In
+                ``batched`` mode it takes a batch (list) and returns one int index
+                per element (same length as the batch).
             paths: A sequence of paths, where each path is a sequence of
                 pipe configs.
             name: Optional name for the stage.
+            batched: If True, route whole batches instead of single items: the
+                batch is partitioned into per-path sub-batches (each path op takes
+                and returns a list) and merged back into one batch. Aggregate the
+                source into batches upstream of this stage. See
+                :py:func:`~spdl.pipeline.defs.PathVariants`.
         """
-        self._process_args.append(PathVariants(router, paths, name=name))
+        self._process_args.append(
+            PathVariants(router, paths, name=name, batched=batched)
+        )
         return self
 
     def add_sink(

--- a/src/spdl/pipeline/_components/_node.py
+++ b/src/spdl/pipeline/_components/_node.py
@@ -46,7 +46,7 @@ from ._queue import _ThreadBasedAsyncQueue, AsyncQueue, get_default_queue_class
 from ._sink import _sink
 from ._source import _source, _source_continuous
 from ._subprocess_pipe import _subprocess_pipeline
-from ._variants import _path_variants_router
+from ._variants import _batched_path_variants_merge, _path_variants_router
 
 T = TypeVar("T")
 S = TypeVar("S")
@@ -69,6 +69,7 @@ __all__ = [
 # pyre-strict
 
 
+@dataclass
 class _PathVariantsMergeConfig:
     """Internal config for the fan-in merge node of PathVariants.
 
@@ -76,7 +77,9 @@ class _PathVariantsMergeConfig:
     so that ``_build_node`` can dispatch to the correct coroutine builder.
     """
 
-    pass
+    batched: bool = False
+    """Whether the parent PathVariants stage routes batches (see
+    :py:func:`~spdl.pipeline._components._variants._batched_path_variants_merge`)."""
 
 
 # Used to express the upstream relation ship of coroutines,
@@ -434,7 +437,7 @@ def _convert_path_variants(
     merge_out_q = q_class(merge_info, buffer_size=_BUFFER_SIZE)
     merge_node = _FanInNode(
         merge_info,
-        _PathVariantsMergeConfig(),
+        _PathVariantsMergeConfig(batched=cfg.batched),
         end_nodes,
         input_queues=[n.output_queue for n in end_nodes],
         output_queue=merge_out_q,
@@ -570,6 +573,7 @@ def _build_node(
                 node.output_queues,
                 node.cfg.router,
                 hooks,
+                batched=node.cfg.batched,
             )
         case _FanInNode():
             hooks = task_hook_factory(node.info)
@@ -585,8 +589,16 @@ def _build_node(
                         cfg.op,
                     )
                 case _PathVariantsMergeConfig():
+                    # A batched stage recombines each input batch's per-path
+                    # sub-batches into one batch; the per-item stage passes items
+                    # through in arrival order (default merge).
                     node._coro = _merge(
-                        node.info, node.input_queues, node.output_queue, fc, hooks, None
+                        node.info,
+                        node.input_queues,
+                        node.output_queue,
+                        fc,
+                        hooks,
+                        _batched_path_variants_merge if cfg.batched else None,
                     )
                 case _:  # pragma: no cover
                     raise ValueError(

--- a/src/spdl/pipeline/_components/_variants.py
+++ b/src/spdl/pipeline/_components/_variants.py
@@ -9,6 +9,7 @@
 # pyre-strict
 
 __all__ = [
+    "_batched_path_variants_merge",
     "_path_variants_router",
 ]
 
@@ -21,7 +22,7 @@ from typing import Any
 
 from spdl.pipeline._common._convert import _to_async
 
-from ._common import _EOF, _EPOCH_END, _ShieldedHook, is_eof, is_epoch_end
+from ._common import _EOF, _EPOCH_END, _ShieldedHook, is_eof, is_epoch_end, StageInfo
 from ._hook import _stage_hooks, TaskHook
 from ._queue import AsyncQueue
 
@@ -29,9 +30,12 @@ _LG: logging.Logger = logging.getLogger(__name__)
 
 
 def _make_async_router(
-    router: Callable[[Any], int] | Callable[[Any], Awaitable[int]],
-) -> Callable[[Any], Awaitable[int]]:
-    """Wrap a sync router with run_in_executor; pass through async routers."""
+    router: Callable[[Any], Any] | Callable[[Any], Awaitable[Any]],
+) -> Callable[[Any], Awaitable[Any]]:
+    """Wrap a sync router with run_in_executor; pass through async routers.
+
+    The router returns an ``int`` (per-item mode) or a ``Sequence[int]`` (batched
+    mode); this wrapper is agnostic to which."""
     if inspect.iscoroutinefunction(router):
         return router
     call = getattr(router, "__call__", None)
@@ -88,14 +92,25 @@ async def _queue_stage_hook(queues: Sequence[AsyncQueue]) -> AsyncGenerator[None
 def _path_variants_router(
     input_queue: AsyncQueue,
     path_queues: Sequence[AsyncQueue],
-    router: Callable[[Any], int] | Callable[[Any], Awaitable[int]],
+    router: Callable[[Any], Any] | Callable[[Any], Awaitable[Any]],
     task_hooks: list[TaskHook],
+    batched: bool = False,
 ) -> Coroutine[None, None, None]:
     """Create a coroutine that routes items to per-path queues.
 
-    The router reads items from ``input_queue``, calls ``router(item)`` to
-    determine the target path index, and puts the item on the corresponding
-    queue in ``path_queues``.
+    In the default (per-item) mode the router reads items from ``input_queue``,
+    calls ``router(item)`` to determine the target path index, and puts the item
+    on the corresponding queue in ``path_queues``.
+
+    In ``batched`` mode each item read from ``input_queue`` is a whole batch (a
+    list). ``router(batch)`` returns one path index per element; the batch is
+    partitioned into per-path sub-batches (preserving order) and each sub-batch
+    is put on its path's queue as a single list. A sub-batch is put on **every**
+    path queue -- an empty list where a path received no elements -- so that each
+    input batch contributes exactly one list to every path queue. This keeps the
+    downstream fan-in merge in lockstep, letting it recombine the sub-batches of
+    one input batch by reading one list from each path (see
+    :py:func:`_batched_path_variants_merge`).
 
     Sync routers are wrapped with ``run_in_executor`` to avoid blocking the
     event loop. Async routers are awaited directly.
@@ -111,14 +126,47 @@ def _path_variants_router(
     Args:
         input_queue: The queue to consume items from.
         path_queues: Per-path output queues, one per variant path.
-        router: Callable that maps an item to a path index.
+        router: Callable that maps an item (or a batch, if ``batched``) to a path
+            index (or a sequence of per-element path indices, if ``batched``).
         task_hooks: Hooks for monitoring.
+        batched: If True, route whole batches (see above) instead of single items.
 
     Returns:
         A coroutine that executes the router stage.
     """
     num_paths: int = len(path_queues)
-    arouter: Callable[[Any], Awaitable[int]] = _make_async_router(router)
+    arouter: Callable[[Any], Awaitable[Any]] = _make_async_router(router)
+
+    async def _route_item(item: Any) -> None:
+        idx = await arouter(item)
+        if idx < 0 or idx >= num_paths:
+            raise IndexError(
+                f"Router returned index {idx}, but there are only "
+                f"{num_paths} paths (valid range: [0, {num_paths}))."
+            )
+        await path_queues[idx].put(item)
+
+    async def _route_batch(batch: Any) -> None:
+        indices = await arouter(batch)
+        if len(indices) != len(batch):
+            raise ValueError(
+                f"Batched router returned {len(indices)} indices for a batch of "
+                f"{len(batch)} items; it must return exactly one index per item."
+            )
+        parts: list[list[Any]] = [[] for _ in range(num_paths)]
+        for item, idx in zip(batch, indices):
+            if idx < 0 or idx >= num_paths:
+                raise IndexError(
+                    f"Router returned index {idx}, but there are only "
+                    f"{num_paths} paths (valid range: [0, {num_paths}))."
+                )
+            parts[idx].append(item)
+        # Emit to every path (empty lists included) so each input batch contributes
+        # exactly one list per path, keeping the fan-in merge in lockstep.
+        for q, part in zip(path_queues, parts):
+            await q.put(part)
+
+    _route: Callable[[Any], Awaitable[None]] = _route_batch if batched else _route_item
 
     @_queue_stage_hook(path_queues)
     # pyrefly: ignore [not-callable]
@@ -134,12 +182,38 @@ def _path_variants_router(
                     await q.put(_EPOCH_END)
                 continue
 
-            idx = await arouter(item)
-            if idx < 0 or idx >= num_paths:
-                raise IndexError(
-                    f"Router returned index {idx}, but there are only "
-                    f"{num_paths} paths (valid range: [0, {num_paths}))."
-                )
-            await path_queues[idx].put(item)
+            await _route(item)
 
     return _router()
+
+
+async def _batched_path_variants_merge(
+    info: StageInfo,
+    input_queues: Sequence[asyncio.Queue],
+    output_queue: asyncio.Queue,
+) -> None:
+    """Fan-in merge for a ``batched`` path_variants stage.
+
+    Each input batch was partitioned by the router into one sub-batch (list) per
+    path, so the queues stay in lockstep: reading one list from every input queue
+    yields the sub-batches of a single original batch. They are concatenated (in
+    path order) back into one batch and emitted, so the stage is batch-in /
+    batch-out and downstream sees whole batches -- not the individual items.
+
+    A fully-empty recombined batch (every path routed nothing, or every element
+    was dropped) is skipped rather than emitted downstream.
+
+    ``_EPOCH_END`` and ``_EOF`` are broadcast by the router to every path queue,
+    so they surface on all input queues together; the merge forwards one epoch
+    boundary and stops on end-of-stream.
+    """
+    while True:
+        items = [await q.get() for q in input_queues]
+        if any(is_eof(it) for it in items):
+            return
+        if any(is_epoch_end(it) for it in items):
+            await output_queue.put(_EPOCH_END)
+            continue
+        combined = [item for sub_batch in items for item in sub_batch]
+        if combined:
+            await output_queue.put(combined)

--- a/src/spdl/pipeline/defs/_defs.py
+++ b/src/spdl/pipeline/defs/_defs.py
@@ -19,7 +19,16 @@ from dataclasses import dataclass
 from enum import IntEnum
 from fractions import Fraction
 from functools import partial
-from typing import Any, Generic, Protocol, runtime_checkable, TypeAlias, TypeVar
+from typing import (
+    Any,
+    Generic,
+    Literal,
+    overload,
+    Protocol,
+    runtime_checkable,
+    TypeAlias,
+    TypeVar,
+)
 
 from spdl.pipeline._common._source_locator import locate_source
 from spdl.pipeline._common._types import _TCallables, _TMergeOp
@@ -544,6 +553,18 @@ class PlacementConfig:
 # PathVariants
 ################################################################################
 
+# path_variants routers. Per-item mode maps one item to one path index; ``batched``
+# mode maps a batch (Sequence) to one index per element. Either form may be sync or
+# async. The two are kept as distinct aliases so ``PathVariants`` can ``@overload`` on
+# ``batched`` and give each mode its own router signature; ``_TRouter`` is their union,
+# used where a value may be either (the config field, the internal router coroutine).
+_TItemRouter: TypeAlias = Callable[[Any], int] | Callable[[Any], Awaitable[int]]
+_TBatchRouter: TypeAlias = (
+    Callable[[Sequence[Any]], Sequence[int]]
+    | Callable[[Sequence[Any]], Awaitable[Sequence[int]]]
+)
+_TRouter: TypeAlias = _TItemRouter | _TBatchRouter
+
 
 @dataclass(frozen=True)
 class PathVariantsConfig(Generic[T]):
@@ -608,10 +629,12 @@ class PathVariantsConfig(Generic[T]):
     name: str
     """Name of the path variants stage."""
 
-    router: Callable[[Any], int] | Callable[[Any], Awaitable[int]]
-    """A function that takes an item and returns an index into the paths list.
+    router: _TRouter
+    """A function that selects the path for each input.
 
-    Can be a regular function or an async function/callable."""
+    In per-item mode (default) it takes an item and returns an int index. In
+    ``batched`` mode it takes a batch (list) and returns one int index per
+    element. Either form can be a regular function or an async function/callable."""
 
     paths: tuple[
         tuple[
@@ -625,6 +648,16 @@ class PathVariantsConfig(Generic[T]):
         ...,
     ]
     """Alternative processing paths. Each path is a tuple of pipe configs."""
+
+    batched: bool = False
+    """If True, route whole batches instead of single items.
+
+    Each incoming item is a batch (a list). ``router(batch)`` returns one path
+    index per element; the batch is partitioned into per-path sub-batches (lists,
+    order preserved), each path processes its sub-batch as a list, and the merge
+    concatenates the sub-batches back into one batch. This amortizes the routing
+    and fan-out/fan-in overhead over a whole batch instead of paying it per item.
+    Aggregate the source into batches upstream of this stage when using it."""
 
     def __post_init__(self) -> None:
         if not callable(self.router) and not hasattr(self.router, "__call__"):
@@ -1182,17 +1215,41 @@ def Disaggregate() -> DisaggregateConfig[Any]:
     return DisaggregateConfig(name="disaggregate")
 
 
+_TPaths: TypeAlias = Sequence[
+    Sequence[
+        PipeConfig[Any, Any]
+        | AggregateConfig[Any]
+        | DisaggregateConfig[Any]
+        | PathVariantsConfig[Any]
+    ]
+]
+
+
+@overload
 def PathVariants(
-    router: Callable[[Any], int] | Callable[[Any], Awaitable[int]],
-    paths: Sequence[
-        Sequence[
-            PipeConfig[Any, Any]
-            | AggregateConfig[Any]
-            | DisaggregateConfig[Any]
-            | PathVariantsConfig[Any]
-        ]
-    ],
+    router: _TItemRouter,
+    paths: _TPaths,
+    name: str | None = ...,
+    *,
+    batched: Literal[False] = ...,
+) -> PathVariantsConfig[Any]: ...
+
+
+@overload
+def PathVariants(
+    router: _TBatchRouter,
+    paths: _TPaths,
+    name: str | None = ...,
+    *,
+    batched: Literal[True],
+) -> PathVariantsConfig[Any]: ...
+
+
+def PathVariants(
+    router: _TRouter,
+    paths: _TPaths,
     name: str | None = None,
+    batched: bool = False,
 ) -> PathVariantsConfig[Any]:
     """Create a :py:class:`PathVariantsConfig` for variant path routing.
 
@@ -1210,18 +1267,34 @@ def PathVariants(
     uncached items go through full data loading, or splitting between local
     and remote processing.
 
+    With ``batched=True`` the routing is applied per batch instead of per item:
+    the router receives a whole batch (a list) and returns one path index per
+    element, the batch is partitioned into per-path sub-batches (each path's ops
+    then operate on a list), and the sub-batches are concatenated back into one
+    batch by the merge. This amortizes the per-item routing and fan-out/fan-in
+    overhead over a whole batch — aggregate the source into batches upstream of
+    the stage. Each path op receives and returns a ``list``; a path may drop
+    elements by returning a shorter list, and must tolerate an empty input list
+    (a path that received no elements for a given batch).
+
     .. versionchanged:: 0.6.0
        Fixed to work with a continuous source.
 
+    .. versionadded:: 0.6.0
+       The ``batched`` argument.
+
     Args:
-        router: A callable that takes an item and returns an int index
-            selecting which path the item should be routed to. The returned
-            index must be in range ``[0, len(paths))``.
+        router: A callable that selects the path for each input. In per-item mode
+            (default) it takes an item and returns an int index. In ``batched``
+            mode it takes a batch (list) and returns a sequence of per-element int
+            indices (one per item, same length as the batch). Every index must be
+            in range ``[0, len(paths))``.
         paths: A sequence of paths. Each path is a sequence of pipe configs
             (:py:class:`PipeConfig`, :py:class:`AggregateConfig`,
             :py:class:`DisaggregateConfig`, or nested :py:class:`PathVariantsConfig`).
             :py:class:`SourceConfig` and :py:class:`SinkConfig` are not allowed.
         name: Optional name for the stage.
+        batched: If True, route whole batches instead of single items (see above).
 
     Returns:
         The config object.
@@ -1249,9 +1322,30 @@ def PathVariants(
            ],
            sink=SinkConfig(buffer_size=10),
        )
+
+    Batched routing (aggregate first; each path op takes and returns a list):
+
+    .. code-block:: python
+
+       config = PipelineConfig(
+           src=SourceConfig(items),
+           pipes=[
+               Aggregate(64),
+               PathVariants(
+                   router=lambda batch: [0 if x in cache else 1 for x in batch],
+                   paths=[
+                       [Pipe(load_batch_from_cache)],   # path 0: cache hits
+                       [Pipe(load_batch_from_source)],  # path 1: cache misses
+                   ],
+                   batched=True,
+               ),
+           ],
+           sink=SinkConfig(buffer_size=10),
+       )
     """
     return PathVariantsConfig(
         name=name or "path_variants",
         router=router,
         paths=tuple(tuple(p) for p in paths),
+        batched=batched,
     )

--- a/tests/pipeline/path_variants_test.py
+++ b/tests/pipeline/path_variants_test.py
@@ -10,7 +10,8 @@
 
 import asyncio
 import unittest
-from collections.abc import AsyncIterator, Iterable
+from collections.abc import AsyncIterator, Iterable, Sequence
+from typing import Any
 
 from spdl.pipeline import build_pipeline
 from spdl.pipeline._components._node import PipelineFailure
@@ -701,6 +702,152 @@ class PathVariantsReprTest(unittest.TestCase):
         self.assertIn("PathVariants", r)
         self.assertIn("path0", r)
         self.assertIn("path1", r)
+
+
+class PathVariantsBatchedTest(unittest.TestCase):
+    """Tests for batched routing (``batched=True``)."""
+
+    def test_basic_batched_routing(self) -> None:
+        """Router partitions each batch; branches process sub-batches; merge recombines.
+
+        Even elements are doubled, odd elements get +100. The output is one
+        recombined batch per input batch (a list), containing all the batch's
+        elements regardless of which path they took.
+        """
+        config = PipelineConfig(
+            src=SourceConfig([[0, 1, 2, 3], [4, 5, 6, 7]]),
+            pipes=[
+                PathVariants(
+                    router=lambda batch: [x % 2 for x in batch],
+                    paths=[
+                        [Pipe(lambda xs: [x * 2 for x in xs])],  # path 0: evens
+                        [Pipe(lambda xs: [x + 100 for x in xs])],  # path 1: odds
+                    ],
+                    batched=True,
+                ),
+            ],
+            sink=SinkConfig(buffer_size=10),
+        )
+        results = _run_pipeline(config)
+        # Each input batch -> one recombined batch (evens*2 ++ odds+100, in path order).
+        self.assertEqual(results, [[0, 4, 101, 103], [8, 12, 105, 107]])
+
+    def test_batched_all_to_one_path(self) -> None:
+        """Warm-cache steady state: every element routes to path 0; path 1 gets an
+        empty sub-batch each batch and must tolerate it."""
+        seen_empty: list[bool] = []
+
+        def _miss_branch(xs: list[int]) -> list[int]:
+            if not xs:  # a path that received no elements for this batch
+                seen_empty.append(True)
+                return []
+            return [x + 1000 for x in xs]
+
+        config = PipelineConfig(
+            src=SourceConfig([[1, 2, 3], [4, 5, 6]]),
+            pipes=[
+                PathVariants(
+                    router=lambda batch: [0 for _ in batch],
+                    paths=[
+                        [Pipe(lambda xs: [x * 10 for x in xs])],
+                        [Pipe(_miss_branch)],
+                    ],
+                    batched=True,
+                ),
+            ],
+            sink=SinkConfig(buffer_size=10),
+        )
+        results = _run_pipeline(config)
+        self.assertEqual(results, [[10, 20, 30], [40, 50, 60]])
+        # The empty (miss) branch was still invoked once per batch.
+        self.assertTrue(seen_empty)
+
+    def test_batched_branch_drops_elements(self) -> None:
+        """A branch may return a shorter list to drop elements; the recombined
+        batch reflects the drop (partial failure handling)."""
+        config = PipelineConfig(
+            src=SourceConfig([[1, 2, 3, 4, 5, 6]]),
+            pipes=[
+                PathVariants(
+                    router=lambda batch: [x % 2 for x in batch],
+                    paths=[
+                        # path 0 (evens): keep only those > 2
+                        [Pipe(lambda xs: [x for x in xs if x > 2])],
+                        # path 1 (odds): keep all
+                        [Pipe(lambda xs: list(xs))],
+                    ],
+                    batched=True,
+                ),
+            ],
+            sink=SinkConfig(buffer_size=10),
+        )
+        results = _run_pipeline(config)
+        # evens {2,4,6} -> keep {4,6}; odds {1,3,5} kept. Path order: evens then odds.
+        self.assertEqual(results, [[4, 6, 1, 3, 5]])
+
+    def test_batched_multi_stage_branch(self) -> None:
+        """A batched branch can be a multi-stage chain of list->list pipes."""
+        config = PipelineConfig(
+            src=SourceConfig([[0, 1, 2, 3]]),
+            pipes=[
+                PathVariants(
+                    router=lambda batch: [x % 2 for x in batch],
+                    paths=[
+                        [
+                            Pipe(lambda xs: [x + 1 for x in xs]),
+                            Pipe(lambda xs: [x * 10 for x in xs]),
+                        ],  # path 0 (evens 0,2): (+1)*10 -> 10, 30
+                        [Pipe(lambda xs: [x for x in xs])],  # path 1 (odds 1,3)
+                    ],
+                    batched=True,
+                ),
+            ],
+            sink=SinkConfig(buffer_size=10),
+        )
+        results = _run_pipeline(config)
+        self.assertEqual(results, [[10, 30, 1, 3]])
+
+    def test_batched_async_router(self) -> None:
+        """An async batched router (returning per-element indices) works."""
+
+        async def _router(batch: Sequence[Any]) -> list[int]:
+            return [x % 2 for x in batch]
+
+        config = PipelineConfig(
+            src=SourceConfig([[0, 1, 2, 3]]),
+            pipes=[
+                PathVariants(
+                    router=_router,
+                    paths=[
+                        [Pipe(lambda xs: [x * 2 for x in xs])],
+                        [Pipe(lambda xs: [x + 100 for x in xs])],
+                    ],
+                    batched=True,
+                ),
+            ],
+            sink=SinkConfig(buffer_size=10),
+        )
+        results = _run_pipeline(config)
+        self.assertEqual(results, [[0, 4, 101, 103]])
+
+    def test_batched_router_wrong_index_count_raises(self) -> None:
+        """A batched router that returns the wrong number of indices fails the pipeline."""
+        config = PipelineConfig(
+            src=SourceConfig([[1, 2, 3]]),
+            pipes=[
+                PathVariants(
+                    router=lambda batch: [0],  # one index for a 3-element batch
+                    paths=[
+                        [Pipe(lambda xs: list(xs))],
+                        [Pipe(lambda xs: list(xs))],
+                    ],
+                    batched=True,
+                ),
+            ],
+            sink=SinkConfig(buffer_size=10),
+        )
+        with self.assertRaises(PipelineFailure):
+            _run_pipeline(config)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Add a `batched` option to `PathVariants` and `PipelineBuilder.path_variants`.

When set, the router receives a whole batch (a list) and returns one path index per element; the batch is partitioned into per-path sub-batches (order preserved), each path processes its sub-batch as a list, and the fan-in merge concatenates the sub-batches back into one batch.

Per-item routing pays the router + fan-out/fan-in machinery once per element. For workloads that route in bulk -- e.g. a cache hit/miss split over an already-aggregated batch -- that fixed per-item cost dominates. Batched routing amortizes it over the whole batch: the router runs once per batch, each branch runs its ops once per batch, and one list (not one item) crosses each queue per batch.

Semantics:
- Each input batch contributes exactly one sub-batch (possibly empty) to every path queue, so the queues stay in lockstep and the merge recombines an input batch's sub-batches by reading one list from each path.
- A branch may drop elements by returning a shorter list, and must tolerate an empty input list (a path that received no elements for a batch).
- A batched router must return exactly one index per element; otherwise the stage fails.

`batched` defaults to `False`, so existing per-item behavior is byte-identical (not backward-incompatible).