### PR TITLE
[pipeline] [3/3] Expose `buffer_size` on `PipelineBuilder.to()`

### DIFF
--- a/docs/source/getting_started/parallelism.rst
+++ b/docs/source/getting_started/parallelism.rst
@@ -386,6 +386,63 @@ worker sub-pipelines warm across epochs, and a region composes with
 since the region config is shipped to the worker. See the
 :py:meth:`~spdl.pipeline.PipelineBuilder.to` reference for the details.
 
+Buffering the boundary
+^^^^^^^^^^^^^^^^^^^^^^
+
+Crossing the region boundary costs a fixed amount *per transfer* — pickling, a
+queue handoff, and (for tensors) a shared-memory allocation — no matter how small
+the item is. When the items are small, that fixed cost dominates. Pass
+``buffer_size`` to :py:meth:`~PipelineBuilder.to` to buffer several items into one
+transfer:
+
+.. code-block::
+
+   pipeline = (
+       PipelineBuilder()
+       .add_source(rows)                  # small per-row items
+       .to(ProcessPoolExecutorConfig(max_workers=4), buffer_size=32)
+       .pipe(decode)                      # still receives ONE row at a time
+       .aggregate(batch_size)             # independent of buffer_size
+       .to(MAIN_PROCESS, buffer_size=2)   # 2 batches per transfer coming back
+       .add_sink()
+       .build(num_threads=...)
+   )
+
+Each marker sizes the handoff that happens where it sits, so a region's two
+directions are configured independently: the ``to()`` that opens the region sizes
+the data flowing into its workers, and the one that closes it sizes the results
+flowing back. That separation matters because the two directions rarely carry
+comparable items — in the example above, single rows go in and whole batches come
+back, so one number could not be right for both. A marker sitting between two
+adjacent regions sizes that single handoff for both sides.
+
+The buffering is transparent: the boundary packs items on one side and unpacks them
+on the other, so stages on both sides — and every stage after the region — still see
+individual items. In particular ``buffer_size`` is independent of any
+:py:meth:`~spdl.pipeline.PipelineBuilder.aggregate` you use, so the training batch
+size and the IPC transfer size can be tuned separately. The default, ``1``,
+transfers one item at a time.
+
+It is an upper bound rather than a fixed grouping: a partial buffer is flushed at
+the end of a stream and at every epoch boundary, so the last transfer of each is
+usually short.
+
+Nothing assumes the region emits as many items as it received: a ``None``-returning
+op, a generator op, and an ``aggregate`` inside the region all work unchanged.
+
+The cost is latency and memory. Up to ``buffer_size - 1`` items are held while a
+transfer fills, so a value well above what the producing side can keep up with
+delays the first results; and because each queued transfer holds up to
+``buffer_size`` items, the in-flight item bound scales with it. Start at the batch
+size you would otherwise have aggregated before the region, then tune.
+
+.. note::
+
+   Placing ``aggregate`` *inside* a region means each worker aggregates only the
+   items routed to it, so batches are formed per worker rather than globally. With
+   ``drop_last=True`` that discards up to ``max_workers × (batch_size - 1)`` items
+   per epoch instead of ``batch_size - 1``.
+
 To run a region in **subinterpreters** (Python 3.14+) instead of subprocesses,
 pass a :py:class:`~spdl.pipeline.defs.InterpreterPoolExecutorConfig`; the region's ops
 must avoid NumPy/PyTorch, which cannot be imported in a subinterpreter.

--- a/src/spdl/pipeline/_builder.py
+++ b/src/spdl/pipeline/_builder.py
@@ -64,6 +64,14 @@ def _has_ordered_pipe(cfg: object) -> bool:
     return False
 
 
+def _validate_buffer_size(buffer_size: int) -> None:
+    """Reject a ``buffer_size`` that cannot form a transfer."""
+    if buffer_size < 1:
+        raise ValueError(
+            f"`buffer_size` must be a positive integer. Got: {buffer_size}."
+        )
+
+
 def _validate_executor_regions(
     pipes: Sequence[
         PipeConfig
@@ -78,8 +86,8 @@ def _validate_executor_regions(
     Stateless scan (a pipeline starts on the main process). Rejects: a subinterpreter region on
     Python < 3.14; a stage using ``output_order="input"`` inside a region (including one nested
     in a ``path_variants`` branch, since order cannot be preserved across independent workers); an
-    empty region (a ``.to(...)`` marker with no stages before the next marker/sink); and a region
-    left open at the sink.
+    empty region (a ``.to(...)`` marker with no stages before the next marker/sink); a region
+    left open at the sink; and an invalid ``buffer_size``.
     """
     in_region = False
     region_has_stage = False
@@ -96,6 +104,7 @@ def _validate_executor_regions(
             target = p.target
             in_region = not isinstance(target, _MainProcess)
             region_has_stage = False
+            _validate_buffer_size(p.buffer_size)
             if isinstance(
                 target, InterpreterPoolExecutorConfig
             ) and sys.version_info < (3, 14):
@@ -318,10 +327,15 @@ class PipelineBuilder(Generic[T, U]):
         self,
         target: "ProcessPoolExecutorConfig | InterpreterPoolExecutorConfig | _MainProcess",
         /,
+        *,
+        buffer_size: int = 1,
     ) -> "PipelineBuilder[T, U]":
         """**[Experimental]** Designate where the subsequent stages execute.
 
         .. versionadded:: 0.6.0
+
+        .. versionadded:: 0.7.0
+           The ``buffer_size`` argument.
 
         Opens (or closes) an *execution region*: every stage added after this call runs on
         ``target`` until the next :py:meth:`to`. A pipeline starts on the main process, so a
@@ -356,6 +370,49 @@ class PipelineBuilder(Generic[T, U]):
                 so the pipeline stays expressible as static config. To run a single stage on a
                 custom executor, use ``pipe(executor=...)`` instead.
 
+            buffer_size: At most this many items are buffered into a single transfer *at
+                this marker*. Default ``1`` (one item per transfer).
+
+                Crossing a process boundary costs a fixed amount per transfer — the pickle
+                and unpickle calls, the queue feeder-thread handoff and the pipe write —
+                regardless of how small the item is. Buffering amortizes that over several
+                items. Costs that are inherently *per item* are not amortized: a tensor still
+                needs its own shared-memory segment whether or not it shares a transfer.
+
+                Each marker sizes the handoff that happens where it sits, so a region's two
+                directions are configured independently::
+
+                    .to(pool, buffer_size=32)      # 32 rows per transfer into the workers
+                    .aggregate(batch_size)
+                    .to(MAIN_PROCESS, buffer_size=2)   # 2 batches per transfer coming back
+
+                Keeping them separate matters because the two directions rarely carry
+                comparable items: with an :py:meth:`aggregate` inside the region, single rows
+                go in and whole batches come back, so one number cannot be right for both.
+
+                It is an upper bound, not a fixed grouping: a partial buffer is flushed at the
+                end of a stream and at every epoch boundary, so the last transfer of each is
+                usually short.
+
+                The buffering is **transparent**: stages on both sides still receive individual
+                items, so ``buffer_size`` is independent of any :py:meth:`aggregate` you place
+                inside or outside the region.
+
+                The trade-off is latency: up to ``buffer_size - 1`` items are held while a
+                transfer fills, so a value well above what the producing side can keep up with
+                delays the first results. It also raises the in-flight item bound, since each
+                queued transfer now holds up to ``buffer_size`` items.
+
+                .. warning::
+
+                   Whole transfers, not individual items, are distributed across the pool's
+                   workers. Keep ``buffer_size × max_workers`` well below the number of items
+                   in a stream (or in one epoch, for a
+                   :py:meth:`continuous source <add_source>`), or some workers get no work at
+                   all: 50 items per epoch with ``max_workers=8`` and ``buffer_size=64`` puts
+                   every item in one transfer on a single worker and leaves the other seven
+                   idle.
+
         .. note::
 
            The region must be closed with ``to(MAIN_PROCESS)`` before :py:meth:`add_sink`, a
@@ -377,7 +434,13 @@ class PipelineBuilder(Generic[T, U]):
                 "`to()` target must be a ProcessPoolExecutorConfig, InterpreterPoolExecutorConfig, or "
                 f"MAIN_PROCESS. Got: {type(target).__name__}."
             )
-        self._process_args.append(PlacementConfig(target=target))
+        # Raised here so it points at the offending `to()` call. `get_config()` re-checks the
+        # assembled markers, but a `PipelineConfig` hand-built without the builder and passed
+        # straight to `build_pipeline()` bypasses both.
+        _validate_buffer_size(buffer_size)
+        self._process_args.append(
+            PlacementConfig(target=target, buffer_size=buffer_size)
+        )
         return self
 
     def path_variants(

--- a/src/spdl/pipeline/_fuse.py
+++ b/src/spdl/pipeline/_fuse.py
@@ -183,6 +183,8 @@ def _build_fused_stage_core(
     user_initargs: tuple[Any, ...],
     report_stats_interval: float,
     continuous: bool,
+    input_buffer_size: int,
+    output_buffer_size: int,
 ) -> tuple[_SubprocessPipelineConfig, _SubprocessPipelinePool]:
     """Spawn a worker pool that runs ``stages`` as a nested pipeline; return the pool and its
     replacement stage. Called by :py:func:`_build_fused_stage_from_spec` once the pool
@@ -210,8 +212,20 @@ def _build_fused_stage_core(
         initializer,
         (),
         continuous=continuous,
+        input_buffer_size=input_buffer_size,
+        output_buffer_size=output_buffer_size,
     )
     name = "subprocess_pipeline(" + "+".join(_stage_name(s) for s in stages) + ")"
+    # Surface the transfer granularity in stats output; a buffered boundary changes how this
+    # stage's queue occupancy should be read. Each direction appears only when it is not the
+    # default, since the two are configured separately.
+    sizes = [
+        f"{label}={size}"
+        for label, size in (("in", input_buffer_size), ("out", output_buffer_size))
+        if size != 1
+    ]
+    if sizes:
+        name += "[buffer_size " + " ".join(sizes) + "]"
     return _SubprocessPipelineConfig(name=name, handle=pool.make_handle()), pool
 
 
@@ -221,13 +235,17 @@ def _build_fused_stage_from_spec(
     backend: _PoolBackend,
     report_stats_interval: float,
     continuous: bool,
+    input_buffer_size: int,
+    output_buffer_size: int,
 ) -> tuple[_SubprocessPipelineConfig, _SubprocessPipelinePool]:
     """Build the worker pool and replacement stage for one ``.to()`` region, reading the pool
     parameters from ``spec``. ``num_threads`` for the nested pipeline is the sum of the region
     stages' concurrency plus one for its source, ``max_workers`` falls back to the CPU count,
     and ``report_stats_interval`` is inherited from
     :py:func:`~spdl.pipeline._build.build_pipeline`. ``backend`` (process or subinterpreter) is
-    chosen by the caller from the spec type."""
+    chosen by the caller from the spec type. The two buffer sizes come from the region's
+    :py:class:`~spdl.pipeline.defs.PlacementConfig` markers, not from ``spec``: they describe
+    the boundary crossings rather than the pool."""
     # ``+ _SOURCE_THREADS``: the nested pipeline's source is a *blocking* read of the worker's
     # input queue, dispatched onto the very same thread pool as the region's ops. Sizing that
     # pool by op concurrency alone lets the read occupy every thread, so the ops cannot drain
@@ -244,6 +262,8 @@ def _build_fused_stage_from_spec(
         user_initargs=spec.initargs,
         report_stats_interval=report_stats_interval,
         continuous=continuous,
+        input_buffer_size=input_buffer_size,
+        output_buffer_size=output_buffer_size,
     )
 
 
@@ -291,9 +311,13 @@ def _fuse_marked_regions(
     target: ProcessPoolExecutorConfig | InterpreterPoolExecutorConfig | _MainProcess = (
         _MainProcess()
     )
+    # Tracked alongside ``target``: the marker that opens a region sizes the transfers into
+    # it, and the marker that closes it sizes the results coming back. Adjacent regions each
+    # get their own, and the marker between them sizes that single handoff for both sides.
+    input_buffer_size: int = 1
     region: list[object] = []
 
-    def _flush() -> None:
+    def _flush(output_buffer_size: int) -> None:
         if not region:
             return
         backend: _PoolBackend
@@ -314,7 +338,13 @@ def _fuse_marked_regions(
         else:  # pragma: no cover -- a main-process target never accumulates a region
             raise AssertionError(f"Unexpected region target: {target!r}")
         fused, pool = _build_fused_stage_from_spec(
-            region, target, backend, report_stats_interval, continuous
+            region,
+            target,
+            backend,
+            report_stats_interval,
+            continuous,
+            input_buffer_size,
+            output_buffer_size,
         )
         pools.append(pool)
         new_pipes.append(fused)
@@ -323,13 +353,18 @@ def _fuse_marked_regions(
     try:
         for p in pipes:
             if isinstance(p, PlacementConfig):
-                _flush()  # close the span running under the previous target
+                # ``p`` both closes the span under the previous target (so it sizes that
+                # region's way out) and opens the next one (sizing its way in).
+                _flush(p.buffer_size)
                 target = p.target
+                input_buffer_size = p.buffer_size
             elif isinstance(target, _MainProcess):
                 new_pipes.append(p)
             else:
                 region.append(p)
-        _flush()  # close a region left open at the end of the pipes
+        # A region left open at the end has no closing marker to size its output; the
+        # builder rejects that shape, so this only guards hand-built configs.
+        _flush(1)
     except BaseException:
         # Reap any pools spawned before the failure; the caller never receives them to reap.
         for pool in pools:

--- a/src/spdl/pipeline/defs/_defs.py
+++ b/src/spdl/pipeline/defs/_defs.py
@@ -543,8 +543,33 @@ class PlacementConfig:
     name: str = "placement"
     """Name of the marker (used only for display)."""
 
+    buffer_size: int = 1
+    """At most this many items are buffered into one transfer *at this marker*.
+
+    Crossing a process boundary costs a fixed amount per transfer — the pickle and unpickle
+    calls, the queue feeder-thread handoff and the pipe write — no matter how small the item is.
+    ``1`` (the default) passes one item at a time; a larger value amortizes that over several
+    items. Per-item costs are unaffected: a tensor still needs its own shared-memory segment
+    whether or not it shares a transfer.
+
+    Each marker sizes the handoff that happens where it sits, so a region's entry and exit are
+    configured independently: the marker that *opens* a region sizes data flowing into its
+    workers, and the marker that *closes* it sizes results flowing back. That separation
+    matters because the two directions rarely carry comparable items — a region ending in
+    :py:func:`Aggregate` takes single rows in and returns whole batches.
+
+    It is an upper bound rather than a fixed grouping: a partial buffer is flushed at the end of
+    a stream and at every epoch boundary, so the last transfer is usually short.
+
+    The buffering is transparent — stages on both sides still see individual items, so this is
+    independent of any :py:func:`Aggregate` inside or outside the region.
+
+    .. versionadded:: 0.7.0
+    """
+
     def __repr__(self) -> str:
-        return f"{self.name}({self.target!r})"
+        buf = f", buffer_size={self.buffer_size}" if self.buffer_size != 1 else ""
+        return f"{self.name}({self.target!r}{buf})"
 
 
 ################################################################################

--- a/tests/pipeline/builder_to_test.py
+++ b/tests/pipeline/builder_to_test.py
@@ -78,6 +78,99 @@ class ToMethodTest(unittest.TestCase):
             b.to("subprocess")  # type: ignore[arg-type]
 
 
+class ToBufferSizeTest(unittest.TestCase):
+    """``to(..., buffer_size=N)``, which sets the region's transfer granularity."""
+
+    def test_defaults_to_one(self) -> None:
+        """Omitting buffer_size means one item per transfer."""
+        config = (
+            PipelineBuilder()
+            .add_source(range(4))
+            .to(ProcessPoolExecutorConfig(max_workers=1))
+            .pipe(add_one)
+            .to(MAIN_PROCESS)
+            .add_sink()
+            .get_config()
+        )
+        markers = [p for p in config.pipes if isinstance(p, PlacementConfig)]
+        self.assertEqual([m.buffer_size for m in markers], [1, 1])
+
+    def test_recorded_on_marker(self) -> None:
+        """buffer_size is carried on the PlacementConfig that opens the region."""
+        config = (
+            PipelineBuilder()
+            .add_source(range(4))
+            .to(ProcessPoolExecutorConfig(max_workers=1), buffer_size=8)
+            .pipe(add_one)
+            .to(MAIN_PROCESS)
+            .add_sink()
+            .get_config()
+        )
+        markers = [p for p in config.pipes if isinstance(p, PlacementConfig)]
+        self.assertEqual([m.buffer_size for m in markers], [8, 1])
+
+    def test_per_region(self) -> None:
+        """Adjacent regions each keep their own buffer_size."""
+        config = (
+            PipelineBuilder()
+            .add_source(range(4))
+            .to(ProcessPoolExecutorConfig(max_workers=1), buffer_size=4)
+            .pipe(add_one)
+            .to(ProcessPoolExecutorConfig(max_workers=1), buffer_size=16)
+            .pipe(times_two)
+            .to(MAIN_PROCESS)
+            .add_sink()
+            .get_config()
+        )
+        markers = [p for p in config.pipes if isinstance(p, PlacementConfig)]
+        self.assertEqual([m.buffer_size for m in markers], [4, 16, 1])
+
+    def test_not_carried_on_the_pool_spec(self) -> None:
+        """The knob belongs to the boundary, not to the worker pool behind it."""
+        self.assertFalse(hasattr(ProcessPoolExecutorConfig(), "buffer_size"))
+        self.assertFalse(hasattr(InterpreterPoolExecutorConfig(), "buffer_size"))
+
+    def test_accepted_on_main_process(self) -> None:
+        """Closing a region is a boundary too -- results cross back there, so it takes a size.
+
+        Each marker sizes the handoff at its own position, so a region's entry and exit are set
+        independently.
+        """
+        config = (
+            PipelineBuilder()
+            .add_source(range(4))
+            .to(ProcessPoolExecutorConfig(max_workers=1), buffer_size=32)
+            .pipe(add_one)
+            .to(MAIN_PROCESS, buffer_size=2)
+            .add_sink()
+            .get_config()
+        )
+        markers = [p for p in config.pipes if isinstance(p, PlacementConfig)]
+        self.assertEqual([m.buffer_size for m in markers], [32, 2])
+
+    def test_rejects_non_positive(self) -> None:
+        """A buffer_size below 1 cannot form a transfer and is rejected at the call site."""
+        b = PipelineBuilder().add_source(range(4))
+        for bad in (0, -1):
+            with self.subTest(buffer_size=bad):
+                with self.assertRaisesRegex(ValueError, "must be a positive integer"):
+                    b.to(ProcessPoolExecutorConfig(max_workers=1), buffer_size=bad)
+
+    def test_validated_at_build_for_hand_built_config(self) -> None:
+        """A PlacementConfig assembled without the builder is still validated."""
+        b = PipelineBuilder().add_source(range(4))
+        # Bypass `to()` so only the build-time scan can catch it.
+        b._process_args.append(
+            PlacementConfig(
+                target=ProcessPoolExecutorConfig(max_workers=1), buffer_size=0
+            )
+        )
+        b._process_args.append(Pipe(add_one))
+        b.to(MAIN_PROCESS).add_sink()
+        with self.assertRaisesRegex(ValueError, "must be a positive integer"):
+            b.get_config()
+
+
 class ToValidationTest(unittest.TestCase):
     """Validation performed on to() regions at get_config()/build()."""
 

--- a/tests/pipeline/marked_region_fuse_test.py
+++ b/tests/pipeline/marked_region_fuse_test.py
@@ -551,6 +551,8 @@ class FusedThreadCountTest(unittest.TestCase):
                 None,  # pyre-ignore[6] -- unused by the fake
                 -1.0,
                 True,
+                1,  # input buffer size; irrelevant to the thread count
+                1,  # output buffer size; likewise
             )
         return captured["num_threads"]
 
@@ -803,6 +805,133 @@ class MarkedRegionSegmentationTest(unittest.TestCase):
                 p for p in new_config.pipes if isinstance(p, _SubprocessPipelineConfig)
             ]
             self.assertEqual(len(fused), 2)
+        finally:
+            for pool in pools:
+                pool.shutdown()
+
+    def test_buffer_size_reaches_the_handle(self) -> None:
+        """The spec's buffer_size lands on the pool handle the bridge stage reads."""
+        config = _cfg(
+            range(4),
+            [
+                PlacementConfig(
+                    target=ProcessPoolExecutorConfig(max_workers=1), buffer_size=8
+                ),
+                Pipe(add_one),
+                PlacementConfig(target=MAIN_PROCESS),
+            ],
+        )
+        new_config, pools = _fuse_marked_regions(config)
+        try:
+            (fused,) = [
+                p for p in new_config.pipes if isinstance(p, _SubprocessPipelineConfig)
+            ]
+            self.assertEqual(fused.handle.input_buffer_size, 8)
+        finally:
+            for pool in pools:
+                pool.shutdown()
+
+    def test_buffer_size_defaults_to_one(self) -> None:
+        """A region whose spec does not set it transfers one item at a time."""
+        config = _cfg(
+            range(4),
+            [
+                PlacementConfig(target=ProcessPoolExecutorConfig(max_workers=1)),
+                Pipe(add_one),
+                PlacementConfig(target=MAIN_PROCESS),
+            ],
+        )
+        new_config, pools = _fuse_marked_regions(config)
+        try:
+            (fused,) = [
+                p for p in new_config.pipes if isinstance(p, _SubprocessPipelineConfig)
+            ]
+            self.assertEqual(fused.handle.input_buffer_size, 1)
+        finally:
+            for pool in pools:
+                pool.shutdown()
+
+    def test_closing_marker_sizes_the_output(self) -> None:
+        """The marker that closes a region sizes the results coming back out of it.
+
+        The two directions are independent, which is the point: a region ending in
+        ``aggregate`` takes single items in and returns whole batches.
+        """
+        config = _cfg(
+            range(4),
+            [
+                PlacementConfig(
+                    target=ProcessPoolExecutorConfig(max_workers=1), buffer_size=32
+                ),
+                Pipe(add_one),
+                PlacementConfig(target=MAIN_PROCESS, buffer_size=2),
+            ],
+        )
+        new_config, pools = _fuse_marked_regions(config)
+        try:
+            (fused,) = [
+                p for p in new_config.pipes if isinstance(p, _SubprocessPipelineConfig)
+            ]
+            self.assertEqual(fused.handle.input_buffer_size, 32)
+            self.assertEqual(fused.handle.output_buffer_size, 2)
+        finally:
+            for pool in pools:
+                pool.shutdown()
+
+    def test_marker_between_adjacent_regions_sizes_both_sides(self) -> None:
+        """One marker closing region A and opening region B sizes that single handoff."""
+        config = _cfg(
+            range(4),
+            [
+                PlacementConfig(
+                    target=ProcessPoolExecutorConfig(max_workers=1), buffer_size=4
+                ),
+                Pipe(add_one),
+                PlacementConfig(
+                    target=ProcessPoolExecutorConfig(max_workers=1), buffer_size=8
+                ),
+                Pipe(times_two),
+                PlacementConfig(target=MAIN_PROCESS, buffer_size=16),
+            ],
+        )
+        new_config, pools = _fuse_marked_regions(config)
+        try:
+            first, second = [
+                p for p in new_config.pipes if isinstance(p, _SubprocessPipelineConfig)
+            ]
+            # The middle marker is region A's exit and region B's entry alike.
+            self.assertEqual(first.handle.input_buffer_size, 4)
+            self.assertEqual(first.handle.output_buffer_size, 8)
+            self.assertEqual(second.handle.input_buffer_size, 8)
+            self.assertEqual(second.handle.output_buffer_size, 16)
+        finally:
+            for pool in pools:
+                pool.shutdown()
+
+    def test_each_region_keeps_its_own_buffer_size(self) -> None:
+        """Two regions are fused with the buffer_size of their own spec."""
+        config = _cfg(
+            range(4),
+            [
+                PlacementConfig(
+                    target=ProcessPoolExecutorConfig(max_workers=1), buffer_size=4
+                ),
+                Pipe(add_one),
+                PlacementConfig(target=MAIN_PROCESS),
+                Pipe(times_two),
+                PlacementConfig(
+                    target=ProcessPoolExecutorConfig(max_workers=1), buffer_size=16
+                ),
+                Pipe(add_one),
+                PlacementConfig(target=MAIN_PROCESS),
+            ],
+        )
+        new_config, pools = _fuse_marked_regions(config)
+        try:
+            fused = [
+                p for p in new_config.pipes if isinstance(p, _SubprocessPipelineConfig)
+            ]
+            self.assertEqual([f.handle.input_buffer_size for f in fused], [4, 16])
         finally:
             for pool in pools:
                 pool.shutdown()

--- a/tests/pipeline/region_buffer_test.py
+++ b/tests/pipeline/region_buffer_test.py
@@ -1,0 +1,310 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""End-to-end tests for ``buffer_size`` -- transfer buffering at a region boundary.
+
+The bridge packs items into one transfer on the way into the region and unpacks them on the way
+out, so the region's stages (and everything downstream) still see individual items. These tests
+pin that transparency: for every scenario the observable output must not depend on
+``buffer_size``.
+
+The interesting cases are the ones where the region's output cardinality differs from its
+input's -- a dropped item, a generator, an ``aggregate`` -- because nothing in the protocol may
+assume the two directions chunk alike. ``continuous`` sources get their own coverage since a
+chunk that straddled an epoch boundary would silently move data between epochs.
+
+Bridge-level packing/flushing is covered directly (and deterministically) in
+``subprocess_pipe_bridge_test.py``; this file only checks the observable end-to-end behavior.
+"""
+
+import unittest
+from collections.abc import Iterator
+from typing import Any
+
+from parameterized import parameterized  # pyre-ignore[21]
+from spdl.pipeline import Pipeline, PipelineBuilder
+from spdl.pipeline.defs import MAIN_PROCESS, ProcessPoolExecutorConfig
+
+# (buffer_size, max_workers). Sizes are deliberately co-prime with the item counts
+# below so the tail chunk is always partial. ``(1, N)`` is the unbuffered control and
+# ``(16, 2)`` covers a transfer larger than a whole epoch. Kept small on purpose: every case
+# spawns a worker pool, and the suite runs these in parallel.
+_MATRIX: list[tuple[int, int]] = [(1, 1), (1, 3), (3, 3), (16, 2)]
+
+# Generous: these cases are correctness checks, not latency checks, and they compete with the
+# rest of the suite for cores. A real hang still fails via the test runner's own timeout.
+_TIMEOUT: float = 180.0
+
+
+def add_one(x: int) -> int:
+    return x + 1
+
+
+def times_two(x: int) -> int:
+    return x * 2
+
+
+def drop_odd(x: int) -> int | None:
+    """1 -> 0 for odd inputs: SPDL absorbs a ``None`` result, so fewer items come out."""
+    return None if x % 2 else x
+
+
+def explode(x: int) -> Iterator[int]:
+    """1 -> 3: a generator op makes the region emit more items than it received."""
+    yield x
+    yield x + 1000
+    yield x + 2000
+
+
+def boom_on_five(x: int) -> int:
+    if x == 5:
+        raise ValueError("boom")
+    return x
+
+
+def _run(pipeline: Pipeline[Any]) -> list[Any]:
+    with pipeline.auto_stop():
+        return list(pipeline.get_iterator(timeout=_TIMEOUT))
+
+
+def _build(
+    source: Any,
+    buffer_size: int,
+    max_workers: int,
+    *,
+    continuous: bool = False,
+) -> PipelineBuilder[Any, Any]:
+    """Open a region over ``source``; the caller adds the region's stages and closes it."""
+    return (
+        PipelineBuilder()
+        .add_source(source, continuous=continuous)
+        .to(
+            ProcessPoolExecutorConfig(max_workers=max_workers),
+            buffer_size=buffer_size,
+        )
+    )
+
+
+class RegionBufferSizeTest(unittest.TestCase):
+    """A buffered region produces exactly what an unbuffered one would."""
+
+    @parameterized.expand(_MATRIX)
+    def test_identity_roundtrip(self, buffer_size: int, max_workers: int) -> None:
+        """Every item makes it through, whatever the transfer size.
+
+        The item count (23) is not a multiple of any size in the matrix, so the tail
+        chunk is always partial -- the case where a missing flush would silently drop items.
+        """
+        n = 23
+        pipeline = (
+            _build(range(n), buffer_size, max_workers)
+            .pipe(add_one)
+            .pipe(times_two)
+            .to(MAIN_PROCESS)
+            .add_sink()
+            .build(num_threads=4)
+        )
+        self.assertEqual(sorted(_run(pipeline)), sorted((x + 1) * 2 for x in range(n)))
+
+    @parameterized.expand(_MATRIX)
+    def test_empty_source(self, buffer_size: int, max_workers: int) -> None:
+        """An empty source completes and yields nothing, rather than hanging on a chunk
+        that never fills."""
+        pipeline = (
+            _build([], buffer_size, max_workers)
+            .pipe(add_one)
+            .to(MAIN_PROCESS)
+            .add_sink()
+            .build(num_threads=4)
+        )
+        self.assertEqual(_run(pipeline), [])
+
+    @parameterized.expand(_MATRIX)
+    def test_fewer_items_than_buffer_size(
+        self, buffer_size: int, max_workers: int
+    ) -> None:
+        """A stream shorter than one chunk is still delivered (flushed at end of stream)."""
+        pipeline = (
+            _build(range(1), buffer_size, max_workers)
+            .pipe(add_one)
+            .to(MAIN_PROCESS)
+            .add_sink()
+            .build(num_threads=4)
+        )
+        self.assertEqual(_run(pipeline), [1])
+
+    @parameterized.expand(_MATRIX)
+    def test_region_emitting_fewer_items(
+        self, buffer_size: int, max_workers: int
+    ) -> None:
+        """1 -> 0 stages: the output chunking must not assume one result per input."""
+        n = 23
+        pipeline = (
+            _build(range(n), buffer_size, max_workers)
+            .pipe(drop_odd)
+            .to(MAIN_PROCESS)
+            .add_sink()
+            .build(num_threads=4)
+        )
+        self.assertEqual(sorted(_run(pipeline)), [x for x in range(n) if x % 2 == 0])
+
+    @parameterized.expand(_MATRIX)
+    def test_region_emitting_more_items(
+        self, buffer_size: int, max_workers: int
+    ) -> None:
+        """1 -> 3 stages: more results than inputs, so output chunks outnumber input chunks."""
+        n = 11
+        pipeline = (
+            _build(range(n), buffer_size, max_workers)
+            .pipe(explode)
+            .to(MAIN_PROCESS)
+            .add_sink()
+            .build(num_threads=4)
+        )
+        expected = sorted(x + k for x in range(n) for k in (0, 1000, 2000))
+        self.assertEqual(sorted(_run(pipeline)), expected)
+
+    @parameterized.expand(_MATRIX)
+    def test_aggregate_inside_region(self, buffer_size: int, max_workers: int) -> None:
+        """N -> 1 stages: batching inside the region is independent of the transfer size.
+
+        This is the shape the feature exists for -- the batch size and the transfer size are
+        set separately. Each worker aggregates only the items routed to it, so batches may be
+        partial at end of stream; the union across batches is what must be preserved.
+        """
+        n = 23
+        batch = 4
+        pipeline = (
+            _build(range(n), buffer_size, max_workers)
+            .aggregate(batch)
+            .to(MAIN_PROCESS)
+            .add_sink()
+            .build(num_threads=4)
+        )
+        batches = _run(pipeline)
+        self.assertTrue(all(len(b) <= batch for b in batches))
+        self.assertCountEqual([x for b in batches for x in b], list(range(n)))
+
+    @parameterized.expand(_MATRIX)
+    def test_drop_last_inside_region(self, buffer_size: int, max_workers: int) -> None:
+        """With drop_last each worker discards its own partial batch, but only whole batches.
+
+        The point is that the loss is a property of per-worker aggregation, not of the transfer
+        size: every emitted batch is full, and nothing outside the source appears.
+        """
+        n = 23
+        batch = 4
+        pipeline = (
+            _build(range(n), buffer_size, max_workers)
+            .aggregate(batch, drop_last=True)
+            .to(MAIN_PROCESS)
+            .add_sink()
+            .build(num_threads=4)
+        )
+        batches = _run(pipeline)
+        self.assertTrue(all(len(b) == batch for b in batches))
+        emitted = [x for b in batches for x in b]
+        self.assertEqual(len(emitted), len(set(emitted)))
+        self.assertTrue(set(emitted) <= set(range(n)))
+
+    @parameterized.expand(_MATRIX)
+    def test_op_failure_drops_only_that_item(
+        self, buffer_size: int, max_workers: int
+    ) -> None:
+        """A failing item is dropped without taking the rest of its transfer with it.
+
+        SPDL's default is to drop a failed item rather than fail the pipeline, and
+        ``max_failures`` is not propagated into a region's nested pipeline, so the observable
+        behavior is a missing item. What matters for buffering is that the *siblings* sharing
+        the failed item's chunk still arrive. The iterator timeout turns a hang into a failure.
+        """
+        n = 23
+        pipeline = (
+            _build(range(n), buffer_size, max_workers)
+            .pipe(boom_on_five)
+            .to(MAIN_PROCESS)
+            .add_sink()
+            .build(num_threads=4)
+        )
+        self.assertEqual(sorted(_run(pipeline)), [x for x in range(n) if x != 5])
+
+
+class ContinuousRegionBufferSizeTest(unittest.TestCase):
+    """Buffering must not move items across an epoch boundary."""
+
+    @parameterized.expand(_MATRIX)
+    def test_each_epoch_exact(self, buffer_size: int, max_workers: int) -> None:
+        """Every epoch delivers exactly its own items -- no tail carried into the next one."""
+        n = 23
+        ref = sorted((x + 1) * 2 for x in range(n))
+        pipeline = (
+            _build(range(n), buffer_size, max_workers, continuous=True)
+            .pipe(add_one)
+            .pipe(times_two)
+            .to(MAIN_PROCESS)
+            .add_sink(n)
+            .build(num_threads=4)
+        )
+        with pipeline.auto_stop():
+            for epoch in range(3):
+                with self.subTest(epoch=epoch):
+                    got = sorted(pipeline.get_iterator(timeout=_TIMEOUT))
+                    # Exact equality, not a subset: a chunk straddling the boundary would show
+                    # up as a short epoch followed by an over-long one.
+                    self.assertEqual(got, ref)
+
+    @parameterized.expand(_MATRIX)
+    def test_epoch_shorter_than_buffer(
+        self, buffer_size: int, max_workers: int
+    ) -> None:
+        """An epoch with fewer items than one chunk must still be flushed at the boundary.
+
+        Without the flush before the ``_EPOCH`` broadcast this deadlocks: the items sit in the
+        feeder's partial chunk, the workers see an empty epoch, and the epoch's results never
+        arrive.
+        """
+        n = 2
+        ref = sorted(x + 1 for x in range(n))
+        pipeline = (
+            _build(range(n), buffer_size, max_workers, continuous=True)
+            .pipe(add_one)
+            .to(MAIN_PROCESS)
+            .add_sink(n)
+            .build(num_threads=4)
+        )
+        with pipeline.auto_stop():
+            for epoch in range(3):
+                with self.subTest(epoch=epoch):
+                    self.assertEqual(
+                        sorted(pipeline.get_iterator(timeout=_TIMEOUT)), ref
+                    )
+
+
+class BufferSizeEquivalenceTest(unittest.TestCase):
+    """The observable result is identical across transfer sizes."""
+
+    def test_same_output_for_every_buffer_size(self) -> None:
+        """A region's output does not depend on how its transfers are chunked."""
+        n = 23
+
+        def _run_with(buffer_size: int) -> list[int]:
+            pipeline = (
+                _build(range(n), buffer_size, 3)
+                .pipe(drop_odd)
+                .pipe(explode)
+                .to(MAIN_PROCESS)
+                .add_sink()
+                .build(num_threads=4)
+            )
+            return sorted(_run(pipeline))
+
+        baseline = _run_with(1)
+        self.assertTrue(baseline)  # guard against the comparison being vacuous
+        for buffer_size in (2, 5, 32):
+            with self.subTest(buffer_size=buffer_size):
+                self.assertEqual(_run_with(buffer_size), baseline)


### PR DESCRIPTION
Last of three, and the only one with a public API change. The two diffs below taught the region
boundary to carry several items per transfer in each direction, defaulting to one so nothing
changed; this exposes the knob and wires it to the region markers.

    .to(ProcessPoolExecutorConfig(max_workers=4), buffer_size=32)
    .pipe(decode)                      # still receives ONE row at a time
    .aggregate(batch_size)
    .to(MAIN_PROCESS, buffer_size=2)   # 2 batches per transfer coming back

Purely additive: a new optional keyword on `to()` and a new `PlacementConfig` field, both
defaulting to `1`, which is exactly the behavior before this stack. Nothing existing changes
shape, so there is no backward incompatibility.

**Each marker sizes the handoff that happens where it sits.** The marker that opens a region
sizes data flowing into its workers; the marker that closes it sizes results flowing back. A
marker between two adjacent regions sizes that single handoff for both sides. This reading
falls out of what `to()` already means -- "from here, flow to X" -- and it is why
`to(MAIN_PROCESS)` takes one too: closing a region *is* a boundary, it is where results cross
back.

Sizing the directions separately is the point rather than an accident. They rarely carry
comparable items: with an `aggregate` inside the region, single rows go in and whole batches
come back, so one number could not be right for both.

It is a **buffer**, not a batch -- an upper bound rather than a fixed grouping. A partial
buffer is flushed at the end of a stream and at every epoch boundary, so the last transfer of
each is usually short. "Batch" is also already taken by `aggregate(batch_size)`, which is
precisely the thing this is meant to be independent of, and `buffer_size` is the house term for
"how many items are held" -- `add_sink`, `AsyncQueue` and `iterate_in_subprocess` all use it.

The knob lives on `to()` rather than on the pool spec because the thing that buffers is the
bridge stage `to()` creates. The pool does not buffer; `max_workers`, `initializer` and
`initargs` are `concurrent.futures.Executor` construction concepts, and a buffer is not one.

Documented trade-offs: latency (up to `buffer_size - 1` items held while a transfer fills), the
in-flight item bound scaling with it, and -- the one most likely to bite -- that whole transfers
rather than individual items are distributed across the pool, so `buffer_size x max_workers`
must stay well below the number of items in a stream or epoch, or workers go idle.