### PR TITLE
Drop the redundant `unittest.main()` guards

### DIFF
--- a/tests/autoresearch/platform_test.py
+++ b/tests/autoresearch/platform_test.py
@@ -222,7 +222,3 @@ class _PlatformTest(unittest.TestCase):
 
             text = (engine / "checkpoint.json").read_text()
             self.assertIn('"priority": -5.0', text)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/pipeline/arena_registry_test.py
+++ b/tests/pipeline/arena_registry_test.py
@@ -228,7 +228,3 @@ class PacketsHandlerTest(unittest.TestCase):
         self.assertIs(type(restored), type(packets))
         self.assertEqual(cast(Any, restored).__getstate__(), packets.__getstate__())
         self.assertIsNone(anchor)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/pipeline/executor_config_test.py
+++ b/tests/pipeline/executor_config_test.py
@@ -57,7 +57,3 @@ class TestPlacementConfig(unittest.TestCase):
         self.assertEqual(
             repr(PlacementConfig(target=MAIN_PROCESS)), "placement(MAIN_PROCESS)"
         )
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/pipeline/merge_config_test.py
+++ b/tests/pipeline/merge_config_test.py
@@ -467,7 +467,3 @@ class MergeConfigTest(unittest.TestCase):
             results = list(pipeline.get_iterator(timeout=30))
 
         self.assertEqual(results, [1, 4, 2, 5, 3, 6])
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/pipeline/path_variants_test.py
+++ b/tests/pipeline/path_variants_test.py
@@ -846,7 +846,3 @@ class PathVariantsBatchedTest(unittest.TestCase):
         )
         with self.assertRaises(PipelineFailure):
             _run_pipeline(config)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/pipeline/region_hooks_test.py
+++ b/tests/pipeline/region_hooks_test.py
@@ -228,7 +228,3 @@ class RegionHookTest(unittest.TestCase):
 
         # The region sub-pipeline's queues carried the data inside the worker(s).
         self.assertGreaterEqual(sum(r["n_get"] for r in queue_records), n)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/pipeline/subprocess_break_reiterate_test.py
+++ b/tests/pipeline/subprocess_break_reiterate_test.py
@@ -102,7 +102,3 @@ class TestSubprocessBreakAndReiterate(unittest.TestCase):
         # Subsequent full iteration must work
         result = list(src)
         self.assertEqual(result, list(range(100)))
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/pipeline/subprocess_pipe_bridge_test.py
+++ b/tests/pipeline/subprocess_pipe_bridge_test.py
@@ -126,7 +126,3 @@ class StallGuardTest(unittest.TestCase):
             asyncio.run(_scenario())
         finally:
             _subprocess_pipe._WORKER_STALL_TIMEOUT = orig
-
-
-if __name__ == "__main__":
-    unittest.main()


### PR DESCRIPTION
Summary:
Nine test modules end with:

    if __name__ == "__main__":
        unittest.main()

Nothing runs them that way. Under Buck they are executed by `python_unittest`, and the OSS CI
drives them through pytest as a runner -- neither imports the module as `__main__`, so the
block is redundant in both. 

Purely mechanical: only the trailing two-line guard is removed, no test bodies or imports
change. `unittest` is still imported in every file for the `TestCase` base classes.

Differential Revision: D118330497


