### PR TITLE
[pipeline] Preserve shared-memory pool leases across epochs

### DIFF
--- a/src/spdl/pipeline/_arena/_arena.py
+++ b/src/spdl/pipeline/_arena/_arena.py
@@ -9,7 +9,7 @@
 
 from __future__ import annotations
 
-from ._offload import _offload, _restore
+from ._offload import _discard, _offload, _restore
 from ._protocol import ArenaProtocol, ArenaReaderProtocol, ArenaWriterProtocol
 from ._registry import _default_registry, _OffloadRegistry
 
@@ -86,3 +86,14 @@ class _Arena:
             copied out, per the backend).
         """
         return _restore(blob, self.reader, self.registry)
+
+    def discard(self, blob: bytes) -> None:
+        """Account for an unread envelope without restoring its payload.
+
+        Args:
+            blob: The envelope produced by :py:meth:`offload`.
+
+        Returns:
+            None.
+        """
+        _discard(blob, self.reader)

--- a/src/spdl/pipeline/_arena/_offload.py
+++ b/src/spdl/pipeline/_arena/_offload.py
@@ -29,11 +29,18 @@ from ._marker import _ShmMarker
 from ._protocol import ArenaReaderProtocol, ArenaWriterProtocol
 from ._registry import _OffloadRegistry
 
-__all__ = ["_DEFAULT_OFFLOAD_THRESHOLD", "_offload", "_restore"]
+__all__ = ["_DEFAULT_OFFLOAD_THRESHOLD", "_discard", "_offload", "_restore"]
 
 _DEFAULT_OFFLOAD_THRESHOLD: int = 4096
 
 _SPAN: struct.Struct = struct.Struct("<Q")
+
+
+def _discard(blob: bytes, reader: ArenaReaderProtocol) -> None:
+    """Account for an unread arena envelope without restoring its payload."""
+    if reader.zero_copy:
+        span = int(_SPAN.unpack_from(blob, 0)[0])
+        reader.end_unit(span, [])
 
 
 def _offload(

--- a/src/spdl/pipeline/_arena/_pool.py
+++ b/src/spdl/pipeline/_arena/_pool.py
@@ -29,11 +29,9 @@ Backpressure is Mode B (blocking): ``begin_unit`` waits on a process-shared
 rate. Set ``acquire_timeout=0`` for non-blocking behavior (raise immediately when
 full). Elastic growth remains future work.
 
-.. note::
-
-   Do not retain zero-copy views across a re-iteration of the same worker: the
-   iteration boundary resets the cursors and the writer may overwrite a segment
-   a stale view still points at.
+Outstanding views remain valid across re-iterations of the same worker. Pool
+accounting is monotonic for the lifetime of the worker, so an iteration boundary
+does not make a segment reusable while an earlier view still aliases it.
 """
 
 from __future__ import annotations
@@ -97,6 +95,10 @@ class SharedMemorySegmentPool:
        Backpressure now uses a process-shared
        :py:class:`multiprocessing.Condition` instead of busy-polling the shared
        reclaim counter; idle producers no longer consume CPU while waiting.
+
+    .. versionchanged:: 0.7.0
+       Restored zero-copy views remain valid across worker re-iterations.
+       Making ``SharedMemorySegmentPool`` safe to use with continuous source.
 
     .. note::
 
@@ -355,9 +357,7 @@ class _PoolWriter:
         self._cursor: int = 0
 
     def reset(self) -> None:
-        """Reset both cursors at an iteration boundary (the pool is quiescent)."""
-        self._p.published = 0
-        self._p.reclaimed = 0
+        """Clear in-progress state while preserving outstanding unit leases."""
         self._cursor = 0
 
     def begin_unit(self) -> None:
@@ -443,13 +443,10 @@ class _SegmentLease:
     firing decrements the count, and the unit is reclaimed when it reaches zero.
     """
 
-    def __init__(
-        self, reader: _PoolReader, unit: int, count: int, generation: int
-    ) -> None:
+    def __init__(self, reader: _PoolReader, unit: int, count: int) -> None:
         self._reader = reader
         self._unit = unit
         self._remaining = count
-        self._generation = generation
         self._lock = threading.Lock()
 
     def release_one(self) -> None:
@@ -457,7 +454,7 @@ class _SegmentLease:
             self._remaining -= 1
             done = self._remaining == 0
         if done:
-            self._reader._unit_released(self._unit, self._generation)
+            self._reader._unit_released(self._unit)
 
 
 class _PoolReader:
@@ -476,16 +473,10 @@ class _PoolReader:
         self._next: int = 0  # next unit index to restore
         self._reclaimed: int = 0  # contiguous reclaim watermark (mirrors shm)
         self._released: set[int] = set()  # released units above the watermark
-        self._generation: int = 0  # invalidates leases from prior iterations
         self._lock = threading.Lock()
 
     def reset(self) -> None:
-        """Reset cursors at an iteration boundary and orphan stale leases."""
-        with self._lock:
-            self._next = 0
-            self._reclaimed = 0
-            self._released.clear()
-            self._generation += 1
+        """Preserve monotonic accounting and outstanding leases."""
 
     def read_binary(self, offset: int, nbytes: int) -> "memoryview[bytes]":
         """Return a live view into the current unit's segment (zero copy)."""
@@ -504,16 +495,14 @@ class _PoolReader:
         if not pinned:
             # Nothing aliases the segment (e.g. all fields copied out) — reclaim
             # immediately.
-            self._unit_released(unit, self._generation)
+            self._unit_released(unit)
             return
-        lease = _SegmentLease(self, unit, len(pinned), self._generation)
+        lease = _SegmentLease(self, unit, len(pinned))
         for anchor in pinned:
             weakref.finalize(anchor, lease.release_one)
 
-    def _unit_released(self, unit: int, generation: int) -> None:
+    def _unit_released(self, unit: int) -> None:
         with self._lock:
-            if generation != self._generation:
-                return  # stale lease from a previous iteration; ignore
             self._released.add(unit)
             advanced = False
             while self._reclaimed in self._released:

--- a/src/spdl/pipeline/_arena/_protocol.py
+++ b/src/spdl/pipeline/_arena/_protocol.py
@@ -37,12 +37,11 @@ class ArenaWriterProtocol(Protocol):
     """
 
     def reset(self) -> None:
-        """Reset per-iteration state at an iteration boundary.
+        """Prepare the writer for a new iteration.
 
-        Called by the worker once per ``START_ITERATION``, while the parent
-        is quiescent. Backends should reclaim any space that leaked across
-        the boundary (e.g. units the parent never read) and return the
-        writer to a clean starting state.
+        Called by the worker once per ``START_ITERATION``. Copy-out backends
+        may reclaim their storage here. Zero-copy backends must preserve any
+        units whose restored views are still alive across the boundary.
 
         Returns:
             None.
@@ -129,12 +128,12 @@ class ArenaReaderProtocol(Protocol):
     owning / copied-out restore."""
 
     def reset(self) -> None:
-        """Reset per-iteration state at an iteration boundary.
+        """Prepare the reader for a new iteration.
 
         Called by the parent once per iteration, after the worker has
-        signaled ``ITERATION_STARTED`` and before the first item is
-        consumed. Backends should clear any per-iteration cursors so the
-        reader matches the writer's freshly-reset state.
+        signaled ``ITERATION_STARTED`` and before the first item is consumed.
+        Zero-copy backends must preserve the accounting for views that remain
+        alive from previous iterations.
 
         Returns:
             None.
@@ -171,7 +170,9 @@ class ArenaReaderProtocol(Protocol):
                 from this unit (e.g. ``np.frombuffer`` arrays). The
                 backend must keep the underlying region alive until every
                 anchor in this list is released; with copy-out backends
-                the list is typically empty and ignored.
+                the list is typically empty and ignored. This method is also
+                called with an empty list to reclaim an unread unit discarded
+                between iterations on zero-copy backends.
 
         Returns:
             None. Called from a ``finally`` block in

--- a/src/spdl/pipeline/_iter_utils/_common.py
+++ b/src/spdl/pipeline/_iter_utils/_common.py
@@ -275,8 +275,7 @@ def _execute_iterable(
             match cmd:
                 case _Cmd.START_ITERATION:
                     if helper is not None:
-                        # Iteration boundary: reclaim leaked arena space. The
-                        # parent is quiescent (waiting for ITERATION_STARTED).
+                        # Let the backend prepare for the next iteration.
                         helper.writer.reset()
                     data_q.put(_Msg(_Status.ITERATION_STARTED))
                 case _Cmd.STOP_ITERATION:
@@ -373,6 +372,7 @@ def _enter_iteration_mode(
     data_q: _Queue[_Msg[Any]],
     timeout: float,
     worker_type: str,
+    discard: Callable[[Any], None] | None = None,
 ) -> None:
     """Instruct the worker to enter iteration mode and wait for the acknowledgement.
 
@@ -384,6 +384,8 @@ def _enter_iteration_mode(
         data_q: Queue to receive status messages from the worker
         timeout: Maximum time to wait for acknowledgement
         worker_type: Type of worker (for error messages)
+        discard: Optional callback that accounts for unread results from the
+            previous iteration.
     """
     wtype = f"worker {worker_type}"
     cmd_q.put(_Cmd.STOP_ITERATION)
@@ -406,9 +408,15 @@ def _enter_iteration_mode(
                 case _Status.ITERATION_STARTED:
                     # the worker is properly transitioning to the iteration mode
                     return
-                case _Status.ITERATION_FINISHED | _Status.ITERATOR_SUCCESS:
-                    # residual from previous iteration. Could be iteration was abandoned, or
-                    # the iteration had been completed when parent commanded STOP_ITERATION.
+                case _Status.ITERATION_FINISHED:
+                    # Residual from the previous iteration.
+                    continue
+                case _Status.ITERATOR_SUCCESS:
+                    # Residual from an abandoned previous iteration. Arena
+                    # backends must account for the committed unit even though
+                    # its payload will not be restored.
+                    if discard is not None:
+                        discard(item.message)
                     continue
                 case _Status.UNEXPECTED_CMD_RECEIVED:
                     # the worker was in the invalid state (iteration mode)

--- a/src/spdl/pipeline/_iter_utils/_subprocess.py
+++ b/src/spdl/pipeline/_iter_utils/_subprocess.py
@@ -112,13 +112,20 @@ class _SubprocessIterable(Iterable[T]):
             raise RuntimeError("The worker process is shutdown. Cannot iterate again.")
 
         try:
+            arena = self._arena
             # pyre-ignore[6]
-            _enter_iteration_mode(if_.cmd_q, if_.data_q, if_.timeout, "subprocess")
-            if (arena := self._arena) is None:
+            _enter_iteration_mode(
+                if_.cmd_q,
+                if_.data_q,
+                if_.timeout,
+                "subprocess",
+                None if arena is None else arena.discard,
+            )
+            if arena is None:
                 yield from _iterate_results(if_.data_q, if_.timeout, "subprocess")
             else:
-                # Reset the reader's per-iteration cursors (the worker has reset
-                # its side and is quiescent until we start consuming).
+                # Let the backend prepare for the next iteration after the
+                # worker has prepared its side.
                 arena.reader.reset()
                 for blob in _iterate_results(if_.data_q, if_.timeout, "subprocess"):
                     yield cast(T, arena.restore(cast(bytes, blob)))

--- a/tests/pipeline/arena_pool_test.py
+++ b/tests/pipeline/arena_pool_test.py
@@ -6,19 +6,40 @@
 
 
 import gc
+import multiprocessing as mp
 import struct
 import threading
 import time
 import unittest
+from collections.abc import Sequence
+from concurrent.futures import ThreadPoolExecutor
 from typing import Any, cast
 
-from spdl.pipeline import iterate_in_subprocess, SharedMemorySegmentPool
+from spdl.pipeline import (
+    iterate_in_subprocess,
+    PipelineBuilder,
+    run_pipeline_in_subprocess,
+    SharedMemorySegmentPool,
+)
 from spdl.pipeline._arena._offload import _offload, _restore
 from spdl.pipeline._arena._registry import _default_registry
+
+_START_METHODS: Sequence[str] = [
+    m for m in ("fork", "spawn") if m in mp.get_all_start_methods()
+]
 
 
 def _make_items() -> list[dict[str, bytes | int]]:
     return [{"i": i, "blob": bytes([i % 256]) * 40_000} for i in range(8)]
+
+
+def _make_tagged_item(unit: int) -> dict[str, bytes | int]:
+    return {"unit": unit, "payload": bytes([unit]) * (1 << 20)}
+
+
+def _delay_item(item: dict[str, object]) -> dict[str, object]:
+    time.sleep(0.005)
+    return item
 
 
 class SharedMemorySegmentPoolTest(unittest.TestCase):
@@ -230,6 +251,64 @@ class SharedMemorySegmentPoolTest(unittest.TestCase):
         # Once the view is gone, the segment returns to the pool.
         self.assertEqual(pool.reclaimed, 1)
 
+    def test_live_view_survives_iteration_reset(self) -> None:
+        """An iteration reset must not recycle a segment with a live view."""
+        pool = self._pool(1 << 16, 2)
+        writer, reader = pool.open_writer(), pool.open_reader()
+        registry = _default_registry()
+        first = cast(
+            dict[str, Any],
+            _restore(
+                _offload({"blob": b"a" * 40_000}, writer, registry),
+                reader,
+                registry,
+            ),
+        )
+        first_view = cast(memoryview, first["blob"])
+
+        writer.reset()
+        reader.reset()
+        second = _restore(
+            _offload({"blob": b"b" * 40_000}, writer, registry),
+            reader,
+            registry,
+        )
+
+        self.assertEqual(bytes(first_view), b"a" * 40_000)
+        del first, first_view, second
+        gc.collect()
+
+    def test_reclaim_watermark_spans_iteration_reset(self) -> None:
+        """A pre-reset lease must unblock later reclaimed segments when released."""
+        pool = self._pool(1 << 16, 2)
+        writer, reader = pool.open_writer(), pool.open_reader()
+        registry = _default_registry()
+        first = cast(
+            dict[str, Any],
+            _restore(
+                _offload({"blob": b"a" * 40_000}, writer, registry),
+                reader,
+                registry,
+            ),
+        )
+        first_view = cast(memoryview, first["blob"])
+        del first
+
+        writer.reset()
+        reader.reset()
+        second = _restore(
+            _offload({"blob": b"b" * 40_000}, writer, registry),
+            reader,
+            registry,
+        )
+        del second
+        gc.collect()
+        self.assertEqual(pool.reclaimed, 0)
+
+        del first_view
+        gc.collect()
+        self.assertEqual(pool.reclaimed, 2)
+
     def test_torch_restore_is_a_zero_copy_view(self) -> None:
         """A restored Torch tensor aliases the segment (no copy)."""
         try:
@@ -346,3 +425,84 @@ class IterateInSubprocessSegmentPoolTest(unittest.TestCase):
             )
             del item  # release the zero-copy view so its segment can be reclaimed
         self.assertEqual(got, _make_items())
+
+    if "fork" in _START_METHODS:
+
+        def test_views_remain_valid_across_continuous_reiteration(self) -> None:
+            """An outer pipeline must not observe pool views overwritten at epoch end."""
+            config = (
+                PipelineBuilder()
+                .add_source(list(range(13)), continuous=True)
+                .pipe(_make_tagged_item)
+                .add_sink(4)
+                .get_config()
+            )
+            source = run_pipeline_in_subprocess(
+                config,
+                num_threads=2,
+                mp_context="fork",
+                buffer_size=3,
+                arena=SharedMemorySegmentPool(segment_size=2 << 20, count=12),
+            )
+
+            with ThreadPoolExecutor(max_workers=1) as executor:
+                pipeline = (
+                    PipelineBuilder()
+                    .add_source(source, continuous=True)
+                    .pipe(_delay_item, concurrency=1, executor=executor)
+                    .add_sink(4)
+                    .build(num_threads=1)
+                )
+                bad: list[tuple[int, int]] = []
+                with pipeline.auto_stop():
+                    for epoch in range(6):
+                        for position, item in enumerate(
+                            pipeline.get_iterator(timeout=30), start=1
+                        ):
+                            record = cast(dict[str, object], item)
+                            unit = cast(int, record["unit"])
+                            payload = cast(memoryview, record["payload"])
+                            if payload[0] != unit or payload[-1] != unit:
+                                bad.append((epoch, position))
+                            del item, record, payload
+
+                self.assertEqual(bad, [])
+
+    if "fork" in _START_METHODS:
+
+        def test_abandoned_iteration_reclaims_unread_units(self) -> None:
+            """Re-iteration must reclaim unread pool units without hanging."""
+            pool = SharedMemorySegmentPool(
+                segment_size=1 << 18,
+                count=3,
+                acquire_timeout=2,
+            )
+            source = iterate_in_subprocess(
+                _make_items,
+                arena=pool,
+                buffer_size=2,
+                mp_context="fork",
+                timeout=10,
+            )
+            iterator = iter(source)
+            first = next(iterator)
+            self.assertEqual(first["i"], 0)
+
+            deadline = time.monotonic() + 5
+            while pool.published < pool.count and time.monotonic() < deadline:
+                time.sleep(0.01)
+            self.assertEqual(pool.published, pool.count)
+
+            del first, iterator
+            gc.collect()
+
+            got = []
+            for item in source:
+                got.append(
+                    {
+                        k: bytes(v) if isinstance(v, memoryview) else v
+                        for k, v in item.items()
+                    }
+                )
+                del item
+            self.assertEqual(got, _make_items())


### PR DESCRIPTION
`SharedMemorySegmentPool` reset its counters and invalidated outstanding leases at every iteration boundary. This is unsafe for continuous sources: after an epoch marker is queued, the source immediately starts the next iteration while downstream stages may still hold zero-copy views from the previous epoch. Resetting the pool at that point lets the worker overwrite those live views.

The solution is to keep pool accounting, reader cursors, and leases monotonic for the lifetime of the worker. This commit removes the notion of generations (iterations) from the implementation. The generations existed only to invalidate prior-iteration leases during reset, which is precisely the unsafe behavior.

Each `_SegmentLease` owns one committed unit, its `weakref.finalize` callbacks are one-shot, and its lock-protected countdown calls `_unit_released` once. `_released` is a set and the reclaim watermark advances only through contiguous unit numbers, so late, out-of-order, or duplicate notifications cannot skip a still-live unit.

Resource cleanup follows the iterator lifecycle:

- On normal exhaustion, including a non-continuous source, every delivered envelope passes through `_restore`, whose `finally` block calls `reader.end_unit`. Units without zero-copy anchors are reclaimed immediately; units with live views remain leased until their anchors are garbage-collected.
- If an iterator is abandoned and the iterable is reused, the next `_enter_iteration_mode` drains committed-but-unread envelopes from the prior iteration. The discard path reads each envelope span and calls `reader.end_unit(span, [])`, reclaiming those units without restoring their payloads. Already-delivered views remain protected by their leases.
- If the subprocess iterable itself is discarded instead of reused, its finalizer terminates the worker, wakes any producer blocked on arena space, then closes and unlinks the arena after the worker exits. Per-unit reclamation is unnecessary because the entire arena is being torn down.

The ring-buffer backend remains safe because restored values are copied out and its iteration reset reclaims unread ring storage.

Address facebookresearch/spdl#1636.