### PR TITLE
[pipeline] [1/2] Buffer transfers across a `to()` region boundary

### DIFF
--- a/src/spdl/pipeline/_components/_subprocess_pipe.py
+++ b/src/spdl/pipeline/_components/_subprocess_pipe.py
@@ -32,6 +32,15 @@ The wire protocol uses small integer message kinds (not sentinel objects): a sen
 onto a multiprocessing queue is a different object on the other side, so identity comparison
 would not survive the trip. ``_EPOCH_END`` itself never crosses — it is translated to the
 ``_EPOCH`` tag on the way in and re-emitted locally on the way out.
+
+``_ITEM`` and ``_RESULT`` payloads are **lists** of items, not single items, so a region whose
+marker sets ``buffer_size=N`` amortizes the fixed per-transfer cost (the pickle and unpickle
+calls, the queue feeder-thread handoff, the pipe write) over up to N items. Per-item costs such
+as a tensor's shared-memory segment are unaffected. An unbuffered region simply sends
+one-element lists. The packing and unpacking live entirely at this boundary — the feeder here
+and the worker source/sink in :py:mod:`spdl.pipeline._subprocess_pipeline_pool` — so the
+region's stages, and every stage outside it, still see individual items. Nothing assumes the two
+directions use the same chunk size, or that the region's output cardinality matches its input's.
 """
 
 from __future__ import annotations
@@ -61,13 +70,13 @@ __all__ = [
 ]
 
 # Input-queue message kinds (this stage -> worker).
-_ITEM = 0  # (_ITEM, value): one item for the sub-pipeline source
+_ITEM = 0  # (_ITEM, [value, ...]): one transfer of items for the sub-pipeline source
 _SESSION_END = 1  # (_SESSION_END, None): end of one input stream; finish the session
 _POOL_SHUTDOWN = 2  # (_POOL_SHUTDOWN, None): tear the worker down entirely
 _EPOCH = 3  # (_EPOCH, None): end of the current epoch (continuous mode); keep the worker alive
 
 # Output-queue message kinds (worker -> this stage).
-_RESULT = 0  # (_RESULT, value): one produced item
+_RESULT = 0  # (_RESULT, [value, ...]): one transfer of produced items
 _ERROR = 1  # (_ERROR, exc): the sub-pipeline failed
 _DONE = 2  # (_DONE, None): a worker finished (session end, or exiting)
 _EPOCH_DONE = (
@@ -138,8 +147,18 @@ async def _feed(
     abort: asyncio.Event,
     feeder_idle: asyncio.Event,
     put_stop: threading.Event,
+    buffer_size: int = 1,
 ) -> None:
-    """Round-robin items across the per-worker queues, then end every worker's session.
+    """Round-robin transfers across the per-worker queues, then end every worker's session.
+
+    Items are accumulated into a chunk of up to ``buffer_size`` and sent as one
+    ``_ITEM`` message; whole chunks, not individual items, are what round-robin across the
+    workers. The tail chunk is flushed before the end markers, so no item is left behind.
+
+    Accumulation blocks: filling a chunk means waiting for ``buffer_size`` items.
+    Flushing early on a momentarily empty upstream is pointless here, because the inter-stage
+    queues are only two deep — a non-blocking drain could never gather more than two or three
+    items and ``buffer_size`` would have no effect.
 
     Sends exactly one ``_SESSION_END`` onto each worker's own queue, so every worker ends
     its session exactly once. Per-worker queues (rather than one shared queue the workers
@@ -151,7 +170,8 @@ async def _feed(
 
     ``abort`` is set by :py:func:`_collect` on a worker error; once set, forwarding stops early
     and only the per-worker ``_SESSION_END`` markers are sent, so the workers wind down their
-    current sessions instead of churning through the rest of the stream.
+    current sessions instead of churning through the rest of the stream. A partly-filled chunk
+    is dropped on that path along with everything else still in flight.
 
     The next-item ``get`` is raced against ``abort`` rather than awaited directly: on the error
     path the feeder is often parked here waiting on a slow/idle upstream, and ``abort`` must still
@@ -164,6 +184,19 @@ async def _feed(
     abort_wait = create_task(abort.wait())
     i = 0
     n = len(in_qs)
+    buf: list[Any] = []
+    reached_eof = False
+
+    async def _flush() -> None:
+        nonlocal buf, i
+        if not buf:
+            return
+        chunk, buf = buf, []
+        await loop.run_in_executor(
+            executor, _put, in_qs[i % n], (_ITEM, chunk), put_stop
+        )
+        i += 1
+
     try:
         while not abort.is_set():
             get_task = create_task(input_queue.get())
@@ -179,13 +212,17 @@ async def _feed(
                 get_task.cancel()
                 feeder_idle.clear()
             if is_eof(item):
+                reached_eof = True
                 break
-            await loop.run_in_executor(
-                executor, _put, in_qs[i % n], (_ITEM, item), put_stop
-            )
-            i += 1
+            buf.append(item)
+            if len(buf) >= buffer_size:
+                await _flush()
     finally:
         abort_wait.cancel()
+    # Only the clean end-of-stream flushes its tail. Keyed on ``reached_eof`` rather than on
+    # ``abort`` so an abort racing the EOF break cannot discard a legitimate tail chunk.
+    if reached_eof:
+        await _flush()
     # Concurrent so a full/slow worker queue does not block the markers to the others.
     await asyncio.gather(
         *(
@@ -213,6 +250,9 @@ async def _collect(
     pipeline is already failing, and forwarding them could block on a no-longer-drained output
     queue.
 
+    Each ``_RESULT`` carries a list of items, which is unpacked onto the output queue one item
+    at a time so the region's buffering stays invisible downstream.
+
     The stall guard is suppressed while ``feeder_idle`` is set: an idle feeder means nothing is
     dispatched and no worker message is due, so a quiet ``out_q`` is input starvation, not a
     dead worker.
@@ -238,7 +278,8 @@ async def _collect(
                 error = payload
                 abort.set()
         elif kind == _RESULT and error is None:
-            await output_queue.put(payload)
+            for item in payload:
+                await output_queue.put(item)
     if error is not None:
         raise error
 
@@ -255,13 +296,23 @@ async def _feed_continuous(
     epoch_barrier: asyncio.Event,
     feeder_idle: asyncio.Event,
     put_stop: threading.Event,
+    buffer_size: int = 1,
 ) -> None:
-    """Round-robin items to per-worker queues; broadcast and barrier each epoch boundary.
+    """Round-robin transfers to per-worker queues; broadcast and barrier each epoch boundary.
+
+    Items are accumulated into chunks of up to ``buffer_size`` and sent as one
+    ``_ITEM`` message each, exactly as in :py:func:`_feed`.
 
     On an epoch boundary the next epoch's items must not be fed until every worker has drained
     the current epoch (otherwise results from two epochs would interleave). The feeder therefore
     broadcasts ``_EPOCH`` to all workers and waits on ``epoch_barrier``, which the collector sets
     once it has emitted the epoch's single ``_EPOCH_END`` downstream.
+
+    A partly-filled chunk **must** be flushed before that broadcast: an ``_ITEM`` put after the
+    ``_EPOCH`` marker would be drained by the worker as part of the *next* epoch, so the tail of
+    one epoch would silently reappear in the following one. Flushing first keeps the chunk ahead
+    of the marker on each worker's FIFO queue. The same applies to the ``_POOL_SHUTDOWN``
+    broadcast at end of stream.
 
     A single shared ``epoch_barrier`` is sufficient (rather than one per epoch) only because the
     feeder cannot advance past a boundary until the collector releases it: the feeder and
@@ -277,22 +328,35 @@ async def _feed_continuous(
 
     i = 0
     n = len(in_qs)
+    buf: list[Any] = []
+
+    async def _flush() -> None:
+        nonlocal buf, i
+        if not buf:
+            return
+        chunk, buf = buf, []
+        await loop.run_in_executor(
+            executor, _put, in_qs[i % n], (_ITEM, chunk), put_stop
+        )
+        i += 1
+
     while True:
         feeder_idle.set()
         item = await input_queue.get()
         feeder_idle.clear()
         if is_eof(item):
+            await _flush()
             await _broadcast((_POOL_SHUTDOWN, None))
             break
         if is_epoch_end(item):
+            await _flush()
             epoch_barrier.clear()
             await _broadcast((_EPOCH, None))
             await epoch_barrier.wait()
             continue
-        await loop.run_in_executor(
-            executor, _put, in_qs[i % n], (_ITEM, item), put_stop
-        )
-        i += 1
+        buf.append(item)
+        if len(buf) >= buffer_size:
+            await _flush()
 
 
 async def _collect_continuous(
@@ -330,7 +394,8 @@ async def _collect_continuous(
         last_progress = time.monotonic()
         kind, payload = res
         if kind == _RESULT:
-            await output_queue.put(payload)
+            for item in payload:
+                await output_queue.put(item)
         elif kind == _EPOCH_DONE:
             workers_at_boundary += 1
             if workers_at_boundary >= num_workers:
@@ -365,6 +430,8 @@ async def _subprocess_pipeline(
     """
     in_qs, out_q = handle.in_qs, handle.out_q
     num_workers = handle.max_workers
+    # Only the inbound size matters here; the worker owns the outbound one.
+    buffer_size = handle.input_buffer_size
     # One thread parked per concurrent blocking op: a put per input queue (the feeder broadcasts
     # epoch/session-end markers across all of them at once) plus the collector get.
     max_threads = len(in_qs) + 1
@@ -384,7 +451,13 @@ async def _subprocess_pipeline(
             epoch_barrier = asyncio.Event()
             feeder = create_task(
                 _feed_continuous(
-                    input_queue, in_qs, executor, epoch_barrier, feeder_idle, put_stop
+                    input_queue,
+                    in_qs,
+                    executor,
+                    epoch_barrier,
+                    feeder_idle,
+                    put_stop,
+                    buffer_size,
                 )
             )
             collector = create_task(
@@ -401,7 +474,15 @@ async def _subprocess_pipeline(
             # Set by the collector on a worker error so the feeder stops forwarding new items.
             abort = asyncio.Event()
             feeder = create_task(
-                _feed(input_queue, in_qs, executor, abort, feeder_idle, put_stop)
+                _feed(
+                    input_queue,
+                    in_qs,
+                    executor,
+                    abort,
+                    feeder_idle,
+                    put_stop,
+                    buffer_size,
+                )
             )
             collector = create_task(
                 _collect(out_q, num_workers, output_queue, executor, abort, feeder_idle)

--- a/src/spdl/pipeline/_pipeline.py
+++ b/src/spdl/pipeline/_pipeline.py
@@ -366,6 +366,69 @@ class _PipelineImpl(Generic[T]):
 
         raise TimeoutError(f"The next item is not available after {elapsed:.1f} sec.")
 
+    def get_item_nowait(self) -> T:
+        """Get the next item if one is already buffered in the sink, without blocking.
+
+        Raises:
+            RuntimeError: The pipeline is not started.
+
+            queue.Empty: No item is currently available. The pipeline is still running, so an
+                item may become available later.
+
+            EOFError: The pipeline is exhausted (or reached an epoch boundary) and the sink is
+                drained.
+        """
+        item = self._get_item_nowait()
+        if is_epoch_end(item):
+            raise EOFError(_EOF_MSG)
+        return item
+
+    async def _get_nowait_on_loop(self) -> T:
+        # Runs on the event loop thread. Deliberately has no ``await``: it completes within a
+        # single loop tick, so the future returned by ``run_coroutine_threadsafe`` is never left
+        # pending. That is what makes this safe where ``get_item(timeout=0)`` is not -- the
+        # latter submits ``queue.get()`` and abandons the future on timeout, stranding whatever
+        # item that ``get()`` eventually receives.
+        return self._output_queue.get_nowait()
+
+    def _get_item_nowait(self) -> T:
+        """Non-blocking counterpart of :py:meth:`_get_item`.
+
+        Normalizes the two queue backends onto one exception contract: ``queue.Empty`` for "not
+        yet", ``EOFError`` for "never". Callers can therefore drain opportunistically without
+        caring which backend the sink uses.
+        """
+        if not self._event_loop.is_started():
+            raise RuntimeError("Pipeline is not started.")
+
+        if isinstance(self._output_queue, _ThreadBasedAsyncQueue):
+            q = self._output_queue._queue  # pyre-ignore[16]
+            try:
+                return q.get_nowait()
+            except queue.Empty:
+                # Empty *and* the producing task is done means no item is ever coming.
+                if self._event_loop.is_task_completed() and q.empty():
+                    self._event_loop.stop()
+                    raise EOFError(_EOF_MSG) from None
+                raise
+
+        if self._event_loop.is_task_completed():
+            # The background loop no longer touches the sink, so direct access is thread-safe.
+            if not self._output_queue.empty():
+                return self._output_queue.get_nowait()
+            self._event_loop.stop()
+            raise EOFError(_EOF_MSG)
+
+        try:
+            return self._event_loop.run_coroutine_threadsafe(
+                self._get_nowait_on_loop()
+            ).result()
+        except asyncio.QueueEmpty:
+            if self._event_loop.is_task_completed() and self._output_queue.empty():
+                self._event_loop.stop()
+                raise EOFError(_EOF_MSG) from None
+            raise queue.Empty from None
+
     def _get_item_thread_queue(self, *, timeout: float | None) -> T:
         q = self._output_queue._queue  # pyre-ignore[16]
 
@@ -682,6 +745,24 @@ class Pipeline(Generic[T]):
         if self._impl._event_loop_state == _EventLoopState.NOT_STARTED:
             self.start()
         return self._impl.get_item(timeout=timeout)
+
+    def _get_item_nowait(self) -> T:
+        """Get the next item if one is already buffered, without blocking.
+
+        Internal: used to drain a burst of already-produced results in one go (see the
+        fused-region worker in :py:mod:`spdl.pipeline._subprocess_pipeline_pool`). Unlike
+        ``get_item(timeout=0)``, this cannot strand an item.
+
+        Raises:
+            RuntimeError: The pipeline is not started.
+
+            queue.Empty: No item is currently available.
+
+            EOFError: The pipeline is exhausted (or reached an epoch boundary) and drained.
+        """
+        # Unlike `get_item`, do not auto-start: a caller polling a not-yet-started pipeline
+        # wants "nothing available", and silently starting it here would hide a usage error.
+        return self._impl.get_item_nowait()
 
     def get_iterator(self, *, timeout: float | None = None) -> Iterator[T]:
         """Get an iterator, which iterates over the pipeline outputs.

--- a/src/spdl/pipeline/_subprocess_pipeline_pool.py
+++ b/src/spdl/pipeline/_subprocess_pipeline_pool.py
@@ -103,8 +103,9 @@ class _DrainSource:
 
     Used as a *continuous* source: :py:func:`spdl.pipeline._components._source._source_continuous`
     calls ``iter()`` once per epoch, so ``__iter__`` must return a fresh generator each time
-    (a one-shot generator object would only ever run one epoch). Each pass yields ``_ITEM``
-    payloads until an ``_EPOCH`` (epoch boundary) or ``_POOL_SHUTDOWN`` (teardown) message.
+    (a one-shot generator object would only ever run one epoch). Each pass yields the items
+    inside each ``_ITEM`` payload until an ``_EPOCH`` (epoch boundary) or ``_POOL_SHUTDOWN``
+    (teardown) message.
 
     ``exiting`` latches once ``_POOL_SHUTDOWN`` is seen; the worker loop reads it to stop after
     the current epoch. The blocking read uses a timeout so the drain thread wakes periodically
@@ -124,7 +125,10 @@ class _DrainSource:
                     return
                 continue
             if kind == _ITEM:
-                yield payload
+                # An ``_ITEM`` payload is always a list (one item when the region is
+                # unbuffered), so unpacking it here is what keeps the region's buffering
+                # invisible to the sub-pipeline's stages.
+                yield from payload
             elif kind == _EPOCH:
                 return
             else:  # _POOL_SHUTDOWN
@@ -149,7 +153,7 @@ def _run_sessions(
         while True:
             kind, payload = in_q.get()
             if kind == _ITEM:
-                yield payload
+                yield from payload
             elif kind == _SESSION_END:
                 session_ended = True
                 return
@@ -164,7 +168,7 @@ def _run_sessions(
             pipeline = build_pipeline(cfg, **build_kwargs)
             with pipeline.auto_stop():
                 for out in pipeline:
-                    out_q.put((_RESULT, out))
+                    out_q.put((_RESULT, [out]))
         except Exception as err:  # relayed to the submitter below
             out_q.put((_ERROR, _to_picklable_error(err, traceback.format_exc())))
             # A pipeline failure abandons the source generator mid-session, so this session's
@@ -210,7 +214,7 @@ def _run_continuous(
         with pipeline.auto_stop():
             while not source.exiting:
                 for out in pipeline:
-                    out_q.put((_RESULT, out))
+                    out_q.put((_RESULT, [out]))
                 if source.exiting:
                     break
                 out_q.put((_EPOCH_DONE, None))
@@ -253,7 +257,7 @@ def _pipeline_worker_loop(
 class _SubprocessPipelineHandle:
     """Picklable submit side of a :py:class:`_SubprocessPipelinePool`.
 
-    Holds only the queues, worker count, and mode, so it is cheap to carry inside a
+    Holds only the queues, worker count, mode, and transfer size, so it is cheap to carry in a
     :py:class:`~spdl.pipeline.defs.PipelineConfig` — including across the pickle boundary into a
     pipeline subprocess (the queues travel as ``Process`` spawn arguments, the only context in
     which an ``mp.Queue`` may be pickled). ``in_qs`` holds one input queue per worker in both
@@ -262,12 +266,18 @@ class _SubprocessPipelineHandle:
     """
 
     def __init__(
-        self, in_qs: list[Any], out_q: Any, max_workers: int, continuous: bool
+        self,
+        in_qs: list[Any],
+        out_q: Any,
+        max_workers: int,
+        continuous: bool,
+        input_buffer_size: int = 1,
     ) -> None:
         self.in_qs = in_qs
         self.out_q = out_q
         self.max_workers = max_workers
         self.continuous = continuous
+        self.input_buffer_size = input_buffer_size
 
 
 class _Worker:
@@ -441,12 +451,17 @@ class _SubprocessPipelinePool:
         initializer: Callable[..., object] | None,
         initargs: tuple[Any, ...],
         continuous: bool = False,
+        input_buffer_size: int = 1,
     ) -> None:
         # Bound the queues so a slow consumer/producer applies backpressure rather than
         # buffering without limit. Sized to keep every worker fed, plus in-flight slack.
+        # The bound counts *messages*, so with a buffer size above 1 the in-flight item
+        # bound is this times that. Left as-is deliberately: the depth is what keeps workers
+        # pipelined, and shrinking it in proportion would stall the pool at large sizes.
         size = max(4, max_workers * 2)
         self._backend = backend
         self._continuous = continuous
+        self._input_buffer_size = input_buffer_size
         self._out_q: Any = backend.make_queue(size)
         # One input queue per worker in both modes. Continuous mode needs it to broadcast epoch
         # boundaries cleanly; non-continuous mode needs it so each worker receives exactly one
@@ -507,7 +522,11 @@ class _SubprocessPipelinePool:
     def make_handle(self) -> _SubprocessPipelineHandle:
         """Create the picklable submit-side handle that rides in the pipeline config."""
         return _SubprocessPipelineHandle(
-            self._in_qs, self._out_q, self._max_workers, self._continuous
+            self._in_qs,
+            self._out_q,
+            self._max_workers,
+            self._continuous,
+            self._input_buffer_size,
         )
 
     def _broadcast_shutdown(self) -> None:

--- a/tests/pipeline/get_item_nowait_test.py
+++ b/tests/pipeline/get_item_nowait_test.py
@@ -1,0 +1,150 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""Tests for ``Pipeline._get_item_nowait``, the non-blocking sink read.
+
+The contract is three-way and has to hold identically on both sink backends: return an item,
+raise ``queue.Empty`` for "not yet", raise ``EOFError`` for "never". The load-bearing property
+is that polling can never *lose* an item -- that is precisely what makes this different from
+``get_item(timeout=0)``, which submits a ``queue.get()`` onto the event loop and abandons the
+future when the timeout expires, stranding whatever that get later receives.
+"""
+
+import queue
+import threading
+import time
+import unittest
+from typing import Any
+
+from parameterized import parameterized  # pyre-ignore[21]
+from spdl.pipeline import Pipeline, PipelineBuilder
+
+_TIMEOUT: float = 60.0
+
+_BACKENDS: list[tuple[str, bool]] = [("async_queue", False), ("thread_queue", True)]
+
+
+def add_one(x: int) -> int:
+    return x + 1
+
+
+# Held by the test so an op can be pinned mid-flight without relying on a sleep: the op
+# cannot return until the test releases it, so "the sink is empty" is a fact rather than a
+# race the host's load could lose.
+_RELEASE_OP: threading.Event = threading.Event()
+
+
+def blocks_until_released(x: int) -> int:
+    _RELEASE_OP.wait()
+    return x
+
+
+def _build(
+    n: int, *, thread_queue: bool, continuous: bool = False, op: Any = add_one
+) -> Pipeline[Any]:
+    return (
+        PipelineBuilder()
+        .add_source(range(n), continuous=continuous)
+        .pipe(op)
+        .add_sink(n or 1)
+        .build(num_threads=2, use_thread_output_queue=thread_queue)
+    )
+
+
+def _drain_nowait(pipeline: Pipeline[Any]) -> list[Any]:
+    """Pull one stream's worth of items using *only* ``_get_item_nowait``.
+
+    Spins on ``queue.Empty`` rather than blocking, so any item the poll drops would show up as a
+    short result rather than as a hang.
+    """
+    out: list[Any] = []
+    deadline = time.monotonic() + _TIMEOUT
+    while True:
+        try:
+            out.append(pipeline._get_item_nowait())
+        except EOFError:
+            return out
+        except queue.Empty:
+            if time.monotonic() > deadline:
+                raise AssertionError(
+                    f"timed out with {len(out)} items; an item was likely dropped"
+                ) from None
+            time.sleep(0.001)
+
+
+class GetItemNowaitTest(unittest.TestCase):
+    """The three-way contract holds identically on both sink backends."""
+
+    @parameterized.expand(_BACKENDS)
+    def test_drains_every_item(self, _name: str, thread_queue: bool) -> None:
+        """Polling alone yields the whole stream -- no item is stranded by a poll.
+
+        This is the regression guard for the abandoned-future bug that
+        ``get_item(timeout=0)`` would have had: a dropped item leaves the drain spinning on
+        ``queue.Empty`` until it gives up.
+        """
+        n = 200
+        pipeline = _build(n, thread_queue=thread_queue)
+        with pipeline.auto_stop():
+            self.assertEqual(sorted(_drain_nowait(pipeline)), [x + 1 for x in range(n)])
+
+    @parameterized.expand(_BACKENDS)
+    def test_empty_when_nothing_ready(self, _name: str, thread_queue: bool) -> None:
+        """A running pipeline with nothing produced yet raises ``queue.Empty``, not EOF.
+
+        The only op is pinned inside ``_RELEASE_OP`` until this test lets it go, so the sink is
+        deterministically empty while the pipeline is still running -- no sleep, and nothing for
+        a loaded host to race.
+        """
+        _RELEASE_OP.clear()
+        pipeline = _build(1, thread_queue=thread_queue, op=blocks_until_released)
+        try:
+            with pipeline.auto_stop():
+                with self.assertRaises(queue.Empty):
+                    pipeline._get_item_nowait()
+                # Release before teardown, or ``stop()`` waits on the pinned op.
+                _RELEASE_OP.set()
+        finally:
+            _RELEASE_OP.set()
+
+    @parameterized.expand(_BACKENDS)
+    def test_eof_when_exhausted(self, _name: str, thread_queue: bool) -> None:
+        """Once the source is drained and the task is done, polling reports ``EOFError``."""
+        pipeline = _build(4, thread_queue=thread_queue)
+        with pipeline.auto_stop():
+            self.assertEqual(sorted(_drain_nowait(pipeline)), [1, 2, 3, 4])
+            # _drain_nowait returns on the first EOFError; nothing further can appear.
+            with self.assertRaises(EOFError):
+                pipeline._get_item_nowait()
+
+    @parameterized.expand(_BACKENDS)
+    def test_epoch_boundary_reported_as_eof(
+        self, _name: str, thread_queue: bool
+    ) -> None:
+        """With a continuous source, each epoch ends in ``EOFError`` and the next one resumes.
+
+        Mirrors how the blocking ``get_item`` reports an epoch boundary, so a caller can drain
+        epoch by epoch without ever blocking.
+        """
+        n = 32
+        ref = [x + 1 for x in range(n)]
+        pipeline = _build(n, thread_queue=thread_queue, continuous=True)
+        with pipeline.auto_stop():
+            for epoch in range(3):
+                with self.subTest(epoch=epoch):
+                    self.assertEqual(sorted(_drain_nowait(pipeline)), ref)
+
+    @parameterized.expand(_BACKENDS)
+    def test_requires_started_pipeline(self, _name: str, thread_queue: bool) -> None:
+        """Polling does not auto-start the pipeline the way ``get_item`` does.
+
+        A caller polling a pipeline it never started wants that surfaced, not silently fixed.
+        """
+        pipeline = _build(4, thread_queue=thread_queue)
+        with self.assertRaisesRegex(RuntimeError, "not started"):
+            pipeline._get_item_nowait()

--- a/tests/pipeline/subprocess_pipe_bridge_test.py
+++ b/tests/pipeline/subprocess_pipe_bridge_test.py
@@ -23,7 +23,48 @@ from typing import Any
 
 from spdl.pipeline import AsyncQueue
 from spdl.pipeline._components import _subprocess_pipe
-from spdl.pipeline._components._common import StageInfo
+from spdl.pipeline._components._common import _EOF, _EPOCH_END, StageInfo
+
+
+def _unbounded_queue(name: str) -> AsyncQueue:
+    """An AsyncQueue with no depth limit (the default is 1, which would block these tests)."""
+    return AsyncQueue(
+        StageInfo(pipeline_id=0, stage_id="0", stage_name=name), buffer_size=0
+    )
+
+
+def _make_input_queue(items: list[Any]) -> AsyncQueue:
+    """A pre-filled stage input queue (unbounded, so the fill never blocks)."""
+    q = _unbounded_queue("input")
+    for item in items:
+        q.put_nowait(item)
+    return q
+
+
+class _AlwaysOpenBarrier(asyncio.Event):
+    """Epoch barrier stand-in that never blocks the feeder.
+
+    ``_feed_continuous`` clears the barrier, broadcasts ``_EPOCH``, then waits for the collector
+    to re-set it. These tests drive the feeder without a collector, so ``clear()`` is a no-op
+    and ``wait()`` returns immediately -- letting the feeder run straight through the boundary.
+    """
+
+    def clear(self) -> None:
+        pass
+
+
+def _drain(q: "_queue.Queue[Any]") -> list[Any]:
+    return [q.get_nowait() for _ in range(q.qsize())]
+
+
+def _items_of(msgs: list[Any]) -> list[Any]:
+    """Flatten the payloads of the ``_ITEM`` messages in ``msgs``, in order."""
+    return [
+        item
+        for kind, payload in msgs
+        if kind == _subprocess_pipe._ITEM
+        for item in payload
+    ]
 
 
 class FeedAbortTest(unittest.TestCase):
@@ -65,6 +106,245 @@ class FeedAbortTest(unittest.TestCase):
         msgs = asyncio.run(_scenario())
         # Every worker's own queue receives exactly one _SESSION_END.
         self.assertEqual(msgs, [[(_subprocess_pipe._SESSION_END, None)]] * num_workers)
+
+
+class FeedBufferingTest(unittest.TestCase):
+    """The feeder packs items into transfers of at most ``buffer_size``."""
+
+    @staticmethod
+    def _run_feed(
+        items: list[Any], num_workers: int, buffer_size: int
+    ) -> list[list[Any]]:
+        async def _scenario() -> list[list[Any]]:
+            in_qs: list[_queue.Queue[Any]] = [
+                _queue.Queue() for _ in range(num_workers)
+            ]
+            input_queue = _make_input_queue([*items, _EOF])
+            with ThreadPoolExecutor(max_workers=num_workers + 1) as ex:
+                await asyncio.wait_for(
+                    _subprocess_pipe._feed(
+                        input_queue,
+                        in_qs,
+                        ex,
+                        asyncio.Event(),
+                        asyncio.Event(),
+                        threading.Event(),
+                        buffer_size,
+                    ),
+                    timeout=10.0,
+                )
+            return [_drain(q) for q in in_qs]
+
+        return asyncio.run(_scenario())
+
+    def test_packs_full_chunks_and_tail(self) -> None:
+        """10 items at buffer_size=4 become transfers of 4, 4, 2 -- nothing dropped."""
+        msgs = self._run_feed(list(range(10)), num_workers=1, buffer_size=4)
+        payloads = [p for kind, p in msgs[0] if kind == _subprocess_pipe._ITEM]
+        self.assertEqual(payloads, [[0, 1, 2, 3], [4, 5, 6, 7], [8, 9]])
+        self.assertEqual(msgs[0][-1], (_subprocess_pipe._SESSION_END, None))
+
+    def test_unbuffered_sends_singleton_lists(self) -> None:
+        """buffer_size=1 (the default) still wraps each item in a one-element list."""
+        msgs = self._run_feed([7, 8], num_workers=1, buffer_size=1)
+        payloads = [p for kind, p in msgs[0] if kind == _subprocess_pipe._ITEM]
+        self.assertEqual(payloads, [[7], [8]])
+
+    def test_chunks_round_robin_across_workers(self) -> None:
+        """Whole chunks, not individual items, are distributed across the workers."""
+        msgs = self._run_feed(list(range(12)), num_workers=3, buffer_size=2)
+        payloads = [
+            [p for kind, p in worker if kind == _subprocess_pipe._ITEM]
+            for worker in msgs
+        ]
+        self.assertEqual(payloads[0], [[0, 1], [6, 7]])
+        self.assertEqual(payloads[1], [[2, 3], [8, 9]])
+        self.assertEqual(payloads[2], [[4, 5], [10, 11]])
+
+    def test_no_item_lost_when_count_not_divisible(self) -> None:
+        """Across every worker, the items fed reproduce the input exactly."""
+        items = list(range(23))
+        msgs = self._run_feed(items, num_workers=4, buffer_size=5)
+        fed = [item for worker in msgs for item in _items_of(worker)]
+        self.assertCountEqual(fed, items)
+        for worker in msgs:
+            self.assertEqual(worker[-1], (_subprocess_pipe._SESSION_END, None))
+
+    def test_empty_stream_sends_only_session_end(self) -> None:
+        """No items means no transfer -- just the per-worker end markers."""
+        msgs = self._run_feed([], num_workers=2, buffer_size=4)
+        self.assertEqual(msgs, [[(_subprocess_pipe._SESSION_END, None)]] * 2)
+
+    def test_abort_drops_partial_chunk(self) -> None:
+        """An abort discards the partly-filled chunk but still ends every session.
+
+        The feeder is given fewer items than ``buffer_size`` and no EOF, so it parks
+        holding a partial chunk. Aborting must not flush it -- the pipeline is already failing
+        -- but the ``_SESSION_END`` markers still have to go out, or the collector never sees
+        every ``_DONE``.
+        """
+
+        async def _scenario() -> list[list[Any]]:
+            in_qs: list[_queue.Queue[Any]] = [_queue.Queue() for _ in range(2)]
+            input_queue = _make_input_queue([1, 2])  # no EOF; fewer than buffer_size
+            abort = asyncio.Event()
+            with ThreadPoolExecutor(max_workers=3) as ex:
+                task = asyncio.ensure_future(
+                    _subprocess_pipe._feed(
+                        input_queue,
+                        in_qs,
+                        ex,
+                        abort,
+                        asyncio.Event(),
+                        threading.Event(),
+                        8,
+                    )
+                )
+                await asyncio.sleep(0.1)  # let it consume both and park
+                self.assertFalse(task.done())
+                abort.set()
+                await asyncio.wait_for(task, timeout=5.0)
+            return [_drain(q) for q in in_qs]
+
+        msgs = asyncio.run(_scenario())
+        self.assertEqual(msgs, [[(_subprocess_pipe._SESSION_END, None)]] * 2)
+
+
+class FeedContinuousBufferingTest(unittest.TestCase):
+    """Chunking in continuous mode, where a chunk must not straddle an epoch boundary."""
+
+    @staticmethod
+    def _run_feed_continuous(
+        items: list[Any], num_workers: int, buffer_size: int
+    ) -> list[list[Any]]:
+        async def _scenario() -> list[list[Any]]:
+            in_qs: list[_queue.Queue[Any]] = [
+                _queue.Queue() for _ in range(num_workers)
+            ]
+            input_queue = _make_input_queue([*items, _EOF])
+            epoch_barrier = _AlwaysOpenBarrier()
+            epoch_barrier.set()
+            with ThreadPoolExecutor(max_workers=num_workers + 1) as ex:
+                await asyncio.wait_for(
+                    _subprocess_pipe._feed_continuous(
+                        input_queue,
+                        in_qs,
+                        ex,
+                        epoch_barrier,
+                        asyncio.Event(),
+                        threading.Event(),
+                        buffer_size,
+                    ),
+                    timeout=10.0,
+                )
+            return [_drain(q) for q in in_qs]
+
+        return asyncio.run(_scenario())
+
+    def test_partial_chunk_flushed_before_epoch_marker(self) -> None:
+        """The tail of an epoch is queued ahead of ``_EPOCH``, not merged into the next epoch.
+
+        Five items at buffer_size=4 leave one buffered when the boundary arrives. If
+        that item were sent after the ``_EPOCH`` marker the worker would drain it as part of
+        epoch 1, silently moving data between epochs.
+        """
+        msgs = self._run_feed_continuous(
+            [0, 1, 2, 3, 4, _EPOCH_END, 5, 6], num_workers=1, buffer_size=4
+        )
+        kinds = [kind for kind, _ in msgs[0]]
+        epoch_at = kinds.index(_subprocess_pipe._EPOCH)
+        before = _items_of(msgs[0][:epoch_at])
+        after = _items_of(msgs[0][epoch_at:])
+        self.assertEqual(before, [0, 1, 2, 3, 4])
+        self.assertEqual(after, [5, 6])
+
+    def test_partial_chunk_flushed_before_shutdown(self) -> None:
+        """A partial chunk at end of stream is sent before ``_POOL_SHUTDOWN``."""
+        msgs = self._run_feed_continuous([0, 1], num_workers=1, buffer_size=8)
+        kinds = [kind for kind, _ in msgs[0]]
+        shutdown_at = kinds.index(_subprocess_pipe._POOL_SHUTDOWN)
+        self.assertEqual(_items_of(msgs[0][:shutdown_at]), [0, 1])
+
+    def test_epoch_marker_broadcast_to_every_worker(self) -> None:
+        """Every worker still receives the boundary, and no epoch's items leak across it."""
+        msgs = self._run_feed_continuous(
+            [*range(6), _EPOCH_END, *range(100, 106)],
+            num_workers=3,
+            buffer_size=2,
+        )
+        for worker in msgs:
+            kinds = [kind for kind, _ in worker]
+            self.assertIn(_subprocess_pipe._EPOCH, kinds)
+            epoch_at = kinds.index(_subprocess_pipe._EPOCH)
+            self.assertTrue(all(i < 100 for i in _items_of(worker[:epoch_at])))
+            self.assertTrue(all(i >= 100 for i in _items_of(worker[epoch_at:])))
+
+
+class CollectUnpackTest(unittest.TestCase):
+    """The collector unpacks a transfer back into individual downstream items."""
+
+    def test_collect_unpacks_in_order(self) -> None:
+        """Items within a ``_RESULT`` payload reach the output queue individually, in order."""
+
+        async def _scenario() -> list[Any]:
+            out_q: _queue.Queue[Any] = _queue.Queue()
+            out_q.put((_subprocess_pipe._RESULT, [1, 2, 3]))
+            out_q.put((_subprocess_pipe._RESULT, [4]))
+            out_q.put((_subprocess_pipe._DONE, None))
+            output_queue = _unbounded_queue("output")
+            with ThreadPoolExecutor(max_workers=2) as ex:
+                await asyncio.wait_for(
+                    _subprocess_pipe._collect(
+                        out_q, 1, output_queue, ex, asyncio.Event(), asyncio.Event()
+                    ),
+                    timeout=10.0,
+                )
+            return [output_queue.get_nowait() for _ in range(output_queue.qsize())]
+
+        self.assertEqual(asyncio.run(_scenario()), [1, 2, 3, 4])
+
+    def test_collect_continuous_unpacks_in_order(self) -> None:
+        """Same for the continuous collector, which also emits the epoch boundary."""
+
+        async def _scenario() -> list[Any]:
+            out_q: _queue.Queue[Any] = _queue.Queue()
+            out_q.put((_subprocess_pipe._RESULT, [1, 2]))
+            out_q.put((_subprocess_pipe._EPOCH_DONE, None))
+            out_q.put((_subprocess_pipe._DONE, None))
+            output_queue = _unbounded_queue("output")
+            epoch_barrier = asyncio.Event()
+            with ThreadPoolExecutor(max_workers=2) as ex:
+                await asyncio.wait_for(
+                    _subprocess_pipe._collect_continuous(
+                        out_q, 1, output_queue, ex, epoch_barrier, asyncio.Event()
+                    ),
+                    timeout=10.0,
+                )
+            return [output_queue.get_nowait() for _ in range(output_queue.qsize())]
+
+        self.assertEqual(asyncio.run(_scenario()), [1, 2, _EPOCH_END])
+
+    def test_results_after_error_are_discarded(self) -> None:
+        """A buffered transfer arriving after the first error is dropped wholesale."""
+
+        async def _scenario() -> list[Any]:
+            out_q: _queue.Queue[Any] = _queue.Queue()
+            out_q.put((_subprocess_pipe._RESULT, [1, 2]))
+            out_q.put((_subprocess_pipe._ERROR, RuntimeError("boom")))
+            out_q.put((_subprocess_pipe._RESULT, [3, 4]))
+            out_q.put((_subprocess_pipe._DONE, None))
+            output_queue = _unbounded_queue("output")
+            with ThreadPoolExecutor(max_workers=2) as ex:
+                with self.assertRaisesRegex(RuntimeError, "boom"):
+                    await asyncio.wait_for(
+                        _subprocess_pipe._collect(
+                            out_q, 1, output_queue, ex, asyncio.Event(), asyncio.Event()
+                        ),
+                        timeout=10.0,
+                    )
+            return [output_queue.get_nowait() for _ in range(output_queue.qsize())]
+
+        self.assertEqual(asyncio.run(_scenario()), [1, 2])
 
 
 class StallGuardTest(unittest.TestCase):


### PR DESCRIPTION
Crossing a `.to()` region boundary costs a fixed amount *per transfer* -- a `pickle.dumps`, a
queue feeder-thread handoff, a pipe write, a `pickle.loads`, and, for tensors, a shared-memory
allocation -- regardless of how small the item is. Until now the bridge sent exactly one item
per transfer, so for small items that fixed cost dominates.

The only workaround was to `aggregate()` *before* the region so a whole batch crossed at once.
That works, but it welds two unrelated knobs together: the batch size also becomes the IPC
transfer granularity, and every region stage has to be written list-to-list.

This adds `to(target, buffer_size=N)`, which buffers up to N items into a single transfer:

    .to(ProcessPoolExecutorConfig(max_workers=4), buffer_size=32)

The buffering is **transparent**. `_ITEM` and `_RESULT` payloads become lists; the feeder packs
items into one transfer and the worker's source unpacks them on arrival, so the region's stages
-- and everything downstream -- still see individual items. `buffer_size` is therefore independent of
any `aggregate()` inside or outside the region. The default, `1`, sends one-element lists and
is behaviorally identical to before.

Nothing assumes the region emits as many items as it received: a `None`-returning op, a
generator op, and an `aggregate` inside the region all keep working, because the two directions
chunk independently.

On the naming and placement:

- It is a **buffer**, not a batch. The value is an upper bound, not a fixed grouping: a partial
  buffer is flushed at end of stream and at every epoch boundary, so the last transfer is
  usually short. "Batch" is also already taken by `aggregate(batch_size)`, which is exactly the
  thing this is meant to be independent of. `buffer_size` is additionally the house term for
  "how many items are held" -- `add_sink`, `AsyncQueue` and `iterate_in_subprocess` all use it.
- It belongs on **`to()`**, not on the pool spec, because the thing that buffers is the bridge
  stage `to()` creates. The pool does not buffer; `max_workers`, `initializer` and `initargs`
  are `concurrent.futures.Executor` construction concepts, and a buffer is not one.
- `to()` is `@overload`ed so only a worker-pool target accepts `buffer_size`. Pairing it with
  `MAIN_PROCESS` -- which closes a region rather than crossing a boundary -- is therefore a type
  error, with a runtime check kept as the backstop for untyped callers.

Notes on the mechanism:

- **The input side blocks to fill a buffer.** Flushing early on a momentarily-empty upstream
  would be pointless here: inter-stage queues are two deep, so a non-blocking drain could never
  gather more than two or three items and the knob would have no effect.
- **A partial buffer is flushed before the epoch broadcast.** An `_ITEM` queued after the
  `_EPOCH` marker would be drained by the worker as part of the *next* epoch, silently moving
  data between epochs. Same for the shutdown broadcast at end of stream.
- **The abort path drops the partial buffer**, matching what already happens to in-flight items
  when the pipeline is failing.
- Output is still one item per transfer; buffering it is the next diff.

The cost is latency and memory: the pipeline holds up to `buffer_size - 1` items while filling
a transfer, and since each queued transfer holds up to that many items, the in-flight item
bound scales with it. Both are documented on the argument.

facebook:

The motivating case is a data loader whose region receives small per-row items; it moves to
this in the last diff of the stack.