### PR TITLE
[pipeline] Budget a worker thread for a path_variants router

### DIFF
--- a/src/spdl/pipeline/_fuse.py
+++ b/src/spdl/pipeline/_fuse.py
@@ -106,9 +106,27 @@ def _is_async_op(op: object) -> bool:
     return inspect.iscoroutinefunction(op) or inspect.isasyncgenfunction(op)
 
 
+def _is_async_router(router: object) -> bool:
+    """Whether a path-variants router runs on the event loop rather than a worker thread.
+
+    Mirrors the dispatch test in
+    :py:func:`~spdl.pipeline._components._variants._make_async_router`, including its callable-
+    instance case: ``inspect.iscoroutinefunction`` is ``False`` for an object whose ``__call__``
+    is a coroutine function, and such a router is passed through rather than wrapped.
+    """
+    if inspect.iscoroutinefunction(router):
+        return True
+    if not callable(router):
+        return False
+    # A callable *instance* whose ``__call__`` is async: ``iscoroutinefunction`` on the
+    # instance itself is False, so the bound method has to be inspected directly.
+    return inspect.iscoroutinefunction(router.__call__)
+
+
 def _stage_concurrency(cfg: object) -> int:
-    """Total worker-thread demand of a fused stage: a pipe's ``concurrency``, or the sum across
-    every branch pipe of a path-variants stage (recursively). Other stages contribute 0.
+    """Total worker-thread demand of a fused stage: a pipe's ``concurrency``, the sum across
+    every branch pipe of a path-variants stage (recursively) plus its router. Other stages
+    contribute 0.
 
     An async pipe contributes 0: its ``concurrency`` bounds concurrent coroutines on the
     worker's event loop, which do not consume worker threads.
@@ -116,7 +134,11 @@ def _stage_concurrency(cfg: object) -> int:
     if isinstance(cfg, PipeConfig):
         return 0 if _is_async_op(cfg._args.op) else cfg._args.concurrency
     if isinstance(cfg, PathVariantsConfig):
-        return sum(_stage_concurrency(s) for path in cfg.paths for s in path)
+        # A sync router is dispatched with ``run_in_executor``, so it occupies a worker thread
+        # for the whole call and must be budgeted alongside the branches it feeds. The fan-in
+        # merge needs nothing: it is pure async.
+        router = 0 if _is_async_router(cfg.router) else 1
+        return router + sum(_stage_concurrency(s) for path in cfg.paths for s in path)
     return 0
 
 

--- a/tests/pipeline/marked_region_fuse_test.py
+++ b/tests/pipeline/marked_region_fuse_test.py
@@ -30,6 +30,7 @@ from spdl.pipeline.defs import (
     Aggregate,
     InterpreterPoolExecutorConfig,
     MAIN_PROCESS,
+    PathVariants,
     Pipe,
     PipelineConfig,
     PlacementConfig,
@@ -46,6 +47,14 @@ def add_one(x: int) -> int:
 
 def times_two(x: int) -> int:
     return x * 2
+
+
+def route_even_odd(x: int) -> int:
+    return x % 2
+
+
+async def aroute_even_odd(x: int) -> int:
+    return x % 2
 
 
 class _Unpicklable:
@@ -116,7 +125,14 @@ def _cfg(src: Any, pipes: Sequence[Any], buffer: int = 16) -> PipelineConfig[Any
     )
 
 
-def _run(pipeline: Pipeline[Any], timeout: float = 60.0) -> list[Any]:
+# Every region test spawns its own worker pool, so a full parallel run of this file has many
+# pools contending for the host at once. The timeout is a hang detector, not a latency
+# assertion -- a genuine deadlock still fails, just later -- so it is set well clear of what a
+# loaded machine needs. At 60s, healthy runs were being failed under stress.
+_TIMEOUT: float = 300.0
+
+
+def _run(pipeline: Pipeline[Any], timeout: float = _TIMEOUT) -> list[Any]:
     with pipeline.auto_stop():
         return list(pipeline.get_iterator(timeout=timeout))
 
@@ -551,6 +567,38 @@ class FusedThreadCountTest(unittest.TestCase):
         """A region of only aggregate-like stages adds no concurrency but still needs one."""
         self.assertEqual(self._num_threads_for([Aggregate(2)]), 2)
 
+    def test_sync_path_variants_router_gets_its_own_thread(self) -> None:
+        """A sync router runs via ``run_in_executor``, so it needs a thread of its own.
+
+        Counting only the branches under-provisions the worker: the router holds a thread for
+        the whole call while the branches it feeds are trying to run on the same pool.
+        """
+        stages = [
+            PathVariants(route_even_odd, [[Pipe(add_one)], [Pipe(times_two)]]),
+        ]
+        # two branches + the router + the source
+        self.assertEqual(self._num_threads_for(stages), 4)
+
+    def test_async_path_variants_router_needs_no_thread(self) -> None:
+        """An async router is awaited on the event loop, so it costs no worker thread."""
+        stages = [
+            PathVariants(aroute_even_odd, [[Pipe(add_one)], [Pipe(times_two)]]),
+        ]
+        # two branches + the source
+        self.assertEqual(self._num_threads_for(stages), 3)
+
+    def test_path_variants_router_counted_alongside_later_stages(self) -> None:
+        """The router's thread is additive with the rest of the region, not absorbed by it.
+
+        This is the shape of ``test_path_variants_process_locality_in_region``: router, two
+        branches, a post-merge pipe and the source all want a thread at once.
+        """
+        stages = [
+            PathVariants(route_even_odd, [[Pipe(add_one)], [Pipe(add_one)]]),
+            Pipe(times_two),
+        ]
+        self.assertEqual(self._num_threads_for(stages), 5)
+
 
 class ContinuousRegionTest(unittest.TestCase):
     """A ``.to()`` region under a continuous source stays warm and correct across epochs."""
@@ -577,7 +625,9 @@ class ContinuousRegionTest(unittest.TestCase):
         with pipeline.auto_stop():
             for epoch in range(2):
                 with self.subTest(epoch=epoch):
-                    self.assertEqual(sorted(pipeline.get_iterator(timeout=60)), ref)
+                    self.assertEqual(
+                        sorted(pipeline.get_iterator(timeout=_TIMEOUT)), ref
+                    )
 
     def test_multi_epoch_correct(self) -> None:
         """A continuous region yields the correct set each epoch from the same warm pool."""
@@ -595,7 +645,7 @@ class ContinuousRegionTest(unittest.TestCase):
         )
         with pipeline.auto_stop():
             for _ in range(3):  # three epochs from the same warm worker pool
-                self.assertEqual(sorted(pipeline.get_iterator(timeout=60)), ref)
+                self.assertEqual(sorted(pipeline.get_iterator(timeout=_TIMEOUT)), ref)
 
     def test_fewer_items_than_workers(self) -> None:
         """An epoch with fewer items than workers still completes (some workers run empty)."""
@@ -613,7 +663,7 @@ class ContinuousRegionTest(unittest.TestCase):
         )
         with pipeline.auto_stop():
             for _ in range(2):
-                self.assertEqual(sorted(pipeline.get_iterator(timeout=60)), ref)
+                self.assertEqual(sorted(pipeline.get_iterator(timeout=_TIMEOUT)), ref)
 
     def test_op_failure_does_not_deadlock(self) -> None:
         """Op failures (dropped per SPDL default) still let each epoch's barrier complete.
@@ -635,7 +685,7 @@ class ContinuousRegionTest(unittest.TestCase):
         )
         with pipeline.auto_stop():
             for _ in range(2):
-                self.assertEqual(list(pipeline.get_iterator(timeout=60)), [])
+                self.assertEqual(list(pipeline.get_iterator(timeout=_TIMEOUT)), [])
 
     def test_teardown_mid_stream_does_not_hang(self) -> None:
         """Tearing a continuous region subprocess pipeline down mid-stream must not hang.


### PR DESCRIPTION
A fused region sizes its worker's thread pool from `_stage_concurrency`, which for a `path_variants` stage sums only the *branch* pipes. It never counts the router. But a sync router is wrapped in `run_in_executor` by `_make_async_router`, so it holds a worker thread for the whole call -- concurrently with the branches it feeds.

The result is a region that is under-provisioned by exactly one thread. Take `test_path_variants_process_locality_in_region`: a router, two branches, a post-merge pipe and the sub-pipeline's own (blocking) source all want a thread at once, five in total, and the pool was sized to four. On an idle host it merely serializes; under load it stalls long enough to trip the test's timeout. This is the same class of bug as the source thread reserved in https://github.com/facebookresearch/spdl/pull/1624, and the fix is the same shape: count what actually consumes a thread.

`_stage_concurrency` now adds one for a `path_variants` stage whose router is sync. An async router is awaited on the event loop and still contributes nothing, matching how pipes are already treated. The fan-in merge needs nothing either way -- it is pure async.

`_is_async_router` deliberately mirrors `_make_async_router`'s dispatch test rather than reusing `_is_async_op`, including the callable-instance case: `inspect.iscoroutinefunction` is False for an object whose `__call__` is a coroutine function, and such a router is passed through unwrapped, so treating it as sync would over-provision.

Separately, this raises the region tests' timeout from 60s to 300s. That timeout is a hang detector, not a latency assertion -- every test in the file spawns its own worker pool, so a parallel run has many pools contending at once, and healthy runs were being failed under stress. A genuine deadlock still fails, just later. Three different tests in this file had been observed timing out at the 60s mark under load while passing in isolation.