### PR TITLE
Improve test assertions to show actual values on failure

### DIFF
--- a/tests/cuda/buffer_transfer_test.py
+++ b/tests/cuda/buffer_transfer_test.py
@@ -69,7 +69,7 @@ class TestTransferBufferToCuda(unittest.TestCase):
         self.assertTrue(cuda_tensor.is_cuda)
         self.assertEqual(cuda_tensor.device, torch.device(f"cuda:{DEFAULT_CUDA}"))
 
-        self.assertTrue(torch.allclose(cpu_tensor, cuda_tensor.cpu()))
+        torch.testing.assert_close(cpu_tensor, cuda_tensor.cpu())
 
     @parameterized.expand(
         [
@@ -128,7 +128,7 @@ class TestTransferBufferToCuda(unittest.TestCase):
             cuda_tensor = spdl.io.to_torch(cuda_buffer)
             self.assertTrue(cuda_tensor.is_cuda)
             self.assertEqual(cuda_tensor.device, torch.device(f"cuda:{DEFAULT_CUDA}"))
-            self.assertTrue(torch.allclose(cpu_tensor, cuda_tensor.cpu()))
+            torch.testing.assert_close(cpu_tensor, cuda_tensor.cpu())
 
             print("Asserting deleter was not yet called")
             self.assertFalse(deleter_called)
@@ -161,7 +161,7 @@ class TestArrayTransfer(unittest.TestCase):
             self.assertEqual(tensor.dtype, dtypes[array.dtype])
             self.assertEqual(tensor.shape, torch.Size(array.shape))
             self.assertEqual(tensor.device, torch.device(device))
-            self.assertTrue(torch.allclose(tensor, torch.from_numpy(array).to(device)))
+            torch.testing.assert_close(tensor, torch.from_numpy(array).to(device))
 
         for dtype in [np.uint8, np.int32, np.int64]:
             max_val = np.iinfo(dtype).max
@@ -182,7 +182,7 @@ class TestArrayTransfer(unittest.TestCase):
             self.assertEqual(cuda_tensor.dtype, cpu_tensor.dtype)
             self.assertEqual(cuda_tensor.shape, cpu_tensor.shape)
             self.assertEqual(cuda_tensor.device, device)
-            self.assertTrue(torch.allclose(cuda_tensor, cpu_tensor.to(device)))
+            torch.testing.assert_close(cuda_tensor, cpu_tensor.to(device))
 
         for dtype in [np.uint8, np.int32, np.int64]:
             max_val = np.iinfo(dtype).max
@@ -205,7 +205,7 @@ class TestArrayTransfer(unittest.TestCase):
         self.assertEqual(cuda_tensor.dtype, cpu_tensor.dtype)
         self.assertEqual(cuda_tensor.shape, cpu_tensor.shape)
         self.assertEqual(cuda_tensor.device, device)
-        self.assertTrue(torch.allclose(cuda_tensor, cpu_tensor.to(device)))
+        torch.testing.assert_close(cuda_tensor, cpu_tensor.to(device))
 
     def test_array_transfer_non_contiguous_numpy(self) -> None:
         """passing noncontiguous array/tensor to transfer_buffer works"""
@@ -224,7 +224,7 @@ class TestArrayTransfer(unittest.TestCase):
         self.assertEqual(tensor.dtype, torch.int64)
         self.assertEqual(tensor.shape, torch.Size(arr.shape))
         self.assertEqual(tensor.device, torch.device(device))
-        self.assertTrue(torch.allclose(tensor, torch.from_numpy(arr).to(device)))
+        torch.testing.assert_close(tensor, torch.from_numpy(arr).to(device))
 
     def test_array_transfer_smoke_test(self) -> None:
         """smoke test for transferring multiple arrays concurrently"""
@@ -253,4 +253,4 @@ class TestTransferCpu(unittest.TestCase):
             self.assertEqual(ref.dtype, cpu_tensor.dtype)
             self.assertEqual(ref.shape, cpu_tensor.shape)
             self.assertEqual(ref.device, cpu_tensor.device)
-            self.assertTrue(torch.allclose(ref, cpu_tensor))
+            torch.testing.assert_close(ref, cpu_tensor)

--- a/tests/cuda/nvjpeg_decode_test.py
+++ b/tests/cuda/nvjpeg_decode_test.py
@@ -44,9 +44,9 @@ class TestNvjpegDecode(unittest.TestCase):
         rgb_tensor = _test(sample.path, "rgb")
         bgr_tensor = _test(sample.path, "bgr")
 
-        self.assertTrue(torch.equal(rgb_tensor[0], bgr_tensor[2]))
-        self.assertTrue(torch.equal(rgb_tensor[1], bgr_tensor[1]))
-        self.assertTrue(torch.equal(rgb_tensor[2], bgr_tensor[0]))
+        torch.testing.assert_close(rgb_tensor[0], bgr_tensor[2])
+        torch.testing.assert_close(rgb_tensor[1], bgr_tensor[1])
+        torch.testing.assert_close(rgb_tensor[2], bgr_tensor[0])
 
     def test_decode_rubbish(self) -> None:
         """When decoding fails, it should raise an error instead of segfault then,

--- a/tests/cuda/pin_memory_test.py
+++ b/tests/cuda/pin_memory_test.py
@@ -88,7 +88,7 @@ class TestPinMemory(unittest.TestCase):
         self.assertEqual(tensor.shape, (10,))
         self.assertEqual(tensor.dtype, torch.int64)
         self.assertEqual(tensor.device, torch.device("cuda:0"))
-        self.assertTrue((vals == tensor.cpu().numpy()).all())
+        np.testing.assert_array_equal(tensor.cpu().numpy(), vals, strict=True)
 
     def test_pin_memory_convert_array_invalid_size(self) -> None:
         """convert_array fails if storage is small."""

--- a/tests/cuda/transfer_test.py
+++ b/tests/cuda/transfer_test.py
@@ -20,4 +20,4 @@ class TransferTest(unittest.TestCase):
         cuda = transfer_tensor(ref)
         print(cuda)
         self.assertEqual(cuda.device.type, "cuda")
-        self.assertTrue(torch.equal(cuda, ref.cuda()))
+        torch.testing.assert_close(cuda, ref.cuda())

--- a/tests/dataloader/sampler_test.py
+++ b/tests/dataloader/sampler_test.py
@@ -462,7 +462,7 @@ class TestDistributedSamplerWeighted(unittest.TestCase):
         print(f"{ref=}")
         print(f"{hyp=}")
 
-        self.assertTrue(np.allclose(hyp, ref, atol=1e-3))
+        np.testing.assert_allclose(hyp, ref, rtol=1e-5, atol=1e-3)
 
 
 class TestDistributedSamplerEmbedShuffle(unittest.TestCase):

--- a/tests/io/array_test.py
+++ b/tests/io/array_test.py
@@ -48,7 +48,7 @@ class TestLoadNpy(unittest.TestCase):
 
         data = _dump_npy(ref)
         recon = spdl.io.load_npy(data)
-        self.assertTrue(np.array_equal(recon, ref))
+        np.testing.assert_array_equal(recon, ref, strict=True)
 
         # Use bytearray to check if the change to the original is refrected to the recon
         # (which means that the recon is referring to the original, no copy)
@@ -56,12 +56,12 @@ class TestLoadNpy(unittest.TestCase):
         print(f"{id(data)=}")
         print(f"{id(recon.data.obj)=}")
         recon = spdl.io.load_npy(data)
-        self.assertTrue(np.array_equal(recon, ref))
+        np.testing.assert_array_equal(recon, ref, strict=True)
 
         self.assertTrue(np.any(recon))
         # Fill zeros. The header is cleared too, but it's already parsed, so not an issue.
         data[:] = b"\x00" * len(data)
-        self.assertFalse(np.any(recon))
+        np.testing.assert_array_equal(recon, 0)
 
     @parameterized.expand(
         [
@@ -81,7 +81,7 @@ class TestLoadNpy(unittest.TestCase):
 
         data = _dump_npy(ref)
         recon = spdl.io.load_npy(data)
-        self.assertTrue(np.array_equal(recon, ref))
+        np.testing.assert_array_equal(recon, ref, strict=True)
 
         # Use bytearray to check if the change to the original is refrected to the recon
         # (which means that the recon is referring to the original, no copy)
@@ -89,12 +89,12 @@ class TestLoadNpy(unittest.TestCase):
         print(f"{id(data)=}")
         print(f"{id(recon.data.obj)=}")
         recon = spdl.io.load_npy(data)
-        self.assertTrue(np.array_equal(recon, ref))
+        np.testing.assert_array_equal(recon, ref, strict=True)
 
         self.assertTrue(np.any(recon))
         # Fill zeros. The header is cleared too, but it's already parsed, so not an issue.
         data[:] = b"\x00" * len(data)
-        self.assertFalse(np.any(recon))
+        np.testing.assert_array_equal(recon, 0)
 
 
 ##############################################################################

--- a/tests/io/async_test.py
+++ b/tests/io/async_test.py
@@ -91,14 +91,14 @@ class TestDecodeAudio(unittest.TestCase):
         arr1 = _decode(num_frames=num_frames)
         self.assertEqual(arr1.dtype, np.int16)
         self.assertEqual(arr1.shape, (num_frames, 1))
-        self.assertTrue(np.all(arr1 == arr0[:num_frames]))
+        np.testing.assert_array_equal(arr1, arr0[:num_frames], strict=True)
 
         num_frames = 32000
         arr2 = _decode(num_frames=num_frames)
         self.assertEqual(arr2.dtype, np.int16)
         self.assertEqual(arr2.shape, (num_frames, 1))
-        self.assertTrue(np.all(arr2[:16000] == arr0))
-        self.assertTrue(np.all(arr2[16000:] == 0))
+        np.testing.assert_array_equal(arr2[:16000], arr0, strict=True)
+        np.testing.assert_array_equal(arr2[16000:], 0)
 
     def test_decode_audio_many_channels_6(self) -> None:
         """Can decode audio with more than 6 channels.
@@ -229,28 +229,30 @@ class TestDecodeVideo(unittest.TestCase):
         arr1 = _decode(num_frames=num_frames)
         self.assertEqual(arr1.dtype, np.uint8)
         self.assertEqual(arr1.shape, (num_frames, 240, 320, 3))
-        self.assertTrue(np.all(arr1 == arr0[:num_frames]))
+        np.testing.assert_array_equal(arr1, arr0[:num_frames], strict=True)
 
         num_frames = 100
         arr2 = _decode(num_frames=num_frames)
         self.assertEqual(arr2.dtype, np.uint8)
         self.assertEqual(arr2.shape, (num_frames, 240, 320, 3))
-        self.assertTrue(np.all(arr2[:50] == arr0))
-        self.assertTrue(np.all(arr2[50:] == arr2[50]))
+        np.testing.assert_array_equal(arr2[:50], arr0, strict=True)
+        np.testing.assert_array_equal(
+            arr2[50:], np.broadcast_to(arr2[50], arr2[50:].shape), strict=True
+        )
 
         num_frames = 100
         arr2 = _decode(num_frames=num_frames, pad_mode="black")
         self.assertEqual(arr2.dtype, np.uint8)
         self.assertEqual(arr2.shape, (num_frames, 240, 320, 3))
-        self.assertTrue(np.all(arr2[:50] == arr0))
-        self.assertTrue(np.all(arr2[50:] == 0))
+        np.testing.assert_array_equal(arr2[:50], arr0, strict=True)
+        np.testing.assert_array_equal(arr2[50:], 0)
 
         num_frames = 100
         arr2 = _decode(num_frames=num_frames, pad_mode="white")
         self.assertEqual(arr2.dtype, np.uint8)
         self.assertEqual(arr2.shape, (num_frames, 240, 320, 3))
-        self.assertTrue(np.all(arr2[:50] == arr0))
-        self.assertTrue(np.all(arr2[50:] == 255))
+        np.testing.assert_array_equal(arr2[:50], arr0, strict=True)
+        np.testing.assert_array_equal(arr2[50:], 255)
 
     def test_decode_video_frame_rate_pts(self) -> None:
         """Applying frame rate outputs correct PTS."""
@@ -267,7 +269,7 @@ class TestDecodeVideo(unittest.TestCase):
         pts = frames.get_timestamps()
         print(pts_ref, pts)
 
-        self.assertTrue(np.all(pts_ref[::2] == pts))
+        np.testing.assert_array_equal(pts_ref[::2], pts, strict=True)
 
 
 class TestConvertFrames(unittest.TestCase):

--- a/tests/io/frames_clone_test.py
+++ b/tests/io/frames_clone_test.py
@@ -56,7 +56,7 @@ class TestCloneFrames(unittest.TestCase):
         array1 = _load_from_frames(frames1)
         array2 = _load_from_frames(frames2)
 
-        self.assertTrue(np.all(array1 == array2))
+        np.testing.assert_array_equal(array1, array2, strict=True)
 
     @parameterized.expand(
         [
@@ -113,4 +113,4 @@ class TestCloneFrames(unittest.TestCase):
         arrays = [_load_from_frames(c) for c in clones]
 
         for i in range(N):
-            self.assertTrue(np.all(array == arrays[i]))
+            np.testing.assert_array_equal(array, arrays[i], strict=True)

--- a/tests/io/image_decoding_test.py
+++ b/tests/io/image_decoding_test.py
@@ -6,6 +6,7 @@
 
 # pyre-unsafe
 
+import operator
 import unittest
 
 import numpy as np
@@ -19,6 +20,18 @@ from ..fixture import FFMPEG_CLI, get_sample, get_samples, load_ref_data, load_r
 
 def _load_image(src, filter_desc="format=pix_fmts=rgb24"):
     return spdl.io.to_numpy(spdl.io.load_image(src, filter_desc=filter_desc))
+
+
+def _assert_all_ge(x, val) -> None:
+    np.testing.assert_array_compare(
+        operator.ge, x, val, header=f"Arrays are not all >= {val}"
+    )
+
+
+def _assert_all_le(x, val) -> None:
+    np.testing.assert_array_compare(
+        operator.le, x, val, header=f"Arrays are not all <= {val}"
+    )
 
 
 class TestDecodeImage(unittest.TestCase):
@@ -44,8 +57,8 @@ class TestDecodeImage(unittest.TestCase):
 
         ffmpeg8 = get_ffmpeg_versions()["libavutil"][0] >= 60
 
-        self.assertTrue(np.all(hyp[..., :32] == 65535 if ffmpeg8 else 65022))
-        self.assertTrue(np.all(hyp[..., 32:] == 0 if ffmpeg8 else 256))
+        np.testing.assert_array_equal(hyp[..., :32], 65535 if ffmpeg8 else 65022)
+        np.testing.assert_array_equal(hyp[..., 32:], 0 if ffmpeg8 else 256)
 
     def test_decode_image_16be_rgb24(self) -> None:
         """Can decode gray16 PNG image (16be) as rgb24"""
@@ -67,8 +80,8 @@ class TestDecodeImage(unittest.TestCase):
         ref = load_ref_image(sample.path, shape)
         np.testing.assert_array_equal(hyp, ref, strict=True)
 
-        self.assertTrue(np.all(hyp[:, :32, :] == 255))
-        self.assertTrue(np.all(hyp[:, 32:, :] == 0))
+        np.testing.assert_array_equal(hyp[:, :32, :], 255)
+        np.testing.assert_array_equal(hyp[:, 32:, :], 0)
 
     def test_decode_image_yuvj422_native(self) -> None:
         """Can decode yuvj422p JPEG image as-is."""
@@ -153,17 +166,17 @@ class TestDecodeImage(unittest.TestCase):
 
         red, green, blue = hyp[:, :width], hyp[:, width:2*width], hyp[:, 2*width:]
 
-        self.assertTrue(np.all(red[..., 0] >= 254))
-        self.assertTrue(np.all(red[..., 1] <= 1))
-        self.assertTrue(np.all(red[..., 2] == 0))
+        _assert_all_ge(red[..., 0], 254)
+        _assert_all_le(red[..., 1], 1)
+        np.testing.assert_array_equal(red[..., 2], 0)
 
-        self.assertTrue(np.all(green[..., 0] == 0))
-        self.assertTrue(np.all(green[..., 1] >= 253))
-        self.assertTrue(np.all(green[..., 2] <= 1))
+        np.testing.assert_array_equal(green[..., 0], 0)
+        _assert_all_ge(green[..., 1], 253)
+        _assert_all_le(green[..., 2], 1)
 
-        self.assertTrue(np.all(blue[..., 0] <= 1))
-        self.assertTrue(np.all(blue[..., 1] <= 1))
-        self.assertTrue(np.all(blue[..., 2] >= 254))
+        _assert_all_le(blue[..., 0], 1)
+        _assert_all_le(blue[..., 1], 1)
+        _assert_all_ge(blue[..., 2], 254)
 
     def test_decode_image_yuvj444p_native(self) -> None:
         """Can decode yuvj444p JPEG image as-is."""
@@ -335,19 +348,19 @@ class TestLoadImageBatch(unittest.TestCase):
 
         left, middle, right = arr[..., :w, :], arr[..., w:-w, :], arr[..., -w:, :]
         # Red
-        self.assertTrue(np.all(left[..., 0] >= 252))
-        self.assertTrue(np.all(left[..., 1] == 0))
-        self.assertTrue(np.all(left[..., 2] == 0))
+        _assert_all_ge(left[..., 0], 252)
+        np.testing.assert_array_equal(left[..., 1], 0)
+        np.testing.assert_array_equal(left[..., 2], 0)
 
         # Green
-        self.assertTrue(np.all(middle[..., 0] == 0))
-        self.assertTrue(np.all(middle[..., 1] >= 253))
-        self.assertTrue(np.all(middle[..., 2] == 0))
+        np.testing.assert_array_equal(middle[..., 0], 0)
+        _assert_all_ge(middle[..., 1], 253)
+        np.testing.assert_array_equal(middle[..., 2], 0)
 
         # Blue
-        self.assertTrue(np.all(right[..., 0] == 0))
-        self.assertTrue(np.all(right[..., 1] == 0))
-        self.assertTrue(np.all(right[..., 2] >= 253))
+        np.testing.assert_array_equal(right[..., 0], 0)
+        np.testing.assert_array_equal(right[..., 1], 0)
+        _assert_all_ge(right[..., 2], 253)
 
     def test_batch_decode_image_handle_failure(self) -> None:
         """load_image_batch dismisses failures when strict=False."""

--- a/tests/io/packets_test.py
+++ b/tests/io/packets_test.py
@@ -165,7 +165,7 @@ class TestClonePackets(unittest.TestCase):
         array1 = _load_from_packets(packets1)
         array2 = _load_from_packets(packets2)
 
-        self.assertTrue(np.all(array1 == array2))
+        np.testing.assert_array_equal(array1, array2, strict=True)
 
     @parameterized.expand(
         [
@@ -226,7 +226,7 @@ class TestClonePackets(unittest.TestCase):
         arrays = [_load_from_packets(c) for c in clones]
 
         for i in range(N):
-            self.assertTrue(np.all(array == arrays[i]))
+            np.testing.assert_array_equal(array, arrays[i], strict=True)
 
 
 class TestSampleDecodingTime(unittest.TestCase):
@@ -261,7 +261,7 @@ class TestSampleDecodingTime(unittest.TestCase):
         array = spdl.io.to_numpy(buffer)
 
         print(f"{elapsed_ref=}, {elapsed=}")
-        self.assertTrue(np.all(array == array_ref))
+        np.testing.assert_array_equal(array, array_ref, strict=True)
 
         # should be much faster than 2x
         self.assertGreater(elapsed_ref / 2, elapsed)
@@ -297,7 +297,7 @@ class TestSampleDecodingTime(unittest.TestCase):
         array = spdl.io.to_numpy(buffer)
 
         print(f"{elapsed_ref=}, {elapsed=}")
-        self.assertTrue(np.all(array == array_ref))
+        np.testing.assert_array_equal(array, array_ref, strict=True)
 
         # should be much faster than 2x
         self.assertGreater(elapsed_ref / 2, elapsed)
@@ -324,7 +324,7 @@ class TestPacketLen(unittest.TestCase):
         self.assertEqual(num_frames, 25)
 
         array = spdl.io.to_numpy(spdl.io.convert_frames(frames))
-        self.assertTrue(np.all(array == ref_array[25:50]))
+        np.testing.assert_array_equal(array, ref_array[25:50], strict=True)
 
     @parameterized.expand(
         [
@@ -405,7 +405,7 @@ class TestSampleDecodingWindow(unittest.TestCase):
         frames = spdl.io.decode_packets(packets.clone())
         self.assertEqual(len(frames), 25)
         array = spdl.io.to_numpy(spdl.io.convert_frames(frames))
-        self.assertTrue(np.all(array == ref_array[25:50]))
+        np.testing.assert_array_equal(array, ref_array[25:50], strict=True)
 
         # Sample decode should offset the indices
         indices = list(range(0, 25, 2))
@@ -414,7 +414,7 @@ class TestSampleDecodingWindow(unittest.TestCase):
         self.assertEqual(len(frames), 13)
         array = spdl.io.to_numpy(spdl.io.convert_frames(frames))
         print(f"{array.shape=}, {ref_array[25:50:2].shape=}")
-        self.assertTrue(np.all(array == ref_array[25:50:2]))
+        np.testing.assert_array_equal(array, ref_array[25:50:2], strict=True)
 
     def test_sample_decoding_window_sync(self) -> None:
         """sample_decode_video returns the correct frame when timestamps is specified."""
@@ -436,7 +436,7 @@ class TestSampleDecodingWindow(unittest.TestCase):
         frames = spdl.io.decode_packets(packets.clone())
         self.assertEqual(len(frames), 25)
         array = spdl.io.to_numpy(spdl.io.convert_frames(frames))
-        self.assertTrue(np.all(array == ref_array[25:50]))
+        np.testing.assert_array_equal(array, ref_array[25:50], strict=True)
 
         # Sample decode should offset the indices
         indices = list(range(0, 25, 2))
@@ -445,7 +445,7 @@ class TestSampleDecodingWindow(unittest.TestCase):
         self.assertEqual(len(frames), 13)
         array = spdl.io.to_numpy(spdl.io.convert_frames(frames))
         print(f"{array.shape=}, {ref_array[25:50:2].shape=}")
-        self.assertTrue(np.all(array == ref_array[25:50:2]))
+        np.testing.assert_array_equal(array, ref_array[25:50:2], strict=True)
 
 
 class TestSampleDecodeVideoDefaultColorSpace(unittest.TestCase):
@@ -510,7 +510,7 @@ class TestSamplePacketGetTimestamps(unittest.TestCase):
 
         packets = spdl.io.demux_video(sample.path)
         ts = packets.get_timestamps()
-        self.assertTrue(np.array_equal(ts, [t / 25 for t in range(10)]))
+        np.testing.assert_array_equal(ts, [t / 25 for t in range(10)])
 
 
 class TestUrl(unittest.TestCase):

--- a/tests/io/streaming_decoding_test.py
+++ b/tests/io/streaming_decoding_test.py
@@ -139,7 +139,7 @@ class TestStreamingVideoDemuxing(unittest.TestCase):
         #     Image.fromarray(ref[i]).save(f"ref_{i}.png")
         #     Image.fromarray(hyp[i] - ref[i]).save(f"diff_{i}.png")
 
-        self.assertTrue(np.array_equal(hyp, ref))
+        np.testing.assert_array_equal(hyp, ref, strict=True)
 
     def test_demuxer_get_codec(self) -> None:
         cmd = f'{FFMPEG_CLI} -hide_banner -y -f lavfi -i testsrc -f lavfi -i sine=sample_rate=48000 -af "pan=stereo|c0=FR|c1=FR" -frames:v 30 sample.mp4'

--- a/tests/io/video_frame_slice_test.py
+++ b/tests/io/video_frame_slice_test.py
@@ -43,10 +43,10 @@ class TestVideoFramesGetitem(unittest.TestCase):
         arr = _to_numpy(frames)
 
         self.assertEqual(len(f2), 50)
-        self.assertTrue(np.array_equal(arr[::2], _to_numpy(f2)))
+        np.testing.assert_array_equal(arr[::2], _to_numpy(f2), strict=True)
 
         self.assertEqual(len(f3), 34)
-        self.assertTrue(np.array_equal(arr[::3], _to_numpy(f3)))
+        np.testing.assert_array_equal(arr[::3], _to_numpy(f3), strict=True)
 
     def test_video_frames_getitem_int(self) -> None:
         """VideoFrames.__getitem__ works for index input"""
@@ -62,7 +62,7 @@ class TestVideoFramesGetitem(unittest.TestCase):
         arr = _to_numpy(frames)
         for i in range(n):
             arr0 = _to_numpy(frames_split[i])
-            self.assertTrue(np.array_equal(arr0, arr[i]))
+            np.testing.assert_array_equal(arr0, arr[i], strict=True)
 
     def test_video_frames_getitem_negative_int(self) -> None:
         """VideoFrames.__getitem__ works for negative index input"""
@@ -78,7 +78,7 @@ class TestVideoFramesGetitem(unittest.TestCase):
         arr = _to_numpy(frames)
         for i in range(n):
             arr0 = _to_numpy(frames_split[i])
-            self.assertTrue(np.array_equal(arr0, arr[-i - 1]))
+            np.testing.assert_array_equal(arr0, arr[-i - 1], strict=True)
 
     def test_video_frames_iterate(self) -> None:
         """VideoFrames can be iterated"""
@@ -94,7 +94,7 @@ class TestVideoFramesGetitem(unittest.TestCase):
         array = _to_numpy(frames)
 
         for i in range(n):
-            self.assertTrue(np.array_equal(array[i], arrs[i]))
+            np.testing.assert_array_equal(array[i], arrs[i], strict=True)
 
 
 class TestVideoFramesListSlice(unittest.TestCase):
@@ -117,7 +117,7 @@ class TestVideoFramesListSlice(unittest.TestCase):
         array = _to_numpy(sampled_frames)
 
         for i in range(len(idx)):
-            self.assertTrue(np.array_equal(array[i], refs[idx[i]]))
+            np.testing.assert_array_equal(array[i], refs[idx[i]], strict=True)
 
     def test_video_frames_list_slice_empty(self) -> None:
         """VideoFrames can be sliced with an empty list"""

--- a/tests/io/zero_copy_bytes_passing_test.py
+++ b/tests/io/zero_copy_bytes_passing_test.py
@@ -40,7 +40,7 @@ class TestDecodeBytes(unittest.TestCase):
             hyp = _decode("audio", f.read())
 
         self.assertEqual(hyp.shape, (1, 48000))
-        self.assertTrue(np.all(ref == hyp))
+        np.testing.assert_array_equal(hyp, ref, strict=True)
 
     def test_decode_video_bytes(self) -> None:
         """video can be decoded from bytes."""
@@ -52,7 +52,7 @@ class TestDecodeBytes(unittest.TestCase):
             hyp = _decode("video", f.read())
 
         self.assertEqual(hyp.shape, (1000, 240, 320, 3))
-        self.assertTrue(np.all(ref == hyp))
+        np.testing.assert_array_equal(hyp, ref, strict=True)
 
     def test_demux_image_bytes(self) -> None:
         """Image (gray) can be decoded from bytes."""
@@ -64,4 +64,4 @@ class TestDecodeBytes(unittest.TestCase):
             hyp = _decode("image", f.read())
 
         self.assertEqual(hyp.shape, (240, 320, 3))
-        self.assertTrue(np.all(ref == hyp))
+        np.testing.assert_array_equal(hyp, ref, strict=True)

--- a/tests/pipeline/arena_pool_test.py
+++ b/tests/pipeline/arena_pool_test.py
@@ -201,7 +201,7 @@ class SharedMemorySegmentPoolTest(unittest.TestCase):
         arr = np.arange(1000, dtype=np.int64)
         out = _restore(_offload({"a": arr}, writer, registry), reader, registry)
         view = cast(dict[str, Any], out)["a"]
-        self.assertTrue(np.array_equal(view, arr))
+        np.testing.assert_array_equal(view, arr, strict=True)
         # Mutating the segment's first int64 is observed through the view, which
         # proves the view aliases shared memory rather than a copy.
         struct.pack_into("<q", pool._segment(0), 0, 999)

--- a/tests/pipeline/arena_registry_test.py
+++ b/tests/pipeline/arena_registry_test.py
@@ -133,13 +133,11 @@ class NumpyHandlerTest(unittest.TestCase):
 
         copied, anchor = _NumpyHandler().from_buffer(_copy_view(buf), meta, False)
         copied = cast(Any, copied)
-        self.assertTrue(np.array_equal(copied, arr))
-        self.assertEqual(copied.dtype, arr.dtype)
-        self.assertEqual(copied.shape, arr.shape)
+        np.testing.assert_array_equal(copied, arr, strict=True)
         self.assertIsNone(anchor)
 
         viewed, view_anchor = _NumpyHandler().from_buffer(_copy_view(buf), meta, True)
-        self.assertTrue(np.array_equal(cast(Any, viewed), arr))
+        np.testing.assert_array_equal(cast(Any, viewed), arr, strict=True)
         self.assertIsNotNone(view_anchor)
 
 
@@ -177,11 +175,11 @@ class TorchHandlerTest(unittest.TestCase):
         buf, meta = _TorchHandler().get_buffer(t)
 
         copied, anchor = _TorchHandler().from_buffer(_copy_view(buf), meta, False)
-        self.assertTrue(torch.equal(cast(Any, copied), t))
+        torch.testing.assert_close(cast(Any, copied), t)
         self.assertIsNone(anchor)
 
         viewed, view_anchor = _TorchHandler().from_buffer(_copy_view(buf), meta, True)
-        self.assertTrue(torch.equal(cast(Any, viewed), t))
+        torch.testing.assert_close(cast(Any, viewed), t)
         self.assertIsNotNone(view_anchor)
 
 

--- a/tests/pipeline/arena_ring_test.py
+++ b/tests/pipeline/arena_ring_test.py
@@ -266,5 +266,4 @@ class OffloadRestoreTest(unittest.TestCase):
             dict[str, Any],
             _restore(_offload({"a": arr}, writer, registry), reader, registry),
         )
-        self.assertTrue(np.array_equal(out["a"], arr))
-        self.assertEqual(out["a"].dtype, arr.dtype)
+        np.testing.assert_array_equal(out["a"], arr, strict=True)


### PR DESCRIPTION
Replace assertion patterns that don't show values on failure with NumPy and PyTorch testing utilities.

Migrate from `self.assertTrue(np.all(...))` and `self.assertTrue(torch.allclose(...))` to `np.testing.assert_array_equal`, `np.testing.assert_array_compare`, `np.testing.assert_allclose`, and `torch.testing.assert_close`. These testing utilities automatically include summaries of actual vs expected values in their error messages, making test failures much easier to debug.