### PR TITLE
Include <cstdint> for uint32_t in numpy_support.h

### DIFF
--- a/src/spdl/io/lib/archive/numpy_support.h
+++ b/src/spdl/io/lib/archive/numpy_support.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <vector>


### PR DESCRIPTION
Summary: This diff adds `#include <cstdint>` to `numpy_support.h`. The header declares `load_npy_compressed(const char*, uint32_t, uint32_t)` but relied on `uint32_t` arriving transitively through `<memory>`, `<string>`, or `<vector>` rather than including the standard header that defines it. That transitive path is not guaranteed and is not provided under newer GCC/libstdc++ toolchains, where the translation unit fails to compile with `'uint32_t' has not been declared`. Including `<cstdint>` directly makes the header self-contained and it compiles cleanly across toolchains.

Differential Revision: D115313605


