### PR TITLE
[pipeline] [2/3] Coalesce outbound transfers out of a region

### DIFF
--- a/src/spdl/pipeline/_subprocess_pipeline_pool.py
+++ b/src/spdl/pipeline/_subprocess_pipeline_pool.py
@@ -136,11 +136,64 @@ class _DrainSource:
                 return
 
 
+def _drain_chunk(pipeline: Any, out: list[Any], output_buffer_size: int) -> bool:
+    """Append up to ``output_buffer_size`` results to ``out``, blocking only for the first.
+
+    Returns whether the current stream ended — an epoch in continuous mode, the session
+    otherwise. ``out`` can be non-empty when that happens, so the caller must flush before
+    acting on the end.
+
+    ``out`` is owned by the caller rather than returned so that results already collected are
+    still reachable (and flushable) if a read raises something other than ``EOFError``.
+
+    Only the first read blocks; the rest are non-blocking, so the chunk is flushed the moment
+    the sub-pipeline's sink runs dry. That is deliberate asymmetry with the input side (which
+    blocks to fill a chunk): a region's output cardinality need not match its input's — a region
+    ending in ``aggregate`` emits one large batch per many inputs — so blocking to fill an
+    output chunk could hold whole batches and multiply latency by that size. Draining only what
+    is already there adds no latency at all, at the cost of smaller chunks whenever the worker
+    is not saturated. The chunk therefore tracks how far the sub-pipeline is running ahead of
+    this drain: a fast region fills toward the bound (the producer keeps refilling the sink
+    mid-drain, so ``_FUSED_SINK_BUFFER`` does not cap it), while a slow one degenerates to one
+    item -- which is exactly when batching the return trip would not have helped anyway.
+    """
+    try:
+        out.append(pipeline.get_item())
+    except EOFError:
+        return True
+    while len(out) < output_buffer_size:
+        try:
+            out.append(pipeline._get_item_nowait())
+        except _queue.Empty:
+            return False
+        except EOFError:
+            return True
+    return False
+
+
+def _stream_results(pipeline: Any, out_q: Any, output_buffer_size: int) -> None:
+    """Forward one stream's (epoch's / session's) results to ``out_q`` in chunks.
+
+    Returns when the stream ends. Any results already collected are flushed even if a read
+    fails, so a mid-chunk failure relays the same results an unbuffered region would have.
+    """
+    while True:
+        chunk: list[Any] = []
+        try:
+            ended = _drain_chunk(pipeline, chunk, output_buffer_size)
+        finally:
+            if chunk:
+                out_q.put((_RESULT, chunk))
+        if ended:
+            return
+
+
 def _run_sessions(
     in_q: Any,
     out_q: Any,
     sub_config: PipelineConfig[Any],
     build_kwargs: dict[str, Any],
+    output_buffer_size: int,
 ) -> None:
     """Non-continuous worker body: one rebuilt sub-pipeline per input stream."""
     from spdl.pipeline._build import build_pipeline
@@ -167,8 +220,7 @@ def _run_sessions(
         try:
             pipeline = build_pipeline(cfg, **build_kwargs)
             with pipeline.auto_stop():
-                for out in pipeline:
-                    out_q.put((_RESULT, [out]))
+                _stream_results(pipeline, out_q, output_buffer_size)
         except Exception as err:  # relayed to the submitter below
             out_q.put((_ERROR, _to_picklable_error(err, traceback.format_exc())))
             # A pipeline failure abandons the source generator mid-session, so this session's
@@ -191,12 +243,13 @@ def _run_continuous(
     out_q: Any,
     sub_config: PipelineConfig[Any],
     build_kwargs: dict[str, Any],
+    output_buffer_size: int,
 ) -> None:
     """Continuous worker body: one warm sub-pipeline, one ``_EPOCH_DONE`` per epoch.
 
     The sub-pipeline is built once with a continuous source draining ``in_q``; each
-    ``for out in pipeline`` pass yields exactly one epoch's results (the continuous pipeline
-    turns each ``_EPOCH_END`` into an iterator stop), after which the worker reports
+    :py:func:`_stream_results` pass forwards exactly one epoch's results (the continuous
+    pipeline turns each ``_EPOCH_END`` into an end-of-stream), after which the worker reports
     ``_EPOCH_DONE`` and loops for the next epoch — keeping the pipeline's prefetch buffers warm.
 
     Unlike :py:func:`_run_sessions`, a fatal sub-pipeline error is terminal here: the worker
@@ -213,8 +266,7 @@ def _run_continuous(
         pipeline = build_pipeline(cfg, **build_kwargs)
         with pipeline.auto_stop():
             while not source.exiting:
-                for out in pipeline:
-                    out_q.put((_RESULT, [out]))
+                _stream_results(pipeline, out_q, output_buffer_size)
                 if source.exiting:
                     break
                 out_q.put((_EPOCH_DONE, None))
@@ -234,6 +286,7 @@ def _pipeline_worker_loop(
     continuous: bool,
     initializer: Callable[..., object] | None,
     initargs: tuple[Any, ...],
+    output_buffer_size: int,
 ) -> None:
     """Worker entry point: run the initializer, then dispatch to the matching body."""
     if initializer is not None:
@@ -249,15 +302,15 @@ def _pipeline_worker_loop(
             out_q.put((_DONE, None))
             return
     if continuous:
-        _run_continuous(in_q, out_q, sub_config, build_kwargs)
+        _run_continuous(in_q, out_q, sub_config, build_kwargs, output_buffer_size)
     else:
-        _run_sessions(in_q, out_q, sub_config, build_kwargs)
+        _run_sessions(in_q, out_q, sub_config, build_kwargs, output_buffer_size)
 
 
 class _SubprocessPipelineHandle:
     """Picklable submit side of a :py:class:`_SubprocessPipelinePool`.
 
-    Holds only the queues, worker count, mode, and transfer size, so it is cheap to carry in a
+    Holds only the queues, worker count, mode, and transfer sizes, so it is cheap to carry in a
     :py:class:`~spdl.pipeline.defs.PipelineConfig` — including across the pickle boundary into a
     pipeline subprocess (the queues travel as ``Process`` spawn arguments, the only context in
     which an ``mp.Queue`` may be pickled). ``in_qs`` holds one input queue per worker in both
@@ -272,12 +325,16 @@ class _SubprocessPipelineHandle:
         max_workers: int,
         continuous: bool,
         input_buffer_size: int = 1,
+        output_buffer_size: int = 1,
     ) -> None:
         self.in_qs = in_qs
         self.out_q = out_q
         self.max_workers = max_workers
         self.continuous = continuous
+        # Sized separately: the two directions rarely carry comparable items (a region ending
+        # in ``aggregate`` takes rows in and returns whole batches).
         self.input_buffer_size = input_buffer_size
+        self.output_buffer_size = output_buffer_size
 
 
 class _Worker:
@@ -452,6 +509,7 @@ class _SubprocessPipelinePool:
         initargs: tuple[Any, ...],
         continuous: bool = False,
         input_buffer_size: int = 1,
+        output_buffer_size: int = 1,
     ) -> None:
         # Bound the queues so a slow consumer/producer applies backpressure rather than
         # buffering without limit. Sized to keep every worker fed, plus in-flight slack.
@@ -462,6 +520,7 @@ class _SubprocessPipelinePool:
         self._backend = backend
         self._continuous = continuous
         self._input_buffer_size = input_buffer_size
+        self._output_buffer_size = output_buffer_size
         self._out_q: Any = backend.make_queue(size)
         # One input queue per worker in both modes. Continuous mode needs it to broadcast epoch
         # boundaries cleanly; non-continuous mode needs it so each worker receives exactly one
@@ -487,6 +546,7 @@ class _SubprocessPipelinePool:
                             continuous,
                             initializer,
                             initargs,
+                            output_buffer_size,
                         ),
                     )
                 )
@@ -527,6 +587,7 @@ class _SubprocessPipelinePool:
             self._max_workers,
             self._continuous,
             self._input_buffer_size,
+            self._output_buffer_size,
         )
 
     def _broadcast_shutdown(self) -> None:

--- a/tests/pipeline/subprocess_pipeline_pool_test.py
+++ b/tests/pipeline/subprocess_pipeline_pool_test.py
@@ -1,0 +1,134 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""Tests for the fused worker's result chunking (``_subprocess_pipeline_pool``).
+
+Output coalescing is invisible end to end -- it changes how many transfers a worker sends, not
+what comes out of the region -- so the properties that matter are asserted here against a
+scripted stand-in for the nested pipeline rather than through a real worker pool. That keeps
+"blocks exactly once", "stops at the bound" and "flushes what it already has" deterministic
+instead of dependent on how fast a subprocess happens to produce.
+"""
+
+import queue
+import unittest
+from typing import Any
+
+from spdl.pipeline._components import _RESULT
+from spdl.pipeline._subprocess_pipeline_pool import _drain_chunk, _stream_results
+
+# Script markers for _FakePipeline.
+_EOF: object = object()  # raise EOFError -- end of the epoch/session
+_EMPTY: object = object()  # raise queue.Empty -- nothing buffered right now
+_BOOM: object = object()  # raise RuntimeError -- an unexpected failure mid-chunk
+
+
+class _FakePipeline:
+    """Nested pipeline stand-in driven by two scripted call sequences.
+
+    ``blocking`` is consumed by ``get_item`` and ``ready`` by ``_get_item_nowait``, so a test
+    states exactly which reads block and which find something already buffered.
+    """
+
+    def __init__(self, blocking: list[Any], ready: list[Any]) -> None:
+        self.blocking: list[Any] = list(blocking)
+        self.ready: list[Any] = list(ready)
+        self.blocking_calls: int = 0
+        self.nowait_calls: int = 0
+
+    @staticmethod
+    def _pop(seq: list[Any], name: str) -> Any:
+        if not seq:
+            raise AssertionError(f"{name} was called more times than the test scripted")
+        value = seq.pop(0)
+        if value is _EOF:
+            raise EOFError
+        if value is _EMPTY:
+            raise queue.Empty
+        if value is _BOOM:
+            raise RuntimeError("boom")
+        return value
+
+    def get_item(self) -> Any:
+        self.blocking_calls += 1
+        return self._pop(self.blocking, "get_item")
+
+    def _get_item_nowait(self) -> Any:
+        self.nowait_calls += 1
+        return self._pop(self.ready, "_get_item_nowait")
+
+
+class DrainChunkTest(unittest.TestCase):
+    """``_drain_chunk`` blocks for the first result and then takes only what is ready."""
+
+    def test_takes_ready_items_after_one_blocking_read(self) -> None:
+        """One read blocks; the rest of the chunk comes from what is already buffered."""
+        pipeline = _FakePipeline(blocking=[1], ready=[2, 3, _EMPTY])
+        out: list[Any] = []
+        self.assertFalse(_drain_chunk(pipeline, out, 8))
+        self.assertEqual(out, [1, 2, 3])
+        self.assertEqual(pipeline.blocking_calls, 1)
+
+    def test_stops_at_output_buffer_size(self) -> None:
+        """The chunk is capped even when more results are already available."""
+        pipeline = _FakePipeline(blocking=[1], ready=[2, 3, 4, 5])
+        out: list[Any] = []
+        self.assertFalse(_drain_chunk(pipeline, out, 3))
+        self.assertEqual(out, [1, 2, 3])
+        self.assertEqual(pipeline.ready, [4, 5])  # not over-drained
+
+    def test_output_buffer_size_one_never_polls(self) -> None:
+        """An unbuffered region pays nothing for coalescing: no non-blocking read happens."""
+        pipeline = _FakePipeline(blocking=[1], ready=[])
+        out: list[Any] = []
+        self.assertFalse(_drain_chunk(pipeline, out, 1))
+        self.assertEqual(out, [1])
+        self.assertEqual(pipeline.nowait_calls, 0)
+
+    def test_end_of_stream_on_first_read(self) -> None:
+        """An epoch/session that produced nothing reports the end with an empty chunk."""
+        pipeline = _FakePipeline(blocking=[_EOF], ready=[])
+        out: list[Any] = []
+        self.assertTrue(_drain_chunk(pipeline, out, 8))
+        self.assertEqual(out, [])
+
+    def test_end_of_stream_mid_chunk_keeps_items(self) -> None:
+        """Hitting the end while filling a chunk keeps what was already collected.
+
+        The caller flushes ``out`` before acting on the end, so these results must survive.
+        """
+        pipeline = _FakePipeline(blocking=[1], ready=[2, _EOF])
+        out: list[Any] = []
+        self.assertTrue(_drain_chunk(pipeline, out, 8))
+        self.assertEqual(out, [1, 2])
+
+
+class StreamResultsTest(unittest.TestCase):
+    """``_stream_results`` forwards one stream as a sequence of chunked transfers."""
+
+    def test_emits_one_transfer_per_chunk(self) -> None:
+        """Each chunk becomes one ``_RESULT`` message; the empty final one is skipped."""
+        pipeline = _FakePipeline(blocking=[1, 4, _EOF], ready=[2, 3, _EMPTY, _EMPTY])
+        out_q: queue.Queue[Any] = queue.Queue()
+        _stream_results(pipeline, out_q, 8)
+        self.assertEqual(
+            [out_q.get_nowait() for _ in range(out_q.qsize())],
+            [(_RESULT, [1, 2, 3]), (_RESULT, [4])],
+        )
+
+    def test_flushes_collected_results_before_propagating_a_failure(self) -> None:
+        """A failure mid-chunk still relays what was produced before it.
+
+        Without the flush, buffering would silently lose results that an unbuffered region
+        would have delivered.
+        """
+        pipeline = _FakePipeline(blocking=[1], ready=[2, _BOOM])
+        out_q: queue.Queue[Any] = queue.Queue()
+        with self.assertRaisesRegex(RuntimeError, "boom"):
+            _stream_results(pipeline, out_q, 8)
+        self.assertEqual(out_q.get_nowait(), (_RESULT, [1, 2]))


### PR DESCRIPTION
The previous diff taught the boundary to carry several items per transfer *into* a region.
This does the same for results coming back out, so a region with small outputs stops paying the
full per-transfer cost on the return trip.

The two directions are **not** symmetric, deliberately. Inbound blocks until it has a full
transfer. Outbound must not: a region's output cardinality need not match its input's -- one
ending in `aggregate` emits a whole batch per many inputs -- so blocking to fill an outbound
transfer would hold whole batches and multiply latency and worker memory by the size.

Instead the worker takes the first result blocking, then drains only what is *already*
available, up to the bound. That adds no latency -- a transfer is never held waiting on
something not yet produced -- at the cost of smaller transfers when the worker is not
saturated. The size therefore tracks how far the sub-pipeline is running ahead of the drain: a
fast region fills toward the bound, a slow one degenerates to one item, which is exactly when
batching the return trip would not have helped anyway. (Note the sink depth does not cap this,
as one might expect -- the producer keeps refilling the sink mid-drain.)

`_drain_chunk` appends into a caller-owned list rather than returning one, so results already
collected stay reachable if a read raises something other than `EOFError`; `_stream_results`
flushes them before letting the failure propagate. Without that, a mid-transfer failure would
silently drop results an unbuffered region would have delivered.

The non-blocking read is `Pipeline._get_item_nowait` from earlier in the stack.

As with the inbound size, the handle carries the outbound one defaulting to 1, which reproduces
exactly today's one-result-per-transfer behavior. The two are separate fields rather than one
because the directions rarely carry comparable items.

Second of three. Internal only -- still no public API changes and no observable behavior
change; the `.to()` argument that turns both directions on lands in the next diff.