### PR TITLE
[pipeline] Add a non-blocking sink read

### DIFF
--- a/src/spdl/pipeline/_pipeline.py
+++ b/src/spdl/pipeline/_pipeline.py
@@ -366,6 +366,69 @@ class _PipelineImpl(Generic[T]):
 
         raise TimeoutError(f"The next item is not available after {elapsed:.1f} sec.")
 
+    def get_item_nowait(self) -> T:
+        """Get the next item if one is already buffered in the sink, without blocking.
+
+        Raises:
+            RuntimeError: The pipeline is not started.
+
+            queue.Empty: No item is currently available. The pipeline is still running, so an
+                item may become available later.
+
+            EOFError: The pipeline is exhausted (or reached an epoch boundary) and the sink is
+                drained.
+        """
+        item = self._get_item_nowait()
+        if is_epoch_end(item):
+            raise EOFError(_EOF_MSG)
+        return item
+
+    async def _get_nowait_on_loop(self) -> T:
+        # Runs on the event loop thread. Deliberately has no ``await``: it completes within a
+        # single loop tick, so the future returned by ``run_coroutine_threadsafe`` is never left
+        # pending. That is what makes this safe where ``get_item(timeout=0)`` is not -- the
+        # latter submits ``queue.get()`` and abandons the future on timeout, stranding whatever
+        # item that ``get()`` eventually receives.
+        return self._output_queue.get_nowait()
+
+    def _get_item_nowait(self) -> T:
+        """Non-blocking counterpart of :py:meth:`_get_item`.
+
+        Normalizes the two queue backends onto one exception contract: ``queue.Empty`` for "not
+        yet", ``EOFError`` for "never". Callers can therefore drain opportunistically without
+        caring which backend the sink uses.
+        """
+        if not self._event_loop.is_started():
+            raise RuntimeError("Pipeline is not started.")
+
+        if isinstance(self._output_queue, _ThreadBasedAsyncQueue):
+            q = self._output_queue._queue  # pyre-ignore[16]
+            try:
+                return q.get_nowait()
+            except queue.Empty:
+                # Empty *and* the producing task is done means no item is ever coming.
+                if self._event_loop.is_task_completed() and q.empty():
+                    self._event_loop.stop()
+                    raise EOFError(_EOF_MSG) from None
+                raise
+
+        if self._event_loop.is_task_completed():
+            # The background loop no longer touches the sink, so direct access is thread-safe.
+            if not self._output_queue.empty():
+                return self._output_queue.get_nowait()
+            self._event_loop.stop()
+            raise EOFError(_EOF_MSG)
+
+        try:
+            return self._event_loop.run_coroutine_threadsafe(
+                self._get_nowait_on_loop()
+            ).result()
+        except asyncio.QueueEmpty:
+            if self._event_loop.is_task_completed() and self._output_queue.empty():
+                self._event_loop.stop()
+                raise EOFError(_EOF_MSG) from None
+            raise queue.Empty from None
+
     def _get_item_thread_queue(self, *, timeout: float | None) -> T:
         q = self._output_queue._queue  # pyre-ignore[16]
 
@@ -682,6 +745,24 @@ class Pipeline(Generic[T]):
         if self._impl._event_loop_state == _EventLoopState.NOT_STARTED:
             self.start()
         return self._impl.get_item(timeout=timeout)
+
+    def _get_item_nowait(self) -> T:
+        """Get the next item if one is already buffered, without blocking.
+
+        Internal: used to drain a burst of already-produced results in one go (see the
+        fused-region worker in :py:mod:`spdl.pipeline._subprocess_pipeline_pool`). Unlike
+        ``get_item(timeout=0)``, this cannot strand an item.
+
+        Raises:
+            RuntimeError: The pipeline is not started.
+
+            queue.Empty: No item is currently available.
+
+            EOFError: The pipeline is exhausted (or reached an epoch boundary) and drained.
+        """
+        # Unlike `get_item`, do not auto-start: a caller polling a not-yet-started pipeline
+        # wants "nothing available", and silently starting it here would hide a usage error.
+        return self._impl.get_item_nowait()
 
     def get_iterator(self, *, timeout: float | None = None) -> Iterator[T]:
         """Get an iterator, which iterates over the pipeline outputs.

--- a/tests/pipeline/get_item_nowait_test.py
+++ b/tests/pipeline/get_item_nowait_test.py
@@ -1,0 +1,150 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""Tests for ``Pipeline._get_item_nowait``, the non-blocking sink read.
+
+The contract is three-way and has to hold identically on both sink backends: return an item,
+raise ``queue.Empty`` for "not yet", raise ``EOFError`` for "never". The load-bearing property
+is that polling can never *lose* an item -- that is precisely what makes this different from
+``get_item(timeout=0)``, which submits a ``queue.get()`` onto the event loop and abandons the
+future when the timeout expires, stranding whatever that get later receives.
+"""
+
+import queue
+import threading
+import time
+import unittest
+from typing import Any
+
+from parameterized import parameterized  # pyre-ignore[21]
+from spdl.pipeline import Pipeline, PipelineBuilder
+
+_TIMEOUT: float = 60.0
+
+_BACKENDS: list[tuple[str, bool]] = [("async_queue", False), ("thread_queue", True)]
+
+
+def add_one(x: int) -> int:
+    return x + 1
+
+
+# Held by the test so an op can be pinned mid-flight without relying on a sleep: the op
+# cannot return until the test releases it, so "the sink is empty" is a fact rather than a
+# race the host's load could lose.
+_RELEASE_OP: threading.Event = threading.Event()
+
+
+def blocks_until_released(x: int) -> int:
+    _RELEASE_OP.wait()
+    return x
+
+
+def _build(
+    n: int, *, thread_queue: bool, continuous: bool = False, op: Any = add_one
+) -> Pipeline[Any]:
+    return (
+        PipelineBuilder()
+        .add_source(range(n), continuous=continuous)
+        .pipe(op)
+        .add_sink(n or 1)
+        .build(num_threads=2, use_thread_output_queue=thread_queue)
+    )
+
+
+def _drain_nowait(pipeline: Pipeline[Any]) -> list[Any]:
+    """Pull one stream's worth of items using *only* ``_get_item_nowait``.
+
+    Spins on ``queue.Empty`` rather than blocking, so any item the poll drops would show up as a
+    short result rather than as a hang.
+    """
+    out: list[Any] = []
+    deadline = time.monotonic() + _TIMEOUT
+    while True:
+        try:
+            out.append(pipeline._get_item_nowait())
+        except EOFError:
+            return out
+        except queue.Empty:
+            if time.monotonic() > deadline:
+                raise AssertionError(
+                    f"timed out with {len(out)} items; an item was likely dropped"
+                ) from None
+            time.sleep(0.001)
+
+
+class GetItemNowaitTest(unittest.TestCase):
+    """The three-way contract holds identically on both sink backends."""
+
+    @parameterized.expand(_BACKENDS)
+    def test_drains_every_item(self, _name: str, thread_queue: bool) -> None:
+        """Polling alone yields the whole stream -- no item is stranded by a poll.
+
+        This is the regression guard for the abandoned-future bug that
+        ``get_item(timeout=0)`` would have had: a dropped item leaves the drain spinning on
+        ``queue.Empty`` until it gives up.
+        """
+        n = 200
+        pipeline = _build(n, thread_queue=thread_queue)
+        with pipeline.auto_stop():
+            self.assertEqual(sorted(_drain_nowait(pipeline)), [x + 1 for x in range(n)])
+
+    @parameterized.expand(_BACKENDS)
+    def test_empty_when_nothing_ready(self, _name: str, thread_queue: bool) -> None:
+        """A running pipeline with nothing produced yet raises ``queue.Empty``, not EOF.
+
+        The only op is pinned inside ``_RELEASE_OP`` until this test lets it go, so the sink is
+        deterministically empty while the pipeline is still running -- no sleep, and nothing for
+        a loaded host to race.
+        """
+        _RELEASE_OP.clear()
+        pipeline = _build(1, thread_queue=thread_queue, op=blocks_until_released)
+        try:
+            with pipeline.auto_stop():
+                with self.assertRaises(queue.Empty):
+                    pipeline._get_item_nowait()
+                # Release before teardown, or ``stop()`` waits on the pinned op.
+                _RELEASE_OP.set()
+        finally:
+            _RELEASE_OP.set()
+
+    @parameterized.expand(_BACKENDS)
+    def test_eof_when_exhausted(self, _name: str, thread_queue: bool) -> None:
+        """Once the source is drained and the task is done, polling reports ``EOFError``."""
+        pipeline = _build(4, thread_queue=thread_queue)
+        with pipeline.auto_stop():
+            self.assertEqual(sorted(_drain_nowait(pipeline)), [1, 2, 3, 4])
+            # _drain_nowait returns on the first EOFError; nothing further can appear.
+            with self.assertRaises(EOFError):
+                pipeline._get_item_nowait()
+
+    @parameterized.expand(_BACKENDS)
+    def test_epoch_boundary_reported_as_eof(
+        self, _name: str, thread_queue: bool
+    ) -> None:
+        """With a continuous source, each epoch ends in ``EOFError`` and the next one resumes.
+
+        Mirrors how the blocking ``get_item`` reports an epoch boundary, so a caller can drain
+        epoch by epoch without ever blocking.
+        """
+        n = 32
+        ref = [x + 1 for x in range(n)]
+        pipeline = _build(n, thread_queue=thread_queue, continuous=True)
+        with pipeline.auto_stop():
+            for epoch in range(3):
+                with self.subTest(epoch=epoch):
+                    self.assertEqual(sorted(_drain_nowait(pipeline)), ref)
+
+    @parameterized.expand(_BACKENDS)
+    def test_requires_started_pipeline(self, _name: str, thread_queue: bool) -> None:
+        """Polling does not auto-start the pipeline the way ``get_item`` does.
+
+        A caller polling a pipeline it never started wants that surfaced, not silently fixed.
+        """
+        pipeline = _build(4, thread_queue=thread_queue)
+        with self.assertRaisesRegex(RuntimeError, "not started"):
+            pipeline._get_item_nowait()


### PR DESCRIPTION
Adds `Pipeline._get_item_nowait()`: return the next item if one is already buffered in the sink, otherwise raise. Internal -- the fused-region worker needs it later in this stack (in "Coalesce region output transfers") to drain a burst of already-produced results in one go, and there is no user-facing use case yet, so it stays underscore-prefixed rather than becoming public API.

`get_item(timeout=0)` is not a substitute, and that is the whole reason this exists. `_get_item_async_queue` submits `output_queue.get()` onto the event loop and polls the resulting future; when the timeout expires it abandons that future. The coroutine is still queued, so whatever item it later receives is consumed from the queue and dropped on the floor. With a zero timeout that happens on essentially every call.

The implementation normalizes the two sink backends onto one exception contract, so callers do not have to care which one is in use:

- an item, when one is buffered;
- `queue.Empty` -- nothing right now, but the pipeline is still running;
- `EOFError` -- the stream is over (exhausted, or an epoch boundary on a continuous source), matching how the blocking `get_item` reports the same condition.

For the asyncio-queue backend the read hops onto the event loop as a coroutine with no `await` in it, so it completes within a single loop tick and the future is never left pending -- which is what makes it safe where the blocking path is not. For the thread-queue backend it is a plain `get_nowait`.

Unlike `get_item`, this deliberately does not auto-start the pipeline: someone polling a pipeline they never started wants that surfaced, not silently fixed.