### PR TITLE
[pipeline] 1/3 Add a non-blocking sink read 

### DIFF
--- a/src/spdl/pipeline/_builder.py
+++ b/src/spdl/pipeline/_builder.py
@@ -64,6 +64,14 @@ def _has_ordered_pipe(cfg: object) -> bool:
     return False
 
 
+def _validate_buffer_size(buffer_size: int) -> None:
+    """Reject a ``buffer_size`` that cannot form a transfer."""
+    if buffer_size < 1:
+        raise ValueError(
+            f"`buffer_size` must be a positive integer. Got: {buffer_size}."
+        )
+
+
 def _validate_executor_regions(
     pipes: Sequence[
         PipeConfig
@@ -78,8 +86,8 @@ def _validate_executor_regions(
     Stateless scan (a pipeline starts on the main process). Rejects: a subinterpreter region on
     Python < 3.14; a stage using ``output_order="input"`` inside a region (including one nested
     in a ``path_variants`` branch, since order cannot be preserved across independent workers); an
-    empty region (a ``.to(...)`` marker with no stages before the next marker/sink); and a region
-    left open at the sink.
+    empty region (a ``.to(...)`` marker with no stages before the next marker/sink); a region
+    left open at the sink; and an invalid ``buffer_size``.
     """
     in_region = False
     region_has_stage = False
@@ -96,6 +104,7 @@ def _validate_executor_regions(
             target = p.target
             in_region = not isinstance(target, _MainProcess)
             region_has_stage = False
+            _validate_buffer_size(p.buffer_size)
             if isinstance(
                 target, InterpreterPoolExecutorConfig
             ) and sys.version_info < (3, 14):
@@ -318,10 +327,15 @@ class PipelineBuilder(Generic[T, U]):
         self,
         target: "ProcessPoolExecutorConfig | InterpreterPoolExecutorConfig | _MainProcess",
         /,
+        *,
+        buffer_size: int = 1,
     ) -> "PipelineBuilder[T, U]":
         """**[Experimental]** Designate where the subsequent stages execute.
 
         .. versionadded:: 0.6.0
+
+        .. versionadded:: 0.7.0
+           The ``buffer_size`` argument.
 
         Opens (or closes) an *execution region*: every stage added after this call runs on
         ``target`` until the next :py:meth:`to`. A pipeline starts on the main process, so a
@@ -356,6 +370,37 @@ class PipelineBuilder(Generic[T, U]):
                 so the pipeline stays expressible as static config. To run a single stage on a
                 custom executor, use ``pipe(executor=...)`` instead.
 
+            buffer_size: At most this many items are buffered into a single transfer *at
+                this marker*. Default ``1`` (one item per transfer).
+
+                Crossing a process boundary costs a fixed amount per transfer (pickling, queue
+                handoff, and — for tensors — a shared-memory allocation) regardless of how
+                small the item is. Buffering amortizes that cost over several items.
+
+                Each marker sizes the handoff that happens where it sits, so a region's two
+                directions are configured independently::
+
+                    .to(pool, buffer_size=32)      # 32 rows per transfer into the workers
+                    .aggregate(batch_size)
+                    .to(MAIN_PROCESS, buffer_size=2)   # 2 batches per transfer coming back
+
+                Keeping them separate matters because the two directions rarely carry
+                comparable items: with an :py:meth:`aggregate` inside the region, single rows
+                go in and whole batches come back, so one number cannot be right for both.
+
+                It is an upper bound, not a fixed grouping: a partial buffer is flushed at the
+                end of a stream and at every epoch boundary, so the last transfer of each is
+                usually short.
+
+                The buffering is **transparent**: stages on both sides still receive individual
+                items, so ``buffer_size`` is independent of any :py:meth:`aggregate` you place
+                inside or outside the region.
+
+                The trade-off is latency: up to ``buffer_size - 1`` items are held while a
+                transfer fills, so a value well above what the producing side can keep up with
+                delays the first results. It also raises the in-flight item bound, since each
+                queued transfer now holds up to ``buffer_size`` items.
+
         .. note::
 
            The region must be closed with ``to(MAIN_PROCESS)`` before :py:meth:`add_sink`, a
@@ -377,7 +422,12 @@ class PipelineBuilder(Generic[T, U]):
                 "`to()` target must be a ProcessPoolExecutorConfig, InterpreterPoolExecutorConfig, or "
                 f"MAIN_PROCESS. Got: {type(target).__name__}."
             )
-        self._process_args.append(PlacementConfig(target=target))
+        # Also re-checked at build time (a config can be assembled without the builder), but
+        # raising here points at the offending `to()` call rather than at `build()`.
+        _validate_buffer_size(buffer_size)
+        self._process_args.append(
+            PlacementConfig(target=target, buffer_size=buffer_size)
+        )
         return self
 
     def path_variants(

--- a/src/spdl/pipeline/_components/_subprocess_pipe.py
+++ b/src/spdl/pipeline/_components/_subprocess_pipe.py
@@ -32,6 +32,14 @@ The wire protocol uses small integer message kinds (not sentinel objects): a sen
 onto a multiprocessing queue is a different object on the other side, so identity comparison
 would not survive the trip. ``_EPOCH_END`` itself never crosses — it is translated to the
 ``_EPOCH`` tag on the way in and re-emitted locally on the way out.
+
+``_ITEM`` and ``_RESULT`` payloads are **lists** of items, not single items, so a region whose
+pool spec sets ``buffer_size=N`` amortizes the fixed per-transfer cost (pickling, queue
+handoff, shared-memory allocation) over up to N items. An unbuffered region simply sends
+one-element lists. The packing and unpacking live entirely at this boundary — the feeder here
+and the worker source/sink in :py:mod:`spdl.pipeline._subprocess_pipeline_pool` — so the
+region's stages, and every stage outside it, still see individual items. Nothing assumes the two
+directions use the same chunk size, or that the region's output cardinality matches its input's.
 """
 
 from __future__ import annotations
@@ -61,13 +69,13 @@ __all__ = [
 ]
 
 # Input-queue message kinds (this stage -> worker).
-_ITEM = 0  # (_ITEM, value): one item for the sub-pipeline source
+_ITEM = 0  # (_ITEM, [value, ...]): one transfer of items for the sub-pipeline source
 _SESSION_END = 1  # (_SESSION_END, None): end of one input stream; finish the session
 _POOL_SHUTDOWN = 2  # (_POOL_SHUTDOWN, None): tear the worker down entirely
 _EPOCH = 3  # (_EPOCH, None): end of the current epoch (continuous mode); keep the worker alive
 
 # Output-queue message kinds (worker -> this stage).
-_RESULT = 0  # (_RESULT, value): one produced item
+_RESULT = 0  # (_RESULT, [value, ...]): one transfer of produced items
 _ERROR = 1  # (_ERROR, exc): the sub-pipeline failed
 _DONE = 2  # (_DONE, None): a worker finished (session end, or exiting)
 _EPOCH_DONE = (
@@ -138,8 +146,18 @@ async def _feed(
     abort: asyncio.Event,
     feeder_idle: asyncio.Event,
     put_stop: threading.Event,
+    buffer_size: int = 1,
 ) -> None:
-    """Round-robin items across the per-worker queues, then end every worker's session.
+    """Round-robin transfers across the per-worker queues, then end every worker's session.
+
+    Items are accumulated into a chunk of up to ``buffer_size`` and sent as one
+    ``_ITEM`` message; whole chunks, not individual items, are what round-robin across the
+    workers. The tail chunk is flushed before the end markers, so no item is left behind.
+
+    Accumulation blocks: filling a chunk means waiting for ``buffer_size`` items.
+    Flushing early on a momentarily empty upstream is pointless here, because the inter-stage
+    queues are only two deep — a non-blocking drain could never gather more than two or three
+    items and ``buffer_size`` would have no effect.
 
     Sends exactly one ``_SESSION_END`` onto each worker's own queue, so every worker ends
     its session exactly once. Per-worker queues (rather than one shared queue the workers
@@ -151,7 +169,8 @@ async def _feed(
 
     ``abort`` is set by :py:func:`_collect` on a worker error; once set, forwarding stops early
     and only the per-worker ``_SESSION_END`` markers are sent, so the workers wind down their
-    current sessions instead of churning through the rest of the stream.
+    current sessions instead of churning through the rest of the stream. A partly-filled chunk
+    is dropped on that path along with everything else still in flight.
 
     The next-item ``get`` is raced against ``abort`` rather than awaited directly: on the error
     path the feeder is often parked here waiting on a slow/idle upstream, and ``abort`` must still
@@ -164,6 +183,19 @@ async def _feed(
     abort_wait = create_task(abort.wait())
     i = 0
     n = len(in_qs)
+    buf: list[Any] = []
+    reached_eof = False
+
+    async def _flush() -> None:
+        nonlocal buf, i
+        if not buf:
+            return
+        chunk, buf = buf, []
+        await loop.run_in_executor(
+            executor, _put, in_qs[i % n], (_ITEM, chunk), put_stop
+        )
+        i += 1
+
     try:
         while not abort.is_set():
             get_task = create_task(input_queue.get())
@@ -179,13 +211,17 @@ async def _feed(
                 get_task.cancel()
                 feeder_idle.clear()
             if is_eof(item):
+                reached_eof = True
                 break
-            await loop.run_in_executor(
-                executor, _put, in_qs[i % n], (_ITEM, item), put_stop
-            )
-            i += 1
+            buf.append(item)
+            if len(buf) >= buffer_size:
+                await _flush()
     finally:
         abort_wait.cancel()
+    # Only the clean end-of-stream flushes its tail. Keyed on ``reached_eof`` rather than on
+    # ``abort`` so an abort racing the EOF break cannot discard a legitimate tail chunk.
+    if reached_eof:
+        await _flush()
     # Concurrent so a full/slow worker queue does not block the markers to the others.
     await asyncio.gather(
         *(
@@ -213,6 +249,9 @@ async def _collect(
     pipeline is already failing, and forwarding them could block on a no-longer-drained output
     queue.
 
+    Each ``_RESULT`` carries a list of items, which is unpacked onto the output queue one item
+    at a time so the region's buffering stays invisible downstream.
+
     The stall guard is suppressed while ``feeder_idle`` is set: an idle feeder means nothing is
     dispatched and no worker message is due, so a quiet ``out_q`` is input starvation, not a
     dead worker.
@@ -238,7 +277,8 @@ async def _collect(
                 error = payload
                 abort.set()
         elif kind == _RESULT and error is None:
-            await output_queue.put(payload)
+            for item in payload:
+                await output_queue.put(item)
     if error is not None:
         raise error
 
@@ -255,13 +295,23 @@ async def _feed_continuous(
     epoch_barrier: asyncio.Event,
     feeder_idle: asyncio.Event,
     put_stop: threading.Event,
+    buffer_size: int = 1,
 ) -> None:
-    """Round-robin items to per-worker queues; broadcast and barrier each epoch boundary.
+    """Round-robin transfers to per-worker queues; broadcast and barrier each epoch boundary.
+
+    Items are accumulated into chunks of up to ``buffer_size`` and sent as one
+    ``_ITEM`` message each, exactly as in :py:func:`_feed`.
 
     On an epoch boundary the next epoch's items must not be fed until every worker has drained
     the current epoch (otherwise results from two epochs would interleave). The feeder therefore
     broadcasts ``_EPOCH`` to all workers and waits on ``epoch_barrier``, which the collector sets
     once it has emitted the epoch's single ``_EPOCH_END`` downstream.
+
+    A partly-filled chunk **must** be flushed before that broadcast: an ``_ITEM`` put after the
+    ``_EPOCH`` marker would be drained by the worker as part of the *next* epoch, so the tail of
+    one epoch would silently reappear in the following one. Flushing first keeps the chunk ahead
+    of the marker on each worker's FIFO queue. The same applies to the ``_POOL_SHUTDOWN``
+    broadcast at end of stream.
 
     A single shared ``epoch_barrier`` is sufficient (rather than one per epoch) only because the
     feeder cannot advance past a boundary until the collector releases it: the feeder and
@@ -277,22 +327,35 @@ async def _feed_continuous(
 
     i = 0
     n = len(in_qs)
+    buf: list[Any] = []
+
+    async def _flush() -> None:
+        nonlocal buf, i
+        if not buf:
+            return
+        chunk, buf = buf, []
+        await loop.run_in_executor(
+            executor, _put, in_qs[i % n], (_ITEM, chunk), put_stop
+        )
+        i += 1
+
     while True:
         feeder_idle.set()
         item = await input_queue.get()
         feeder_idle.clear()
         if is_eof(item):
+            await _flush()
             await _broadcast((_POOL_SHUTDOWN, None))
             break
         if is_epoch_end(item):
+            await _flush()
             epoch_barrier.clear()
             await _broadcast((_EPOCH, None))
             await epoch_barrier.wait()
             continue
-        await loop.run_in_executor(
-            executor, _put, in_qs[i % n], (_ITEM, item), put_stop
-        )
-        i += 1
+        buf.append(item)
+        if len(buf) >= buffer_size:
+            await _flush()
 
 
 async def _collect_continuous(
@@ -330,7 +393,8 @@ async def _collect_continuous(
         last_progress = time.monotonic()
         kind, payload = res
         if kind == _RESULT:
-            await output_queue.put(payload)
+            for item in payload:
+                await output_queue.put(item)
         elif kind == _EPOCH_DONE:
             workers_at_boundary += 1
             if workers_at_boundary >= num_workers:
@@ -365,6 +429,8 @@ async def _subprocess_pipeline(
     """
     in_qs, out_q = handle.in_qs, handle.out_q
     num_workers = handle.max_workers
+    # Only the inbound size matters here; the worker owns the outbound one.
+    buffer_size = handle.input_buffer_size
     # One thread parked per concurrent blocking op: a put per input queue (the feeder broadcasts
     # epoch/session-end markers across all of them at once) plus the collector get.
     max_threads = len(in_qs) + 1
@@ -384,7 +450,13 @@ async def _subprocess_pipeline(
             epoch_barrier = asyncio.Event()
             feeder = create_task(
                 _feed_continuous(
-                    input_queue, in_qs, executor, epoch_barrier, feeder_idle, put_stop
+                    input_queue,
+                    in_qs,
+                    executor,
+                    epoch_barrier,
+                    feeder_idle,
+                    put_stop,
+                    buffer_size,
                 )
             )
             collector = create_task(
@@ -401,7 +473,15 @@ async def _subprocess_pipeline(
             # Set by the collector on a worker error so the feeder stops forwarding new items.
             abort = asyncio.Event()
             feeder = create_task(
-                _feed(input_queue, in_qs, executor, abort, feeder_idle, put_stop)
+                _feed(
+                    input_queue,
+                    in_qs,
+                    executor,
+                    abort,
+                    feeder_idle,
+                    put_stop,
+                    buffer_size,
+                )
             )
             collector = create_task(
                 _collect(out_q, num_workers, output_queue, executor, abort, feeder_idle)

--- a/src/spdl/pipeline/_fuse.py
+++ b/src/spdl/pipeline/_fuse.py
@@ -161,6 +161,8 @@ def _build_fused_stage_core(
     user_initargs: tuple[Any, ...],
     report_stats_interval: float,
     continuous: bool,
+    input_buffer_size: int,
+    output_buffer_size: int,
 ) -> tuple[_SubprocessPipelineConfig, _SubprocessPipelinePool]:
     """Spawn a worker pool that runs ``stages`` as a nested pipeline; return the pool and its
     replacement stage. Called by :py:func:`_build_fused_stage_from_spec` once the pool
@@ -188,8 +190,20 @@ def _build_fused_stage_core(
         initializer,
         (),
         continuous=continuous,
+        input_buffer_size=input_buffer_size,
+        output_buffer_size=output_buffer_size,
     )
     name = "subprocess_pipeline(" + "+".join(_stage_name(s) for s in stages) + ")"
+    # Surface the transfer granularity in stats output; a buffered boundary changes how this
+    # stage's queue occupancy should be read. Each direction appears only when it is not the
+    # default, since the two are configured separately.
+    sizes = [
+        f"{label}={size}"
+        for label, size in (("in", input_buffer_size), ("out", output_buffer_size))
+        if size != 1
+    ]
+    if sizes:
+        name += "[buffer_size " + " ".join(sizes) + "]"
     return _SubprocessPipelineConfig(name=name, handle=pool.make_handle()), pool
 
 
@@ -199,13 +213,17 @@ def _build_fused_stage_from_spec(
     backend: _PoolBackend,
     report_stats_interval: float,
     continuous: bool,
+    input_buffer_size: int,
+    output_buffer_size: int,
 ) -> tuple[_SubprocessPipelineConfig, _SubprocessPipelinePool]:
     """Build the worker pool and replacement stage for one ``.to()`` region, reading the pool
     parameters from ``spec``. ``num_threads`` for the nested pipeline is the sum of the region
     stages' concurrency plus one for its source, ``max_workers`` falls back to the CPU count,
     and ``report_stats_interval`` is inherited from
     :py:func:`~spdl.pipeline._build.build_pipeline`. ``backend`` (process or subinterpreter) is
-    chosen by the caller from the spec type."""
+    chosen by the caller from the spec type. The two buffer sizes come from the region's
+    :py:class:`~spdl.pipeline.defs.PlacementConfig` markers, not from ``spec``: they describe
+    the boundary crossings rather than the pool."""
     # ``+ _SOURCE_THREADS``: the nested pipeline's source is a *blocking* read of the worker's
     # input queue, dispatched onto the very same thread pool as the region's ops. Sizing that
     # pool by op concurrency alone lets the read occupy every thread, so the ops cannot drain
@@ -222,6 +240,8 @@ def _build_fused_stage_from_spec(
         user_initargs=spec.initargs,
         report_stats_interval=report_stats_interval,
         continuous=continuous,
+        input_buffer_size=input_buffer_size,
+        output_buffer_size=output_buffer_size,
     )
 
 
@@ -269,9 +289,13 @@ def _fuse_marked_regions(
     target: ProcessPoolExecutorConfig | InterpreterPoolExecutorConfig | _MainProcess = (
         _MainProcess()
     )
+    # Tracked alongside ``target``: the marker that opens a region sizes the transfers into
+    # it, and the marker that closes it sizes the results coming back. Adjacent regions each
+    # get their own, and the marker between them sizes that single handoff for both sides.
+    input_buffer_size: int = 1
     region: list[object] = []
 
-    def _flush() -> None:
+    def _flush(output_buffer_size: int) -> None:
         if not region:
             return
         backend: _PoolBackend
@@ -292,7 +316,13 @@ def _fuse_marked_regions(
         else:  # pragma: no cover -- a main-process target never accumulates a region
             raise AssertionError(f"Unexpected region target: {target!r}")
         fused, pool = _build_fused_stage_from_spec(
-            region, target, backend, report_stats_interval, continuous
+            region,
+            target,
+            backend,
+            report_stats_interval,
+            continuous,
+            input_buffer_size,
+            output_buffer_size,
         )
         pools.append(pool)
         new_pipes.append(fused)
@@ -301,13 +331,18 @@ def _fuse_marked_regions(
     try:
         for p in pipes:
             if isinstance(p, PlacementConfig):
-                _flush()  # close the span running under the previous target
+                # ``p`` both closes the span under the previous target (so it sizes that
+                # region's way out) and opens the next one (sizing its way in).
+                _flush(p.buffer_size)
                 target = p.target
+                input_buffer_size = p.buffer_size
             elif isinstance(target, _MainProcess):
                 new_pipes.append(p)
             else:
                 region.append(p)
-        _flush()  # close a region left open at the end of the pipes
+        # A region left open at the end has no closing marker to size its output; the
+        # builder rejects that shape, so this only guards hand-built configs.
+        _flush(1)
     except BaseException:
         # Reap any pools spawned before the failure; the caller never receives them to reap.
         for pool in pools:

--- a/src/spdl/pipeline/_pipeline.py
+++ b/src/spdl/pipeline/_pipeline.py
@@ -366,6 +366,69 @@ class _PipelineImpl(Generic[T]):
 
         raise TimeoutError(f"The next item is not available after {elapsed:.1f} sec.")
 
+    def get_item_nowait(self) -> T:
+        """Get the next item if one is already buffered in the sink, without blocking.
+
+        Raises:
+            RuntimeError: The pipeline is not started.
+
+            queue.Empty: No item is currently available. The pipeline is still running, so an
+                item may become available later.
+
+            EOFError: The pipeline is exhausted (or reached an epoch boundary) and the sink is
+                drained.
+        """
+        item = self._get_item_nowait()
+        if is_epoch_end(item):
+            raise EOFError(_EOF_MSG)
+        return item
+
+    async def _get_nowait_on_loop(self) -> T:
+        # Runs on the event loop thread. Deliberately has no ``await``: it completes within a
+        # single loop tick, so the future returned by ``run_coroutine_threadsafe`` is never left
+        # pending. That is what makes this safe where ``get_item(timeout=0)`` is not -- the
+        # latter submits ``queue.get()`` and abandons the future on timeout, stranding whatever
+        # item that ``get()`` eventually receives.
+        return self._output_queue.get_nowait()
+
+    def _get_item_nowait(self) -> T:
+        """Non-blocking counterpart of :py:meth:`_get_item`.
+
+        Normalizes the two queue backends onto one exception contract: ``queue.Empty`` for "not
+        yet", ``EOFError`` for "never". Callers can therefore drain opportunistically without
+        caring which backend the sink uses.
+        """
+        if not self._event_loop.is_started():
+            raise RuntimeError("Pipeline is not started.")
+
+        if isinstance(self._output_queue, _ThreadBasedAsyncQueue):
+            q = self._output_queue._queue  # pyre-ignore[16]
+            try:
+                return q.get_nowait()
+            except queue.Empty:
+                # Empty *and* the producing task is done means no item is ever coming.
+                if self._event_loop.is_task_completed() and q.empty():
+                    self._event_loop.stop()
+                    raise EOFError(_EOF_MSG) from None
+                raise
+
+        if self._event_loop.is_task_completed():
+            # The background loop no longer touches the sink, so direct access is thread-safe.
+            if not self._output_queue.empty():
+                return self._output_queue.get_nowait()
+            self._event_loop.stop()
+            raise EOFError(_EOF_MSG)
+
+        try:
+            return self._event_loop.run_coroutine_threadsafe(
+                self._get_nowait_on_loop()
+            ).result()
+        except asyncio.QueueEmpty:
+            if self._event_loop.is_task_completed() and self._output_queue.empty():
+                self._event_loop.stop()
+                raise EOFError(_EOF_MSG) from None
+            raise queue.Empty from None
+
     def _get_item_thread_queue(self, *, timeout: float | None) -> T:
         q = self._output_queue._queue  # pyre-ignore[16]
 
@@ -682,6 +745,24 @@ class Pipeline(Generic[T]):
         if self._impl._event_loop_state == _EventLoopState.NOT_STARTED:
             self.start()
         return self._impl.get_item(timeout=timeout)
+
+    def _get_item_nowait(self) -> T:
+        """Get the next item if one is already buffered, without blocking.
+
+        Internal: used to drain a burst of already-produced results in one go (see the
+        fused-region worker in :py:mod:`spdl.pipeline._subprocess_pipeline_pool`). Unlike
+        ``get_item(timeout=0)``, this cannot strand an item.
+
+        Raises:
+            RuntimeError: The pipeline is not started.
+
+            queue.Empty: No item is currently available.
+
+            EOFError: The pipeline is exhausted (or reached an epoch boundary) and drained.
+        """
+        # Unlike `get_item`, do not auto-start: a caller polling a not-yet-started pipeline
+        # wants "nothing available", and silently starting it here would hide a usage error.
+        return self._impl.get_item_nowait()
 
     def get_iterator(self, *, timeout: float | None = None) -> Iterator[T]:
         """Get an iterator, which iterates over the pipeline outputs.

--- a/src/spdl/pipeline/_subprocess_pipeline_pool.py
+++ b/src/spdl/pipeline/_subprocess_pipeline_pool.py
@@ -103,8 +103,9 @@ class _DrainSource:
 
     Used as a *continuous* source: :py:func:`spdl.pipeline._components._source._source_continuous`
     calls ``iter()`` once per epoch, so ``__iter__`` must return a fresh generator each time
-    (a one-shot generator object would only ever run one epoch). Each pass yields ``_ITEM``
-    payloads until an ``_EPOCH`` (epoch boundary) or ``_POOL_SHUTDOWN`` (teardown) message.
+    (a one-shot generator object would only ever run one epoch). Each pass yields the items
+    inside each ``_ITEM`` payload until an ``_EPOCH`` (epoch boundary) or ``_POOL_SHUTDOWN``
+    (teardown) message.
 
     ``exiting`` latches once ``_POOL_SHUTDOWN`` is seen; the worker loop reads it to stop after
     the current epoch. The blocking read uses a timeout so the drain thread wakes periodically
@@ -124,7 +125,10 @@ class _DrainSource:
                     return
                 continue
             if kind == _ITEM:
-                yield payload
+                # An ``_ITEM`` payload is always a list (one item when the region is
+                # unbuffered), so unpacking it here is what keeps the region's buffering
+                # invisible to the sub-pipeline's stages.
+                yield from payload
             elif kind == _EPOCH:
                 return
             else:  # _POOL_SHUTDOWN
@@ -149,7 +153,7 @@ def _run_sessions(
         while True:
             kind, payload = in_q.get()
             if kind == _ITEM:
-                yield payload
+                yield from payload
             elif kind == _SESSION_END:
                 session_ended = True
                 return
@@ -164,7 +168,7 @@ def _run_sessions(
             pipeline = build_pipeline(cfg, **build_kwargs)
             with pipeline.auto_stop():
                 for out in pipeline:
-                    out_q.put((_RESULT, out))
+                    out_q.put((_RESULT, [out]))
         except Exception as err:  # relayed to the submitter below
             out_q.put((_ERROR, _to_picklable_error(err, traceback.format_exc())))
             # A pipeline failure abandons the source generator mid-session, so this session's
@@ -210,7 +214,7 @@ def _run_continuous(
         with pipeline.auto_stop():
             while not source.exiting:
                 for out in pipeline:
-                    out_q.put((_RESULT, out))
+                    out_q.put((_RESULT, [out]))
                 if source.exiting:
                     break
                 out_q.put((_EPOCH_DONE, None))
@@ -253,7 +257,7 @@ def _pipeline_worker_loop(
 class _SubprocessPipelineHandle:
     """Picklable submit side of a :py:class:`_SubprocessPipelinePool`.
 
-    Holds only the queues, worker count, and mode, so it is cheap to carry inside a
+    Holds only the queues, worker count, mode, and transfer sizes, so it is cheap to carry in a
     :py:class:`~spdl.pipeline.defs.PipelineConfig` — including across the pickle boundary into a
     pipeline subprocess (the queues travel as ``Process`` spawn arguments, the only context in
     which an ``mp.Queue`` may be pickled). ``in_qs`` holds one input queue per worker in both
@@ -262,12 +266,22 @@ class _SubprocessPipelineHandle:
     """
 
     def __init__(
-        self, in_qs: list[Any], out_q: Any, max_workers: int, continuous: bool
+        self,
+        in_qs: list[Any],
+        out_q: Any,
+        max_workers: int,
+        continuous: bool,
+        input_buffer_size: int = 1,
+        output_buffer_size: int = 1,
     ) -> None:
         self.in_qs = in_qs
         self.out_q = out_q
         self.max_workers = max_workers
         self.continuous = continuous
+        # Sized separately: the two directions rarely carry comparable items (a region ending
+        # in ``aggregate`` takes rows in and returns whole batches).
+        self.input_buffer_size = input_buffer_size
+        self.output_buffer_size = output_buffer_size
 
 
 class _Worker:
@@ -441,12 +455,19 @@ class _SubprocessPipelinePool:
         initializer: Callable[..., object] | None,
         initargs: tuple[Any, ...],
         continuous: bool = False,
+        input_buffer_size: int = 1,
+        output_buffer_size: int = 1,
     ) -> None:
         # Bound the queues so a slow consumer/producer applies backpressure rather than
         # buffering without limit. Sized to keep every worker fed, plus in-flight slack.
+        # The bound counts *messages*, so with a buffer size above 1 the in-flight item
+        # bound is this times that. Left as-is deliberately: the depth is what keeps workers
+        # pipelined, and shrinking it in proportion would stall the pool at large sizes.
         size = max(4, max_workers * 2)
         self._backend = backend
         self._continuous = continuous
+        self._input_buffer_size = input_buffer_size
+        self._output_buffer_size = output_buffer_size
         self._out_q: Any = backend.make_queue(size)
         # One input queue per worker in both modes. Continuous mode needs it to broadcast epoch
         # boundaries cleanly; non-continuous mode needs it so each worker receives exactly one
@@ -507,7 +528,12 @@ class _SubprocessPipelinePool:
     def make_handle(self) -> _SubprocessPipelineHandle:
         """Create the picklable submit-side handle that rides in the pipeline config."""
         return _SubprocessPipelineHandle(
-            self._in_qs, self._out_q, self._max_workers, self._continuous
+            self._in_qs,
+            self._out_q,
+            self._max_workers,
+            self._continuous,
+            self._input_buffer_size,
+            self._output_buffer_size,
         )
 
     def _broadcast_shutdown(self) -> None:

--- a/src/spdl/pipeline/defs/_defs.py
+++ b/src/spdl/pipeline/defs/_defs.py
@@ -543,8 +543,31 @@ class PlacementConfig:
     name: str = "placement"
     """Name of the marker (used only for display)."""
 
+    buffer_size: int = 1
+    """At most this many items are buffered into one transfer *at this marker*.
+
+    Crossing a process boundary costs a fixed amount per transfer (pickling, queue handoff, and
+    — for tensors — a shared-memory allocation) no matter how small the item is. ``1`` (the
+    default) passes one item at a time; a larger value amortizes that cost over several items.
+
+    Each marker sizes the handoff that happens where it sits, so a region's entry and exit are
+    configured independently: the marker that *opens* a region sizes data flowing into its
+    workers, and the marker that *closes* it sizes results flowing back. That separation
+    matters because the two directions rarely carry comparable items — a region ending in
+    :py:func:`Aggregate` takes single rows in and returns whole batches.
+
+    It is an upper bound rather than a fixed grouping: a partial buffer is flushed at the end of
+    a stream and at every epoch boundary, so the last transfer is usually short.
+
+    The buffering is transparent — stages on both sides still see individual items, so this is
+    independent of any :py:func:`Aggregate` inside or outside the region.
+
+    .. versionadded:: 0.7.0
+    """
+
     def __repr__(self) -> str:
-        return f"{self.name}({self.target!r})"
+        buf = f", buffer_size={self.buffer_size}" if self.buffer_size != 1 else ""
+        return f"{self.name}({self.target!r}{buf})"
 
 
 ################################################################################

--- a/tests/pipeline/builder_to_test.py
+++ b/tests/pipeline/builder_to_test.py
@@ -78,6 +78,99 @@ class ToMethodTest(unittest.TestCase):
             b.to("subprocess")  # type: ignore[arg-type]
 
 
+class ToBufferSizeTest(unittest.TestCase):
+    """``to(..., buffer_size=N)``, which sets the region's transfer granularity."""
+
+    def test_defaults_to_one(self) -> None:
+        """Omitting buffer_size means one item per transfer."""
+        config = (
+            PipelineBuilder()
+            .add_source(range(4))
+            .to(ProcessPoolExecutorConfig(max_workers=1))
+            .pipe(add_one)
+            .to(MAIN_PROCESS)
+            .add_sink()
+            .get_config()
+        )
+        markers = [p for p in config.pipes if isinstance(p, PlacementConfig)]
+        self.assertEqual([m.buffer_size for m in markers], [1, 1])
+
+    def test_recorded_on_marker(self) -> None:
+        """buffer_size is carried on the PlacementConfig that opens the region."""
+        config = (
+            PipelineBuilder()
+            .add_source(range(4))
+            .to(ProcessPoolExecutorConfig(max_workers=1), buffer_size=8)
+            .pipe(add_one)
+            .to(MAIN_PROCESS)
+            .add_sink()
+            .get_config()
+        )
+        markers = [p for p in config.pipes if isinstance(p, PlacementConfig)]
+        self.assertEqual([m.buffer_size for m in markers], [8, 1])
+
+    def test_per_region(self) -> None:
+        """Adjacent regions each keep their own buffer_size."""
+        config = (
+            PipelineBuilder()
+            .add_source(range(4))
+            .to(ProcessPoolExecutorConfig(max_workers=1), buffer_size=4)
+            .pipe(add_one)
+            .to(ProcessPoolExecutorConfig(max_workers=1), buffer_size=16)
+            .pipe(times_two)
+            .to(MAIN_PROCESS)
+            .add_sink()
+            .get_config()
+        )
+        markers = [p for p in config.pipes if isinstance(p, PlacementConfig)]
+        self.assertEqual([m.buffer_size for m in markers], [4, 16, 1])
+
+    def test_not_carried_on_the_pool_spec(self) -> None:
+        """The knob belongs to the boundary, not to the worker pool behind it."""
+        self.assertFalse(hasattr(ProcessPoolExecutorConfig(), "buffer_size"))
+        self.assertFalse(hasattr(InterpreterPoolExecutorConfig(), "buffer_size"))
+
+    def test_accepted_on_main_process(self) -> None:
+        """Closing a region is a boundary too -- results cross back there, so it takes a size.
+
+        Each marker sizes the handoff at its own position, so a region's entry and exit are set
+        independently.
+        """
+        config = (
+            PipelineBuilder()
+            .add_source(range(4))
+            .to(ProcessPoolExecutorConfig(max_workers=1), buffer_size=32)
+            .pipe(add_one)
+            .to(MAIN_PROCESS, buffer_size=2)
+            .add_sink()
+            .get_config()
+        )
+        markers = [p for p in config.pipes if isinstance(p, PlacementConfig)]
+        self.assertEqual([m.buffer_size for m in markers], [32, 2])
+
+    def test_rejects_non_positive(self) -> None:
+        """A buffer_size below 1 cannot form a transfer and is rejected at the call site."""
+        b = PipelineBuilder().add_source(range(4))
+        for bad in (0, -1):
+            with self.subTest(buffer_size=bad):
+                with self.assertRaisesRegex(ValueError, "must be a positive integer"):
+                    b.to(ProcessPoolExecutorConfig(max_workers=1), buffer_size=bad)
+
+    def test_validated_at_build_for_hand_built_config(self) -> None:
+        """A PlacementConfig assembled without the builder is still validated."""
+        b = PipelineBuilder().add_source(range(4))
+        # Bypass `to()` so only the build-time scan can catch it.
+        b._process_args.append(
+            PlacementConfig(
+                target=ProcessPoolExecutorConfig(max_workers=1), buffer_size=0
+            )
+        )
+        b._process_args.append(Pipe(add_one))
+        b.to(MAIN_PROCESS).add_sink()
+        with self.assertRaisesRegex(ValueError, "must be a positive integer"):
+            b.get_config()
+
+
 class ToValidationTest(unittest.TestCase):
     """Validation performed on to() regions at get_config()/build()."""
 

--- a/tests/pipeline/get_item_nowait_test.py
+++ b/tests/pipeline/get_item_nowait_test.py
@@ -1,0 +1,140 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""Tests for ``Pipeline._get_item_nowait``, the non-blocking sink read.
+
+The contract is three-way and has to hold identically on both sink backends: return an item,
+raise ``queue.Empty`` for "not yet", raise ``EOFError`` for "never". The load-bearing property
+is that polling can never *lose* an item -- that is precisely what makes this different from
+``get_item(timeout=0)``, which submits a ``queue.get()`` onto the event loop and abandons the
+future when the timeout expires, stranding whatever that get later receives.
+"""
+
+import queue
+import time
+import unittest
+from typing import Any
+
+from parameterized import parameterized  # pyre-ignore[21]
+from spdl.pipeline import Pipeline, PipelineBuilder
+
+_TIMEOUT: float = 60.0
+
+_BACKENDS: list[tuple[str, bool]] = [("async_queue", False), ("thread_queue", True)]
+
+
+def add_one(x: int) -> int:
+    return x + 1
+
+
+def slow(x: int) -> int:
+    time.sleep(2.0)
+    return x
+
+
+def _build(
+    n: int, *, thread_queue: bool, continuous: bool = False, op: Any = add_one
+) -> Pipeline[Any]:
+    return (
+        PipelineBuilder()
+        .add_source(range(n), continuous=continuous)
+        .pipe(op)
+        .add_sink(n or 1)
+        .build(num_threads=2, use_thread_output_queue=thread_queue)
+    )
+
+
+def _drain_nowait(pipeline: Pipeline[Any]) -> list[Any]:
+    """Pull one stream's worth of items using *only* ``_get_item_nowait``.
+
+    Spins on ``queue.Empty`` rather than blocking, so any item the poll drops would show up as a
+    short result rather than as a hang.
+    """
+    out: list[Any] = []
+    deadline = time.monotonic() + _TIMEOUT
+    while True:
+        try:
+            out.append(pipeline._get_item_nowait())
+        except EOFError:
+            return out
+        except queue.Empty:
+            if time.monotonic() > deadline:
+                raise AssertionError(
+                    f"timed out with {len(out)} items; an item was likely dropped"
+                ) from None
+            time.sleep(0.001)
+
+
+class GetItemNowaitTest(unittest.TestCase):
+    """The three-way contract holds identically on both sink backends."""
+
+    @parameterized.expand(_BACKENDS)
+    def test_drains_every_item(self, _name: str, thread_queue: bool) -> None:
+        """Polling alone yields the whole stream -- no item is stranded by a poll.
+
+        This is the regression guard for the abandoned-future bug that
+        ``get_item(timeout=0)`` would have had: a dropped item leaves the drain spinning on
+        ``queue.Empty`` until it gives up.
+        """
+        n = 200
+        pipeline = _build(n, thread_queue=thread_queue)
+        with pipeline.auto_stop():
+            self.assertEqual(sorted(_drain_nowait(pipeline)), [x + 1 for x in range(n)])
+
+    @parameterized.expand(_BACKENDS)
+    def test_empty_when_nothing_ready(self, _name: str, thread_queue: bool) -> None:
+        """A running pipeline with nothing produced yet raises ``queue.Empty``, not EOF.
+
+        The op sleeps far longer than this check takes, so the sink is guaranteed to be empty
+        while the pipeline is still very much alive.
+        """
+        pipeline = _build(1, thread_queue=thread_queue, op=slow)
+        with pipeline.auto_stop():
+            with self.assertRaises(queue.Empty):
+                pipeline._get_item_nowait()
+
+    @parameterized.expand(_BACKENDS)
+    def test_eof_when_exhausted(self, _name: str, thread_queue: bool) -> None:
+        """Once the source is drained and the task is done, polling reports ``EOFError``."""
+        pipeline = _build(4, thread_queue=thread_queue)
+        with pipeline.auto_stop():
+            self.assertEqual(sorted(_drain_nowait(pipeline)), [1, 2, 3, 4])
+            # _drain_nowait returns on the first EOFError; nothing further can appear.
+            with self.assertRaises(EOFError):
+                pipeline._get_item_nowait()
+
+    @parameterized.expand(_BACKENDS)
+    def test_epoch_boundary_reported_as_eof(
+        self, _name: str, thread_queue: bool
+    ) -> None:
+        """With a continuous source, each epoch ends in ``EOFError`` and the next one resumes.
+
+        Mirrors how the blocking ``get_item`` reports an epoch boundary, so a caller can drain
+        epoch by epoch without ever blocking.
+        """
+        n = 32
+        ref = [x + 1 for x in range(n)]
+        pipeline = _build(n, thread_queue=thread_queue, continuous=True)
+        with pipeline.auto_stop():
+            for epoch in range(3):
+                with self.subTest(epoch=epoch):
+                    self.assertEqual(sorted(_drain_nowait(pipeline)), ref)
+
+    @parameterized.expand(_BACKENDS)
+    def test_requires_started_pipeline(self, _name: str, thread_queue: bool) -> None:
+        """Polling does not auto-start the pipeline the way ``get_item`` does.
+
+        A caller polling a pipeline it never started wants that surfaced, not silently fixed.
+        """
+        pipeline = _build(4, thread_queue=thread_queue)
+        with self.assertRaisesRegex(RuntimeError, "not started"):
+            pipeline._get_item_nowait()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/pipeline/marked_region_fuse_test.py
+++ b/tests/pipeline/marked_region_fuse_test.py
@@ -535,6 +535,8 @@ class FusedThreadCountTest(unittest.TestCase):
                 None,  # pyre-ignore[6] -- unused by the fake
                 -1.0,
                 True,
+                1,  # input buffer size; irrelevant to the thread count
+                1,  # output buffer size; likewise
             )
         return captured["num_threads"]
 
@@ -753,6 +755,133 @@ class MarkedRegionSegmentationTest(unittest.TestCase):
                 p for p in new_config.pipes if isinstance(p, _SubprocessPipelineConfig)
             ]
             self.assertEqual(len(fused), 2)
+        finally:
+            for pool in pools:
+                pool.shutdown()
+
+    def test_buffer_size_reaches_the_handle(self) -> None:
+        """The spec's buffer_size lands on the pool handle the bridge stage reads."""
+        config = _cfg(
+            range(4),
+            [
+                PlacementConfig(
+                    target=ProcessPoolExecutorConfig(max_workers=1), buffer_size=8
+                ),
+                Pipe(add_one),
+                PlacementConfig(target=MAIN_PROCESS),
+            ],
+        )
+        new_config, pools = _fuse_marked_regions(config)
+        try:
+            (fused,) = [
+                p for p in new_config.pipes if isinstance(p, _SubprocessPipelineConfig)
+            ]
+            self.assertEqual(fused.handle.input_buffer_size, 8)
+        finally:
+            for pool in pools:
+                pool.shutdown()
+
+    def test_buffer_size_defaults_to_one(self) -> None:
+        """A region whose spec does not set it transfers one item at a time."""
+        config = _cfg(
+            range(4),
+            [
+                PlacementConfig(target=ProcessPoolExecutorConfig(max_workers=1)),
+                Pipe(add_one),
+                PlacementConfig(target=MAIN_PROCESS),
+            ],
+        )
+        new_config, pools = _fuse_marked_regions(config)
+        try:
+            (fused,) = [
+                p for p in new_config.pipes if isinstance(p, _SubprocessPipelineConfig)
+            ]
+            self.assertEqual(fused.handle.input_buffer_size, 1)
+        finally:
+            for pool in pools:
+                pool.shutdown()
+
+    def test_closing_marker_sizes_the_output(self) -> None:
+        """The marker that closes a region sizes the results coming back out of it.
+
+        The two directions are independent, which is the point: a region ending in
+        ``aggregate`` takes single items in and returns whole batches.
+        """
+        config = _cfg(
+            range(4),
+            [
+                PlacementConfig(
+                    target=ProcessPoolExecutorConfig(max_workers=1), buffer_size=32
+                ),
+                Pipe(add_one),
+                PlacementConfig(target=MAIN_PROCESS, buffer_size=2),
+            ],
+        )
+        new_config, pools = _fuse_marked_regions(config)
+        try:
+            (fused,) = [
+                p for p in new_config.pipes if isinstance(p, _SubprocessPipelineConfig)
+            ]
+            self.assertEqual(fused.handle.input_buffer_size, 32)
+            self.assertEqual(fused.handle.output_buffer_size, 2)
+        finally:
+            for pool in pools:
+                pool.shutdown()
+
+    def test_marker_between_adjacent_regions_sizes_both_sides(self) -> None:
+        """One marker closing region A and opening region B sizes that single handoff."""
+        config = _cfg(
+            range(4),
+            [
+                PlacementConfig(
+                    target=ProcessPoolExecutorConfig(max_workers=1), buffer_size=4
+                ),
+                Pipe(add_one),
+                PlacementConfig(
+                    target=ProcessPoolExecutorConfig(max_workers=1), buffer_size=8
+                ),
+                Pipe(times_two),
+                PlacementConfig(target=MAIN_PROCESS, buffer_size=16),
+            ],
+        )
+        new_config, pools = _fuse_marked_regions(config)
+        try:
+            first, second = [
+                p for p in new_config.pipes if isinstance(p, _SubprocessPipelineConfig)
+            ]
+            # The middle marker is region A's exit and region B's entry alike.
+            self.assertEqual(first.handle.input_buffer_size, 4)
+            self.assertEqual(first.handle.output_buffer_size, 8)
+            self.assertEqual(second.handle.input_buffer_size, 8)
+            self.assertEqual(second.handle.output_buffer_size, 16)
+        finally:
+            for pool in pools:
+                pool.shutdown()
+
+    def test_each_region_keeps_its_own_buffer_size(self) -> None:
+        """Two regions are fused with the buffer_size of their own spec."""
+        config = _cfg(
+            range(4),
+            [
+                PlacementConfig(
+                    target=ProcessPoolExecutorConfig(max_workers=1), buffer_size=4
+                ),
+                Pipe(add_one),
+                PlacementConfig(target=MAIN_PROCESS),
+                Pipe(times_two),
+                PlacementConfig(
+                    target=ProcessPoolExecutorConfig(max_workers=1), buffer_size=16
+                ),
+                Pipe(add_one),
+                PlacementConfig(target=MAIN_PROCESS),
+            ],
+        )
+        new_config, pools = _fuse_marked_regions(config)
+        try:
+            fused = [
+                p for p in new_config.pipes if isinstance(p, _SubprocessPipelineConfig)
+            ]
+            self.assertEqual([f.handle.input_buffer_size for f in fused], [4, 16])
         finally:
             for pool in pools:
                 pool.shutdown()

--- a/tests/pipeline/region_buffer_test.py
+++ b/tests/pipeline/region_buffer_test.py
@@ -1,0 +1,314 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""End-to-end tests for ``buffer_size`` -- transfer buffering at a region boundary.
+
+The bridge packs items into one transfer on the way into the region and unpacks them on the way
+out, so the region's stages (and everything downstream) still see individual items. These tests
+pin that transparency: for every scenario the observable output must not depend on
+``buffer_size``.
+
+The interesting cases are the ones where the region's output cardinality differs from its
+input's -- a dropped item, a generator, an ``aggregate`` -- because nothing in the protocol may
+assume the two directions chunk alike. ``continuous`` sources get their own coverage since a
+chunk that straddled an epoch boundary would silently move data between epochs.
+
+Bridge-level packing/flushing is covered directly (and deterministically) in
+``subprocess_pipe_bridge_test.py``; this file only checks the observable end-to-end behavior.
+"""
+
+import unittest
+from collections.abc import Iterator
+from typing import Any
+
+from parameterized import parameterized  # pyre-ignore[21]
+from spdl.pipeline import Pipeline, PipelineBuilder
+from spdl.pipeline.defs import MAIN_PROCESS, ProcessPoolExecutorConfig
+
+# (buffer_size, max_workers). Sizes are deliberately co-prime with the item counts
+# below so the tail chunk is always partial. ``(1, N)`` is the unbuffered control and
+# ``(16, 2)`` covers a transfer larger than a whole epoch. Kept small on purpose: every case
+# spawns a worker pool, and the suite runs these in parallel.
+_MATRIX: list[tuple[int, int]] = [(1, 1), (1, 3), (3, 3), (16, 2)]
+
+# Generous: these cases are correctness checks, not latency checks, and they compete with the
+# rest of the suite for cores. A real hang still fails via the test runner's own timeout.
+_TIMEOUT: float = 180.0
+
+
+def add_one(x: int) -> int:
+    return x + 1
+
+
+def times_two(x: int) -> int:
+    return x * 2
+
+
+def drop_odd(x: int) -> int | None:
+    """1 -> 0 for odd inputs: SPDL absorbs a ``None`` result, so fewer items come out."""
+    return None if x % 2 else x
+
+
+def explode(x: int) -> Iterator[int]:
+    """1 -> 3: a generator op makes the region emit more items than it received."""
+    yield x
+    yield x + 1000
+    yield x + 2000
+
+
+def boom_on_five(x: int) -> int:
+    if x == 5:
+        raise ValueError("boom")
+    return x
+
+
+def _run(pipeline: Pipeline[Any]) -> list[Any]:
+    with pipeline.auto_stop():
+        return list(pipeline.get_iterator(timeout=_TIMEOUT))
+
+
+def _build(
+    source: Any,
+    buffer_size: int,
+    max_workers: int,
+    *,
+    continuous: bool = False,
+) -> PipelineBuilder[Any, Any]:
+    """Open a region over ``source``; the caller adds the region's stages and closes it."""
+    return (
+        PipelineBuilder()
+        .add_source(source, continuous=continuous)
+        .to(
+            ProcessPoolExecutorConfig(max_workers=max_workers),
+            buffer_size=buffer_size,
+        )
+    )
+
+
+class RegionBufferSizeTest(unittest.TestCase):
+    """A buffered region produces exactly what an unbuffered one would."""
+
+    @parameterized.expand(_MATRIX)
+    def test_identity_roundtrip(self, buffer_size: int, max_workers: int) -> None:
+        """Every item makes it through, whatever the transfer size.
+
+        The item count (23) is not a multiple of any size in the matrix, so the tail
+        chunk is always partial -- the case where a missing flush would silently drop items.
+        """
+        n = 23
+        pipeline = (
+            _build(range(n), buffer_size, max_workers)
+            .pipe(add_one)
+            .pipe(times_two)
+            .to(MAIN_PROCESS)
+            .add_sink()
+            .build(num_threads=4)
+        )
+        self.assertEqual(sorted(_run(pipeline)), sorted((x + 1) * 2 for x in range(n)))
+
+    @parameterized.expand(_MATRIX)
+    def test_empty_source(self, buffer_size: int, max_workers: int) -> None:
+        """An empty source completes and yields nothing, rather than hanging on a chunk
+        that never fills."""
+        pipeline = (
+            _build([], buffer_size, max_workers)
+            .pipe(add_one)
+            .to(MAIN_PROCESS)
+            .add_sink()
+            .build(num_threads=4)
+        )
+        self.assertEqual(_run(pipeline), [])
+
+    @parameterized.expand(_MATRIX)
+    def test_fewer_items_than_buffer_size(
+        self, buffer_size: int, max_workers: int
+    ) -> None:
+        """A stream shorter than one chunk is still delivered (flushed at end of stream)."""
+        pipeline = (
+            _build(range(1), buffer_size, max_workers)
+            .pipe(add_one)
+            .to(MAIN_PROCESS)
+            .add_sink()
+            .build(num_threads=4)
+        )
+        self.assertEqual(_run(pipeline), [1])
+
+    @parameterized.expand(_MATRIX)
+    def test_region_emitting_fewer_items(
+        self, buffer_size: int, max_workers: int
+    ) -> None:
+        """1 -> 0 stages: the output chunking must not assume one result per input."""
+        n = 23
+        pipeline = (
+            _build(range(n), buffer_size, max_workers)
+            .pipe(drop_odd)
+            .to(MAIN_PROCESS)
+            .add_sink()
+            .build(num_threads=4)
+        )
+        self.assertEqual(sorted(_run(pipeline)), [x for x in range(n) if x % 2 == 0])
+
+    @parameterized.expand(_MATRIX)
+    def test_region_emitting_more_items(
+        self, buffer_size: int, max_workers: int
+    ) -> None:
+        """1 -> 3 stages: more results than inputs, so output chunks outnumber input chunks."""
+        n = 11
+        pipeline = (
+            _build(range(n), buffer_size, max_workers)
+            .pipe(explode)
+            .to(MAIN_PROCESS)
+            .add_sink()
+            .build(num_threads=4)
+        )
+        expected = sorted(x + k for x in range(n) for k in (0, 1000, 2000))
+        self.assertEqual(sorted(_run(pipeline)), expected)
+
+    @parameterized.expand(_MATRIX)
+    def test_aggregate_inside_region(self, buffer_size: int, max_workers: int) -> None:
+        """N -> 1 stages: batching inside the region is independent of the transfer size.
+
+        This is the shape the feature exists for -- the batch size and the transfer size are
+        set separately. Each worker aggregates only the items routed to it, so batches may be
+        partial at end of stream; the union across batches is what must be preserved.
+        """
+        n = 23
+        batch = 4
+        pipeline = (
+            _build(range(n), buffer_size, max_workers)
+            .aggregate(batch)
+            .to(MAIN_PROCESS)
+            .add_sink()
+            .build(num_threads=4)
+        )
+        batches = _run(pipeline)
+        self.assertTrue(all(len(b) <= batch for b in batches))
+        self.assertCountEqual([x for b in batches for x in b], list(range(n)))
+
+    @parameterized.expand(_MATRIX)
+    def test_drop_last_inside_region(self, buffer_size: int, max_workers: int) -> None:
+        """With drop_last each worker discards its own partial batch, but only whole batches.
+
+        The point is that the loss is a property of per-worker aggregation, not of the transfer
+        size: every emitted batch is full, and nothing outside the source appears.
+        """
+        n = 23
+        batch = 4
+        pipeline = (
+            _build(range(n), buffer_size, max_workers)
+            .aggregate(batch, drop_last=True)
+            .to(MAIN_PROCESS)
+            .add_sink()
+            .build(num_threads=4)
+        )
+        batches = _run(pipeline)
+        self.assertTrue(all(len(b) == batch for b in batches))
+        emitted = [x for b in batches for x in b]
+        self.assertEqual(len(emitted), len(set(emitted)))
+        self.assertTrue(set(emitted) <= set(range(n)))
+
+    @parameterized.expand(_MATRIX)
+    def test_op_failure_drops_only_that_item(
+        self, buffer_size: int, max_workers: int
+    ) -> None:
+        """A failing item is dropped without taking the rest of its transfer with it.
+
+        SPDL's default is to drop a failed item rather than fail the pipeline, and
+        ``max_failures`` is not propagated into a region's nested pipeline, so the observable
+        behavior is a missing item. What matters for buffering is that the *siblings* sharing
+        the failed item's chunk still arrive. The iterator timeout turns a hang into a failure.
+        """
+        n = 23
+        pipeline = (
+            _build(range(n), buffer_size, max_workers)
+            .pipe(boom_on_five)
+            .to(MAIN_PROCESS)
+            .add_sink()
+            .build(num_threads=4)
+        )
+        self.assertEqual(sorted(_run(pipeline)), [x for x in range(n) if x != 5])
+
+
+class ContinuousRegionBufferSizeTest(unittest.TestCase):
+    """Buffering must not move items across an epoch boundary."""
+
+    @parameterized.expand(_MATRIX)
+    def test_each_epoch_exact(self, buffer_size: int, max_workers: int) -> None:
+        """Every epoch delivers exactly its own items -- no tail carried into the next one."""
+        n = 23
+        ref = sorted((x + 1) * 2 for x in range(n))
+        pipeline = (
+            _build(range(n), buffer_size, max_workers, continuous=True)
+            .pipe(add_one)
+            .pipe(times_two)
+            .to(MAIN_PROCESS)
+            .add_sink(n)
+            .build(num_threads=4)
+        )
+        with pipeline.auto_stop():
+            for epoch in range(3):
+                with self.subTest(epoch=epoch):
+                    got = sorted(pipeline.get_iterator(timeout=_TIMEOUT))
+                    # Exact equality, not a subset: a chunk straddling the boundary would show
+                    # up as a short epoch followed by an over-long one.
+                    self.assertEqual(got, ref)
+
+    @parameterized.expand(_MATRIX)
+    def test_epoch_shorter_than_buffer(
+        self, buffer_size: int, max_workers: int
+    ) -> None:
+        """An epoch with fewer items than one chunk must still be flushed at the boundary.
+
+        Without the flush before the ``_EPOCH`` broadcast this deadlocks: the items sit in the
+        feeder's partial chunk, the workers see an empty epoch, and the epoch's results never
+        arrive.
+        """
+        n = 2
+        ref = sorted(x + 1 for x in range(n))
+        pipeline = (
+            _build(range(n), buffer_size, max_workers, continuous=True)
+            .pipe(add_one)
+            .to(MAIN_PROCESS)
+            .add_sink(n)
+            .build(num_threads=4)
+        )
+        with pipeline.auto_stop():
+            for epoch in range(3):
+                with self.subTest(epoch=epoch):
+                    self.assertEqual(
+                        sorted(pipeline.get_iterator(timeout=_TIMEOUT)), ref
+                    )
+
+
+class BufferSizeEquivalenceTest(unittest.TestCase):
+    """The observable result is identical across transfer sizes."""
+
+    def test_same_output_for_every_buffer_size(self) -> None:
+        """A region's output does not depend on how its transfers are chunked."""
+        n = 23
+
+        def _run_with(buffer_size: int) -> list[int]:
+            pipeline = (
+                _build(range(n), buffer_size, 3)
+                .pipe(drop_odd)
+                .pipe(explode)
+                .to(MAIN_PROCESS)
+                .add_sink()
+                .build(num_threads=4)
+            )
+            return sorted(_run(pipeline))
+
+        baseline = _run_with(1)
+        self.assertTrue(baseline)  # guard against the comparison being vacuous
+        for buffer_size in (2, 5, 32):
+            with self.subTest(buffer_size=buffer_size):
+                self.assertEqual(_run_with(buffer_size), baseline)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/pipeline/subprocess_pipe_bridge_test.py
+++ b/tests/pipeline/subprocess_pipe_bridge_test.py
@@ -23,7 +23,48 @@ from typing import Any
 
 from spdl.pipeline import AsyncQueue
 from spdl.pipeline._components import _subprocess_pipe
-from spdl.pipeline._components._common import StageInfo
+from spdl.pipeline._components._common import _EOF, _EPOCH_END, StageInfo
+
+
+def _unbounded_queue(name: str) -> AsyncQueue:
+    """An AsyncQueue with no depth limit (the default is 1, which would block these tests)."""
+    return AsyncQueue(
+        StageInfo(pipeline_id=0, stage_id="0", stage_name=name), buffer_size=0
+    )
+
+
+def _make_input_queue(items: list[Any]) -> AsyncQueue:
+    """A pre-filled stage input queue (unbounded, so the fill never blocks)."""
+    q = _unbounded_queue("input")
+    for item in items:
+        q.put_nowait(item)
+    return q
+
+
+class _AlwaysOpenBarrier(asyncio.Event):
+    """Epoch barrier stand-in that never blocks the feeder.
+
+    ``_feed_continuous`` clears the barrier, broadcasts ``_EPOCH``, then waits for the collector
+    to re-set it. These tests drive the feeder without a collector, so ``clear()`` is a no-op
+    and ``wait()`` returns immediately -- letting the feeder run straight through the boundary.
+    """
+
+    def clear(self) -> None:
+        pass
+
+
+def _drain(q: "_queue.Queue[Any]") -> list[Any]:
+    return [q.get_nowait() for _ in range(q.qsize())]
+
+
+def _items_of(msgs: list[Any]) -> list[Any]:
+    """Flatten the payloads of the ``_ITEM`` messages in ``msgs``, in order."""
+    return [
+        item
+        for kind, payload in msgs
+        if kind == _subprocess_pipe._ITEM
+        for item in payload
+    ]
 
 
 class FeedAbortTest(unittest.TestCase):
@@ -65,6 +106,245 @@ class FeedAbortTest(unittest.TestCase):
         msgs = asyncio.run(_scenario())
         # Every worker's own queue receives exactly one _SESSION_END.
         self.assertEqual(msgs, [[(_subprocess_pipe._SESSION_END, None)]] * num_workers)
+
+
+class FeedBufferingTest(unittest.TestCase):
+    """The feeder packs items into transfers of at most ``buffer_size``."""
+
+    @staticmethod
+    def _run_feed(
+        items: list[Any], num_workers: int, buffer_size: int
+    ) -> list[list[Any]]:
+        async def _scenario() -> list[list[Any]]:
+            in_qs: list[_queue.Queue[Any]] = [
+                _queue.Queue() for _ in range(num_workers)
+            ]
+            input_queue = _make_input_queue([*items, _EOF])
+            with ThreadPoolExecutor(max_workers=num_workers + 1) as ex:
+                await asyncio.wait_for(
+                    _subprocess_pipe._feed(
+                        input_queue,
+                        in_qs,
+                        ex,
+                        asyncio.Event(),
+                        asyncio.Event(),
+                        threading.Event(),
+                        buffer_size,
+                    ),
+                    timeout=10.0,
+                )
+            return [_drain(q) for q in in_qs]
+
+        return asyncio.run(_scenario())
+
+    def test_packs_full_chunks_and_tail(self) -> None:
+        """10 items at buffer_size=4 become transfers of 4, 4, 2 -- nothing dropped."""
+        msgs = self._run_feed(list(range(10)), num_workers=1, buffer_size=4)
+        payloads = [p for kind, p in msgs[0] if kind == _subprocess_pipe._ITEM]
+        self.assertEqual(payloads, [[0, 1, 2, 3], [4, 5, 6, 7], [8, 9]])
+        self.assertEqual(msgs[0][-1], (_subprocess_pipe._SESSION_END, None))
+
+    def test_unbuffered_sends_singleton_lists(self) -> None:
+        """buffer_size=1 (the default) still wraps each item in a one-element list."""
+        msgs = self._run_feed([7, 8], num_workers=1, buffer_size=1)
+        payloads = [p for kind, p in msgs[0] if kind == _subprocess_pipe._ITEM]
+        self.assertEqual(payloads, [[7], [8]])
+
+    def test_chunks_round_robin_across_workers(self) -> None:
+        """Whole chunks, not individual items, are distributed across the workers."""
+        msgs = self._run_feed(list(range(12)), num_workers=3, buffer_size=2)
+        payloads = [
+            [p for kind, p in worker if kind == _subprocess_pipe._ITEM]
+            for worker in msgs
+        ]
+        self.assertEqual(payloads[0], [[0, 1], [6, 7]])
+        self.assertEqual(payloads[1], [[2, 3], [8, 9]])
+        self.assertEqual(payloads[2], [[4, 5], [10, 11]])
+
+    def test_no_item_lost_when_count_not_divisible(self) -> None:
+        """Across every worker, the items fed reproduce the input exactly."""
+        items = list(range(23))
+        msgs = self._run_feed(items, num_workers=4, buffer_size=5)
+        fed = [item for worker in msgs for item in _items_of(worker)]
+        self.assertCountEqual(fed, items)
+        for worker in msgs:
+            self.assertEqual(worker[-1], (_subprocess_pipe._SESSION_END, None))
+
+    def test_empty_stream_sends_only_session_end(self) -> None:
+        """No items means no transfer -- just the per-worker end markers."""
+        msgs = self._run_feed([], num_workers=2, buffer_size=4)
+        self.assertEqual(msgs, [[(_subprocess_pipe._SESSION_END, None)]] * 2)
+
+    def test_abort_drops_partial_chunk(self) -> None:
+        """An abort discards the partly-filled chunk but still ends every session.
+
+        The feeder is given fewer items than ``buffer_size`` and no EOF, so it parks
+        holding a partial chunk. Aborting must not flush it -- the pipeline is already failing
+        -- but the ``_SESSION_END`` markers still have to go out, or the collector never sees
+        every ``_DONE``.
+        """
+
+        async def _scenario() -> list[list[Any]]:
+            in_qs: list[_queue.Queue[Any]] = [_queue.Queue() for _ in range(2)]
+            input_queue = _make_input_queue([1, 2])  # no EOF; fewer than buffer_size
+            abort = asyncio.Event()
+            with ThreadPoolExecutor(max_workers=3) as ex:
+                task = asyncio.ensure_future(
+                    _subprocess_pipe._feed(
+                        input_queue,
+                        in_qs,
+                        ex,
+                        abort,
+                        asyncio.Event(),
+                        threading.Event(),
+                        8,
+                    )
+                )
+                await asyncio.sleep(0.1)  # let it consume both and park
+                self.assertFalse(task.done())
+                abort.set()
+                await asyncio.wait_for(task, timeout=5.0)
+            return [_drain(q) for q in in_qs]
+
+        msgs = asyncio.run(_scenario())
+        self.assertEqual(msgs, [[(_subprocess_pipe._SESSION_END, None)]] * 2)
+
+
+class FeedContinuousBufferingTest(unittest.TestCase):
+    """Chunking in continuous mode, where a chunk must not straddle an epoch boundary."""
+
+    @staticmethod
+    def _run_feed_continuous(
+        items: list[Any], num_workers: int, buffer_size: int
+    ) -> list[list[Any]]:
+        async def _scenario() -> list[list[Any]]:
+            in_qs: list[_queue.Queue[Any]] = [
+                _queue.Queue() for _ in range(num_workers)
+            ]
+            input_queue = _make_input_queue([*items, _EOF])
+            epoch_barrier = _AlwaysOpenBarrier()
+            epoch_barrier.set()
+            with ThreadPoolExecutor(max_workers=num_workers + 1) as ex:
+                await asyncio.wait_for(
+                    _subprocess_pipe._feed_continuous(
+                        input_queue,
+                        in_qs,
+                        ex,
+                        epoch_barrier,
+                        asyncio.Event(),
+                        threading.Event(),
+                        buffer_size,
+                    ),
+                    timeout=10.0,
+                )
+            return [_drain(q) for q in in_qs]
+
+        return asyncio.run(_scenario())
+
+    def test_partial_chunk_flushed_before_epoch_marker(self) -> None:
+        """The tail of an epoch is queued ahead of ``_EPOCH``, not merged into the next epoch.
+
+        Five items at buffer_size=4 leave one buffered when the boundary arrives. If
+        that item were sent after the ``_EPOCH`` marker the worker would drain it as part of
+        epoch 1, silently moving data between epochs.
+        """
+        msgs = self._run_feed_continuous(
+            [0, 1, 2, 3, 4, _EPOCH_END, 5, 6], num_workers=1, buffer_size=4
+        )
+        kinds = [kind for kind, _ in msgs[0]]
+        epoch_at = kinds.index(_subprocess_pipe._EPOCH)
+        before = _items_of(msgs[0][:epoch_at])
+        after = _items_of(msgs[0][epoch_at:])
+        self.assertEqual(before, [0, 1, 2, 3, 4])
+        self.assertEqual(after, [5, 6])
+
+    def test_partial_chunk_flushed_before_shutdown(self) -> None:
+        """A partial chunk at end of stream is sent before ``_POOL_SHUTDOWN``."""
+        msgs = self._run_feed_continuous([0, 1], num_workers=1, buffer_size=8)
+        kinds = [kind for kind, _ in msgs[0]]
+        shutdown_at = kinds.index(_subprocess_pipe._POOL_SHUTDOWN)
+        self.assertEqual(_items_of(msgs[0][:shutdown_at]), [0, 1])
+
+    def test_epoch_marker_broadcast_to_every_worker(self) -> None:
+        """Every worker still receives the boundary, and no epoch's items leak across it."""
+        msgs = self._run_feed_continuous(
+            [*range(6), _EPOCH_END, *range(100, 106)],
+            num_workers=3,
+            buffer_size=2,
+        )
+        for worker in msgs:
+            kinds = [kind for kind, _ in worker]
+            self.assertIn(_subprocess_pipe._EPOCH, kinds)
+            epoch_at = kinds.index(_subprocess_pipe._EPOCH)
+            self.assertTrue(all(i < 100 for i in _items_of(worker[:epoch_at])))
+            self.assertTrue(all(i >= 100 for i in _items_of(worker[epoch_at:])))
+
+
+class CollectUnpackTest(unittest.TestCase):
+    """The collector unpacks a transfer back into individual downstream items."""
+
+    def test_collect_unpacks_in_order(self) -> None:
+        """Items within a ``_RESULT`` payload reach the output queue individually, in order."""
+
+        async def _scenario() -> list[Any]:
+            out_q: _queue.Queue[Any] = _queue.Queue()
+            out_q.put((_subprocess_pipe._RESULT, [1, 2, 3]))
+            out_q.put((_subprocess_pipe._RESULT, [4]))
+            out_q.put((_subprocess_pipe._DONE, None))
+            output_queue = _unbounded_queue("output")
+            with ThreadPoolExecutor(max_workers=2) as ex:
+                await asyncio.wait_for(
+                    _subprocess_pipe._collect(
+                        out_q, 1, output_queue, ex, asyncio.Event(), asyncio.Event()
+                    ),
+                    timeout=10.0,
+                )
+            return [output_queue.get_nowait() for _ in range(output_queue.qsize())]
+
+        self.assertEqual(asyncio.run(_scenario()), [1, 2, 3, 4])
+
+    def test_collect_continuous_unpacks_in_order(self) -> None:
+        """Same for the continuous collector, which also emits the epoch boundary."""
+
+        async def _scenario() -> list[Any]:
+            out_q: _queue.Queue[Any] = _queue.Queue()
+            out_q.put((_subprocess_pipe._RESULT, [1, 2]))
+            out_q.put((_subprocess_pipe._EPOCH_DONE, None))
+            out_q.put((_subprocess_pipe._DONE, None))
+            output_queue = _unbounded_queue("output")
+            epoch_barrier = asyncio.Event()
+            with ThreadPoolExecutor(max_workers=2) as ex:
+                await asyncio.wait_for(
+                    _subprocess_pipe._collect_continuous(
+                        out_q, 1, output_queue, ex, epoch_barrier, asyncio.Event()
+                    ),
+                    timeout=10.0,
+                )
+            return [output_queue.get_nowait() for _ in range(output_queue.qsize())]
+
+        self.assertEqual(asyncio.run(_scenario()), [1, 2, _EPOCH_END])
+
+    def test_results_after_error_are_discarded(self) -> None:
+        """A buffered transfer arriving after the first error is dropped wholesale."""
+
+        async def _scenario() -> list[Any]:
+            out_q: _queue.Queue[Any] = _queue.Queue()
+            out_q.put((_subprocess_pipe._RESULT, [1, 2]))
+            out_q.put((_subprocess_pipe._ERROR, RuntimeError("boom")))
+            out_q.put((_subprocess_pipe._RESULT, [3, 4]))
+            out_q.put((_subprocess_pipe._DONE, None))
+            output_queue = _unbounded_queue("output")
+            with ThreadPoolExecutor(max_workers=2) as ex:
+                with self.assertRaisesRegex(RuntimeError, "boom"):
+                    await asyncio.wait_for(
+                        _subprocess_pipe._collect(
+                            out_q, 1, output_queue, ex, asyncio.Event(), asyncio.Event()
+                        ),
+                        timeout=10.0,
+                    )
+            return [output_queue.get_nowait() for _ in range(output_queue.qsize())]
+
+        self.assertEqual(asyncio.run(_scenario()), [1, 2])
 
 
 class StallGuardTest(unittest.TestCase):


### PR DESCRIPTION
Adds `Pipeline._get_item_nowait()`: return the next item if one is already buffered in the
sink, otherwise raise. Internal for now -- the fused-region worker in the next diff needs it to
drain a burst of already-produced results in one go, and there is no user-facing use case yet,
so it stays underscore-prefixed rather than becoming public API.

`get_item(timeout=0)` is not a substitute, and that is the whole reason this exists.
`_get_item_async_queue` submits `output_queue.get()` onto the event loop and polls the
resulting future; when the timeout expires it abandons that future. The coroutine is still
queued, so whatever item it later receives is consumed from the queue and dropped on the floor.
With a zero timeout that happens on essentially every call.

The implementation normalizes the two sink backends onto one exception contract, so callers do
not have to care which one is in use:

- an item, when one is buffered;
- `queue.Empty` -- nothing right now, but the pipeline is still running;
- `EOFError` -- the stream is over (exhausted, or an epoch boundary on a continuous source),
  matching how the blocking `get_item` reports the same condition.

For the asyncio-queue backend the read hops onto the event loop as a coroutine with no `await`
in it, so it completes within a single loop tick and the future is never left pending -- which
is what makes it safe where the blocking path is not. For the thread-queue backend it is a
plain `get_nowait`.

Unlike `get_item`, this deliberately does not auto-start the pipeline: someone polling a
pipeline they never started wants that surfaced, not silently fixed.