### PR TITLE
fbcode/libspdl, fbcode/spdl/io/lib: add missing <fmt/format.h> includes for fmt 12.2.0

### DIFF
--- a/src/libspdl/core/adaptor/bytes.cpp
+++ b/src/libspdl/core/adaptor/bytes.cpp
@@ -11,6 +11,7 @@
 #include "libspdl/core/detail/ffmpeg/ctx_utils.h"
 
 #include <fmt/core.h>
+#include <fmt/format.h>
 #include <glog/logging.h>
 
 extern "C" {

--- a/src/libspdl/core/detail/ffmpeg/compat.h
+++ b/src/libspdl/core/detail/ffmpeg/compat.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <fmt/core.h>
+#include <fmt/format.h>
 
 extern "C" {
 #include <libavcodec/avcodec.h>

--- a/src/libspdl/core/detail/ffmpeg/decoder.cpp
+++ b/src/libspdl/core/detail/ffmpeg/decoder.cpp
@@ -15,6 +15,7 @@
 #include "libspdl/core/detail/ffmpeg/logging.h"
 #include "libspdl/core/detail/tracing.h"
 
+#include <fmt/format.h>
 #include <glog/logging.h>
 
 namespace spdl::core::detail {

--- a/src/libspdl/core/detail/ffmpeg/logging.h
+++ b/src/libspdl/core/detail/ffmpeg/logging.h
@@ -11,6 +11,7 @@
 #include "libspdl/core/detail/logging.h"
 
 #include <fmt/core.h>
+#include <fmt/format.h>
 
 extern "C" {
 #include <libavutil/attributes.h>

--- a/src/libspdl/core/detail/ffmpeg/muxer.cpp
+++ b/src/libspdl/core/detail/ffmpeg/muxer.cpp
@@ -17,6 +17,7 @@
 #include <fmt/core.h>
 #include <fmt/format.h>
 
+#include <cstring>
 #include <filesystem>
 #include <set>
 

--- a/src/libspdl/core/detail/ffmpeg/wrappers.cpp
+++ b/src/libspdl/core/detail/ffmpeg/wrappers.cpp
@@ -97,6 +97,7 @@ OptionDict parse_dict(const AVDictionary* metadata) {
 #ifdef SPDL_DEBUG_REFCOUNT
 
 #include <fmt/core.h>
+#include <fmt/format.h>
 #include <glog/logging.h>
 
 extern "C" {

--- a/src/libspdl/core/detail/logging.cpp
+++ b/src/libspdl/core/detail/logging.cpp
@@ -9,6 +9,7 @@
 #include "libspdl/core/detail/logging.h"
 
 #include <fmt/core.h>
+#include <fmt/format.h>
 
 namespace spdl::core::detail {
 

--- a/src/libspdl/core/frames.cpp
+++ b/src/libspdl/core/frames.cpp
@@ -17,6 +17,8 @@
 #include "libspdl/core/detail/ffmpeg/wrappers.h"
 #include "libspdl/core/detail/tracing.h"
 
+#include <fmt/format.h>
+
 #include <algorithm>
 #include <cassert>
 

--- a/src/libspdl/core/muxer.cpp
+++ b/src/libspdl/core/muxer.cpp
@@ -12,6 +12,7 @@
 #include "libspdl/core/detail/logging.h"
 
 #include <fmt/core.h>
+#include <fmt/format.h>
 
 namespace spdl::core {
 

--- a/src/libspdl/core/packets.cpp
+++ b/src/libspdl/core/packets.cpp
@@ -16,6 +16,7 @@
 #include "libspdl/core/detail/tracing.h"
 
 #include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <algorithm>
 #include <cassert>

--- a/src/libspdl/core/utils.cpp
+++ b/src/libspdl/core/utils.cpp
@@ -14,6 +14,7 @@
 #include "libspdl/core/detail/tracing.h"
 
 #include <fmt/core.h>
+#include <fmt/format.h>
 #include <glog/logging.h>
 
 #include <cstdint>

--- a/src/libspdl/cuda/color_conversion.cpp
+++ b/src/libspdl/cuda/color_conversion.cpp
@@ -15,6 +15,7 @@
 #include "libspdl/cuda/detail/utils.h"
 
 #include <fmt/core.h>
+#include <fmt/format.h>
 #include <fmt/ranges.h>
 
 #include <vector>

--- a/src/libspdl/cuda/detail/utils.h
+++ b/src/libspdl/cuda/detail/utils.h
@@ -11,6 +11,7 @@
 #include "libspdl/core/detail/logging.h"
 
 #include <fmt/core.h>
+#include <fmt/format.h>
 
 // Make sure CUDA_API_PER_THREAD_DEFAULT_STREAM is defined by compiler
 // so that it is applied globally

--- a/src/libspdl/cuda/npp/detail/resize.cpp
+++ b/src/libspdl/cuda/npp/detail/resize.cpp
@@ -14,6 +14,7 @@
 #include "libspdl/cuda/nvjpeg/detail/utils.h"
 
 #include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <nppi.h>
 

--- a/src/libspdl/cuda/npp/detail/utils.h
+++ b/src/libspdl/cuda/npp/detail/utils.h
@@ -11,6 +11,7 @@
 #include <nppdefs.h>
 
 #include <fmt/core.h>
+#include <fmt/format.h>
 #include <glog/logging.h>
 
 namespace spdl::cuda::detail {

--- a/src/libspdl/cuda/nvdec/decoder.cpp
+++ b/src/libspdl/cuda/nvdec/decoder.cpp
@@ -14,6 +14,7 @@
 #include "libspdl/cuda/nvdec/detail/decoder.h"
 
 #include <fmt/core.h>
+#include <fmt/format.h>
 
 // Macro for hiding argument names if not using this module.
 // So as to workaround -Werror=unused-variable

--- a/src/libspdl/cuda/nvdec/detail/buffer.cpp
+++ b/src/libspdl/cuda/nvdec/detail/buffer.cpp
@@ -14,6 +14,7 @@
 #include <cuda.h>
 
 #include <fmt/core.h>
+#include <fmt/format.h>
 
 namespace spdl::cuda::detail {
 

--- a/src/libspdl/cuda/nvdec/detail/decoder.cpp
+++ b/src/libspdl/cuda/nvdec/detail/decoder.cpp
@@ -18,6 +18,7 @@
 #include "libspdl/cuda/nvdec/detail/utils.h"
 
 #include <fmt/core.h>
+#include <fmt/format.h>
 #include <glog/logging.h>
 
 #include <sys/types.h>

--- a/src/libspdl/cuda/nvdec/detail/wrapper.cpp
+++ b/src/libspdl/cuda/nvdec/detail/wrapper.cpp
@@ -12,6 +12,7 @@
 #include "libspdl/cuda/detail/utils.h"
 
 #include <fmt/core.h>
+#include <fmt/format.h>
 #include <glog/logging.h>
 
 #include <cuda.h>

--- a/src/libspdl/cuda/storage.cpp
+++ b/src/libspdl/cuda/storage.cpp
@@ -12,6 +12,7 @@
 #include "libspdl/cuda/detail/utils.h"
 
 #include <fmt/core.h>
+#include <fmt/format.h>
 #include <glog/logging.h>
 
 namespace spdl::cuda {

--- a/src/spdl/io/lib/archive/register_tar.cpp
+++ b/src/spdl/io/lib/archive/register_tar.cpp
@@ -8,6 +8,7 @@
 
 #include "register_tar.h"
 #include <fmt/core.h>
+#include <fmt/format.h>
 #include "tar_iterator.h"
 
 #include <nanobind/make_iterator.h>

--- a/src/spdl/io/lib/core/buffer.cpp
+++ b/src/spdl/io/lib/core/buffer.cpp
@@ -11,6 +11,7 @@
 #include <libspdl/core/buffer.h>
 
 #include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <nanobind/nanobind.h>
 #include <nanobind/stl/string.h>

--- a/src/spdl/io/lib/core/demuxing.cpp
+++ b/src/spdl/io/lib/core/demuxing.cpp
@@ -12,6 +12,7 @@
 #include <libspdl/core/rational_utils.h>
 
 #include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <nanobind/nanobind.h>
 #include <nanobind/stl/function.h>

--- a/src/spdl/io/lib/core/frames.cpp
+++ b/src/spdl/io/lib/core/frames.cpp
@@ -11,6 +11,7 @@
 #include <libspdl/core/frames.h>
 
 #include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <nanobind/nanobind.h>
 #include <nanobind/stl/map.h>

--- a/src/spdl/io/lib/cuda/buffer.cpp
+++ b/src/spdl/io/lib/cuda/buffer.cpp
@@ -12,6 +12,7 @@
 #include <libspdl/cuda/buffer.h>
 
 #include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <nanobind/nanobind.h>
 #include <nanobind/stl/string.h>

--- a/src/spdl/io/lib/cuda/transfer.cpp
+++ b/src/spdl/io/lib/cuda/transfer.cpp
@@ -18,6 +18,7 @@
 #include <nanobind/stl/unique_ptr.h>
 
 #include <fmt/core.h>
+#include <fmt/format.h>
 
 namespace nb = nanobind;
 


### PR DESCRIPTION
Summary:
fmt::format() moved out of fmt/core.h in fmt 12.2.0; these files only
included fmt/core.h (or no fmt header at all) and relied on fmt::format
transitively/implicitly. Add the explicit <fmt/format.h> include across the
libspdl/spdl core and cuda subtrees, found via a subsystem sweep after
fbcode//spdl/io/lib:_spdl_ffmpeg failed to build.

Differential Revision: D112806772


